### PR TITLE
feat: show universe entities in project view (an-r9z)

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -66,6 +66,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
   const [storyObjects, setStoryObjects] = useState<StoryObject[]>([]);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [selectedObjectId, setSelectedObjectId] = useState<string | null>(null);
+  const [selectedObjectSource, setSelectedObjectSource] = useState<"project" | "universe">("project");
   const [activeTab, setActiveTab] = useState<SidebarTab>("outline");
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -234,6 +235,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
 
   const handleSearchSelectObject = (objectId: string, objectType: string) => {
     setSelectedObjectId(objectId);
+    setSelectedObjectSource("project");
     setSelectedNodeId(null);
     const tab = OBJECT_TYPE_TO_TAB[objectType];
     if (tab) setActiveTab(tab);
@@ -468,14 +470,22 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
                         )}
                         onClick={() => {
                           setSelectedObjectId(obj.id);
+                          setSelectedObjectSource(obj.source || "project");
                           setSelectedNodeId(null);
                           setSidebarOpen(false);
                         }}
                       >
-                        {obj.name}
-                        {obj.role && (
-                          <span className="ml-2 text-xs text-text-muted">{obj.role}</span>
-                        )}
+                        <span className="flex items-center gap-1.5">
+                          {obj.name}
+                          {obj.source === "universe" && (
+                            <span title="Universe entity">
+                              <Globe className="h-3 w-3 text-accent/60 flex-shrink-0" />
+                            </span>
+                          )}
+                          {obj.role && (
+                            <span className="text-xs text-text-muted">{obj.role}</span>
+                          )}
+                        </span>
                       </button>
                     ))}
                   </div>
