### PR TITLE
ci: unify gates into scripts/gates.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,23 +32,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Typecheck
-        run: npm run typecheck
+      - name: Setup
+        run: ./scripts/gates.sh setup
 
       - name: Lint
-        run: npm run lint
+        run: ./scripts/gates.sh lint
+
+      - name: Typecheck
+        run: ./scripts/gates.sh typecheck
+
+      - name: Test
+        run: ./scripts/gates.sh test
 
       - name: Build
-        run: npm run build
+        run: ./scripts/gates.sh build
 
-      - name: Test with coverage
-        run: npm run test:coverage
-
-  build-and-push:
-    name: Build & Push Docker Image
+  deploy:
+    name: Deploy to server
     runs-on: ubuntu-latest
     needs: [quality]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -87,12 +87,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy:
-    name: Deploy to server
-    runs-on: ubuntu-latest
-    needs: [build-and-push]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    steps:
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4
         with:

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# gates.sh — Single source of truth for all quality gates.
+# Called by: polecats (pre-verify), refinery (fallback), CI (GitHub Actions).
+#
+# Usage:
+#   ./scripts/gates.sh [STAGE...]
+#
+# Stages: setup, lint, typecheck, test, build
+# No args = run all stages in order.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+run_setup() {
+    echo "=== Setup ==="
+    npm ci
+}
+
+run_lint() {
+    echo "=== Lint ==="
+    npm run lint
+}
+
+run_typecheck() {
+    echo "=== Typecheck ==="
+    npm run typecheck
+}
+
+run_test() {
+    echo "=== Test ==="
+    npm run test:coverage
+}
+
+run_build() {
+    echo "=== Build (Docker) ==="
+    docker build -t word-coach-annie:gate-check .
+}
+
+# If no args, run all stages
+if [ $# -eq 0 ]; then
+    STAGES=(setup lint typecheck test build)
+else
+    STAGES=("$@")
+fi
+
+FAILED=0
+for stage in "${STAGES[@]}"; do
+    if ! "run_${stage}"; then
+        echo "FAILED: ${stage}"
+        FAILED=1
+        break
+    fi
+    echo "PASSED: ${stage}"
+    echo ""
+done
+
+if [ $FAILED -eq 0 ]; then
+    echo "=== All gates passed ==="
+else
+    echo "=== Gates FAILED ==="
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Single source of truth for all quality gates (`scripts/gates.sh`)
- CI workflow and polecat pre-verification now call the same script
- Stages: setup, lint, typecheck, test, build (Docker)

## Test plan
- [ ] CI passes on this PR (gates.sh runs correctly in GitHub Actions)
- [ ] Verify stages can be run individually: `./scripts/gates.sh lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)