### PR TITLE
fix: sort scene navigation by chapter order then scene order (an-u5w)

### DIFF
--- a/src/lib/controllers/focus.ts
+++ b/src/lib/controllers/focus.ts
@@ -11,13 +11,16 @@ export class FocusController {
 
         if (!scene) throw new Error(`Scene not found: ${sceneId}`);
 
-        // Get adjacent scenes
+        // Get adjacent scenes ordered by chapter then scene position
         const siblings = await prisma.structureNode.findMany({
             where: {
                 projectId: scene.projectId,
                 type: "SCENE"
             },
-            orderBy: { orderIndex: "asc" },
+            orderBy: [
+                { parent: { orderIndex: "asc" } },
+                { orderIndex: "asc" }
+            ],
             select: { id: true, title: true, orderIndex: true }
         });
 

--- a/src/lib/controllers/structure.ts
+++ b/src/lib/controllers/structure.ts
@@ -124,6 +124,14 @@ export class StructureController {
             }
         }
 
+        // Sort children within each parent by orderIndex
+        for (const node of nodeMap.values()) {
+            if (node.children.length > 1) {
+                node.children.sort((a, b) => a.orderIndex - b.orderIndex);
+            }
+        }
+        roots.sort((a, b) => a.orderIndex - b.orderIndex);
+
         return roots;
     }
 


### PR DESCRIPTION
## Summary
- Fix scene navigation in focus view showing scenes in wrong order
- Order scenes by parent chapter orderIndex first, then scene orderIndex in `FocusController.getSceneContext`
- Sort children within each parent by orderIndex in `StructureController.getOutline` after building the tree

## Issue
Fixes an-u5w: Scene navigation in focus view is in random order

## Test plan
- [x] Gates passed (setup, typecheck, lint, test, build) by polecat pre-verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)