@@ -490,6 +500,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
           {selectedObjectId ? (
             <StoryObjectPanel
               objectId={selectedObjectId}
+              source={selectedObjectSource}
               onClose={() => setSelectedObjectId(null)}
               onDeleted={() => {
                 setSelectedObjectId(null);

--- a/src/components/story-object-panel.tsx
+++ b/src/components/story-object-panel.tsx
@@ -26,6 +26,7 @@ import type { StoryObject, StoryObjectType, Project } from "@/lib/types";
 
 interface StoryObjectPanelProps {
     objectId: string;
+    source?: "project" | "universe";
     onClose: () => void;
     onDeleted: () => void;
     onUpdated: () => void;
@@ -39,7 +40,7 @@ const TYPE_LABELS: Record<StoryObjectType, string> = {
     NOTE: "Note",
 };
 
-export function StoryObjectPanel({ objectId, onClose, onDeleted, onUpdated }: StoryObjectPanelProps) {
+export function StoryObjectPanel({ objectId, source = "project", onClose, onDeleted, onUpdated }: StoryObjectPanelProps) {
     const [obj, setObj] = useState<StoryObject | null>(null);
     const [name, setName] = useState("");
     const [description, setDescription] = useState("");
@@ -53,8 +54,11 @@ export function StoryObjectPanel({ objectId, onClose, onDeleted, onUpdated }: St
     const [transferOpen, setTransferOpen] = useState(false);
     const [transferring, setTransferring] = useState(false);
 
+    const isUniverse = source === "universe";
+    const apiBase = isUniverse ? "/api/world-objects" : "/api/story-objects";
+
     useEffect(() => {
-        fetch(`/api/story-objects/${objectId}`)
+        fetch(`${apiBase}/${objectId}`)
             .then((res) => res.json())
             .then((data) => {
                 setObj(data);
@@ -64,20 +68,25 @@ export function StoryObjectPanel({ objectId, onClose, onDeleted, onUpdated }: St
                 setRole(data.role || "");
                 setTags(data.tags || "");
 
-                // Fetch project to see if it's linked to a universe
-                fetch(`/api/projects/${data.projectId}`)
-                    .then(res => res.json())
-                    .then(p => setProject(p));
+                if (!isUniverse && data.projectId) {
+                    // Fetch project to see if it's linked to a universe
+                    fetch(`/api/projects/${data.projectId}`)
+                        .then(res => res.json())
+                        .then(p => setProject(p));
+                }
             });
-    }, [objectId]);
+    }, [objectId, apiBase, isUniverse]);
 
     const handleSave = async () => {
         setSaving(true);
         setSaved(false);
-        await fetch(`/api/story-objects/${objectId}`, {
+        const body = isUniverse
+            ? { name, description, notes, tags }
+            : { name, description, notes, role: role || null, tags };
+        await fetch(`${apiBase}/${objectId}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ name, description, notes, role: role || null, tags }),
+            body: JSON.stringify(body),
         });
         setSaving(false);
         setSaved(true);
@@ -86,7 +95,7 @@ export function StoryObjectPanel({ objectId, onClose, onDeleted, onUpdated }: St
     };
 
     const handleDelete = async () => {
-        await fetch(`/api/story-objects/${objectId}`, { method: "DELETE" });
+        await fetch(`${apiBase}/${objectId}`, { method: "DELETE" });
         setDeleteOpen(false);
         onDeleted();
     };
@@ -133,6 +142,12 @@ export function StoryObjectPanel({ objectId, onClose, onDeleted, onUpdated }: St
             <div className="flex items-center justify-between px-5 py-3 border-b border-border bg-surface-raised">
                 <div className="flex items-center gap-2">
                     <span className="tag-pill text-accent">{TYPE_LABELS[obj.type as StoryObjectType] || obj.type}</span>
+                    {isUniverse && (
+                        <span className="tag-pill text-xs bg-accent/10 text-accent/80 flex items-center gap-1">
+                            <Globe className="h-3 w-3" />
+                            Universe
+                        </span>
+                    )}
                     <h2 className="font-semibold text-text-primary truncate">{obj.name}</h2>
                 </div>
                 <Button variant="ghost" size="icon" className="h-8 w-8 flex-shrink-0" onClick={onClose}>
@@ -206,7 +221,7 @@ export function StoryObjectPanel({ objectId, onClose, onDeleted, onUpdated }: St
                     Delete
                 </Button>
                 <div className="flex items-center gap-2">
-                    {project?.universeId && (
+                    {!isUniverse && project?.universeId && (
                         <Button
                             variant="outline"
                             size="sm"

--- a/src/lib/controllers/story-objects.ts
+++ b/src/lib/controllers/story-objects.ts
@@ -16,7 +16,7 @@ export class StoryObjectController {
 
         const project = await prisma.project.findUnique({
             where: { id: projectId },
-            select: { id: true },
+            select: { id: true, universeId: true },
         });
         if (!project) throw new Error(`Project not found: ${projectId}`);
 
@@ -28,7 +28,20 @@ export class StoryObjectController {
         if (type) where.type = type;
         if (search) where.name = { contains: search };
 
-        const [storyObjects, total] = await Promise.all([
+        // WorldObject types that overlap with StoryObject types
+        const WORLD_OBJECT_TYPES = ["CHARACTER", "LOCATION", "WORLD_ELEMENT"];
+
+        // Fetch project story objects and universe world objects in parallel
+        const shouldFetchWorldObjects = project.universeId &&
+            (!type || WORLD_OBJECT_TYPES.includes(type));
+
+        const worldObjectWhere: Record<string, unknown> = project.universeId
+            ? { universeId: project.universeId }
+            : {};
+        if (type) worldObjectWhere.type = type;
+        if (search) worldObjectWhere.name = { contains: search };
+
+        const [storyObjects, storyTotal, worldObjects] = await Promise.all([
             prisma.storyObject.findMany({
                 where,
                 orderBy: { createdAt: "desc" },
@@ -36,21 +49,43 @@ export class StoryObjectController {
                 skip: offset,
             }),
             prisma.storyObject.count({ where }),
+            shouldFetchWorldObjects
+                ? prisma.worldObject.findMany({
+                    where: worldObjectWhere,
+                    orderBy: { createdAt: "desc" },
+                })
+                : Promise.resolve([]),
         ]);
 
+        const projectObjects = storyObjects.map((obj) => ({
+            id: obj.id,
+            type: obj.type,
+            name: obj.name,
+            description: obj.description,
+            notes: obj.notes,
+            role: obj.role,
+            tags: obj.tags,
+            source: "project" as const,
+            createdAt: obj.createdAt.toISOString(),
+            updatedAt: obj.updatedAt.toISOString(),
+        }));
+
+        const universeObjects = worldObjects.map((obj) => ({
+            id: obj.id,
+            type: obj.type,
+            name: obj.name,
+            description: obj.description,
+            notes: obj.notes,
+            role: null,
+            tags: obj.tags,
+            source: "universe" as const,
+            createdAt: obj.createdAt.toISOString(),
+            updatedAt: obj.updatedAt.toISOString(),
+        }));
+
         return {
-            objects: storyObjects.map((obj) => ({
-                id: obj.id,
-                type: obj.type,
-                name: obj.name,
-                description: obj.description,
-                notes: obj.notes,
-                role: obj.role,
-                tags: obj.tags,
-                createdAt: obj.createdAt.toISOString(),
-                updatedAt: obj.updatedAt.toISOString(),
-            })),
-            total,
+            objects: [...projectObjects, ...universeObjects],
+            total: storyTotal + worldObjects.length,
         };
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,6 +86,7 @@ export interface StoryObject {
   notes: string;
   role: string | null;
   tags: string;
+  source?: "project" | "universe";
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- Include universe WorldObjects in project entity lists (Characters/Locations/World)
- Add visual distinction (Globe icon + "Universe" badge) for universe-sourced entities
- Route universe entity API calls through `/api/world-objects` endpoint
- Add `source` field to StoryObject type for project/universe discrimination

## Issue
Fixes an-r9z: Universe entities not showing in project view

## Test plan
- [x] Gates passed by polecat pre-verification
- [x] Rebased on current master (by refinery — polecat was dead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)