### PR TITLE
feat: expose MCP as HTTP endpoint instead of stdio (an-6s1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ COPY . .
 
 RUN npx prisma generate
 RUN npm run build
-RUN npm run mcp:build
 
 # --- Stage 3: Production runtime ---
 FROM node:20-slim AS runner
@@ -36,7 +35,6 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
-COPY --from=builder /app/dist/mcp ./dist/mcp
 COPY --from=builder /app/.skills ./.skills
 
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "db:studio": "prisma studio",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
-    "e2e:update-snapshots": "playwright test --update-snapshots",
-    "mcp:build": "esbuild src/mcp/index.ts --bundle --platform=node --format=esm --outfile=dist/mcp/index.mjs --minify --external:@prisma/client --alias:@=./src"
+    "e2e:update-snapshots": "playwright test --update-snapshots"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,30 @@
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { server } from "@/mcp";
+
+let transport: WebStandardStreamableHTTPServerTransport | null = null;
+
+async function getTransport(): Promise<WebStandardStreamableHTTPServerTransport> {
+    if (!transport) {
+        transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: undefined, // stateless mode
+            enableJsonResponse: true,
+        });
+        await server.connect(transport);
+    }
+    return transport;
+}
+
+export async function POST(req: Request): Promise<Response> {
+    const t = await getTransport();
+    return t.handleRequest(req);
+}
+
+export async function GET(req: Request): Promise<Response> {
+    const t = await getTransport();
+    return t.handleRequest(req);
+}
+
+export async function DELETE(req: Request): Promise<Response> {
+    const t = await getTransport();
+    return t.handleRequest(req);
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,5 +1,4 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { initSnapshotRepo } from "./snapshot";
 import { listSkills, loadSkill } from "./skills";
@@ -904,15 +903,4 @@ for (const skillMeta of availableSkills) {
 
 console.error(`Registered ${availableSkills.length} skill(s) as MCP prompts`);
 
-// ─── Start server ────────────────────────────────────────────────────────────
-
-async function main() {
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
-    console.error("Word Coach Annie MCP server running on stdio");
-}
-
-main().catch((error) => {
-    console.error("Fatal error:", error);
-    process.exit(1);
-});
+export { server };


### PR DESCRIPTION
## Summary

- Replace stdio-based MCP server with HTTP endpoint at `/api/mcp` using StreamableHTTPServerTransport
- Eliminates bundling/docker-exec issues for MCP connectivity

- **Issue**: an-6s1
- **Polecat**: furiosa
- **Branch**: polecat/furiosa/an-6s1@mmrmexwy
- **Tests**: 356/356 passed (verified by refinery)
- **Typecheck**: clean
- **Lint**: 0 errors
- **Build**: successful

---
*Created by Gas Town Refinery*