### PR TITLE
fix: add GHCR_PAT to deploy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,15 +94,21 @@ jobs:
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
         with:
           host: 100.120.193.82
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.SSH_DEPLOY_KEY }}
+          envs: GHCR_PAT
           script: |
             cd /home/asiri/gt/annie/mayor/rig
 
             # Pull latest compose file
             git pull --rebase
+
+            # Authenticate with GHCR
+            echo "$GHCR_PAT" | docker login ghcr.io -u alexsiri7 --password-stdin
 
             # Tag current running image as rollback before pulling new one
             docker tag ghcr.io/alexsiri7/word-coach-annie:latest \


### PR DESCRIPTION
## Summary
- Deploy was failing because docker pull on the server had no GHCR auth
- Added GHCR_PAT env passthrough (was in old CI, dropped during gates.sh rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)