### PR TITLE
fix: exclude beat text from scene word count (an-mxq)

### DIFF
--- a/src/__tests__/beats.test.ts
+++ b/src/__tests__/beats.test.ts
@@ -100,6 +100,26 @@ describe("Scene Beats", () => {
             );
         });
 
+        it("should exclude beat div annotations from word count (MCP path)", async () => {
+            (prisma.structureNode.findUnique as any).mockResolvedValue(mockNode);
+            (prisma.contentVersion.create as any).mockResolvedValue({
+                id: "v1", createdAt: new Date(), nodeId: "scene-1", wordCount: 2
+            });
+            (prisma.contentVersion.findMany as any).mockResolvedValue([]);
+
+            const content = '<p>Hello world</p><div data-type="beat-annotation">This beat has five words</div>';
+
+            await StructureController.writeSceneContent("scene-1", content);
+
+            expect(prisma.contentVersion.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        wordCount: 2, // only "Hello world", not the beat div content
+                    }),
+                })
+            );
+        });
+
         it("should accept content without beats", async () => {
             (prisma.structureNode.findUnique as any).mockResolvedValue(mockNode);
             (prisma.contentVersion.create as any).mockResolvedValue({ id: "v1", createdAt: new Date() });

--- a/src/lib/controllers/structure.ts
+++ b/src/lib/controllers/structure.ts
@@ -369,7 +369,14 @@ export class StructureController {
 
         StructureController.validateSceneContent(content);
 
-        const prose = content.replace(/(<!-- beat:[\s\S]*?-->)/g, "").trim();
+        // Strip beat annotations in both storage formats:
+        // 1. HTML comment format (normal save path via beatsToComments)
+        // 2. HTML div format (MCP or direct writes without conversion)
+        const stripped = content
+            .replace(/<div[^>]*data-type="beat-annotation"[^>]*>[\s\S]*?<\/div>/g, "")
+            .replace(/(<!-- beat:[\s\S]*?-->)/g, "");
+        // Strip HTML tags (replace with space so adjacent tags don't merge words)
+        const prose = stripped.replace(/<[^>]*>/g, " ").replace(/&nbsp;/gi, " ").replace(/\s+/g, " ").trim();
         const wordCount = prose === "" ? 0 : prose.split(/\s+/).length;
 
         const version = await prisma.contentVersion.create({


### PR DESCRIPTION
## Summary
- Strip beat annotations in both HTML comment and div formats before counting words
- Strip HTML tags (replacing with spaces to avoid merging adjacent words)
- Add test for MCP path beat div annotation exclusion

## Issue
Fixes an-mxq: Scene word count includes beat text

## Test plan
- [x] Gates passed by polecat pre-verification
- [x] Rebased on current master (by refinery — polecat was dead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)