### PR TITLE
fix: MCP route crashes - stateless transport reused across requests (an-rtg)

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,30 +1,18 @@
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import { server } from "@/mcp";
+import { createServer } from "@/mcp";
 
-let transport: WebStandardStreamableHTTPServerTransport | null = null;
-
-async function getTransport(): Promise<WebStandardStreamableHTTPServerTransport> {
-    if (!transport) {
-        transport = new WebStandardStreamableHTTPServerTransport({
-            sessionIdGenerator: undefined, // stateless mode
-            enableJsonResponse: true,
-        });
-        await server.connect(transport);
-    }
-    return transport;
+async function handleMcpRequest(req: Request): Promise<Response> {
+    const server = createServer();
+    const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined, // stateless mode
+        enableJsonResponse: true,
+    });
+    await server.connect(transport);
+    const response = await transport.handleRequest(req);
+    await server.close();
+    return response;
 }
 
-export async function POST(req: Request): Promise<Response> {
-    const t = await getTransport();
-    return t.handleRequest(req);
-}
-
-export async function GET(req: Request): Promise<Response> {
-    const t = await getTransport();
-    return t.handleRequest(req);
-}
-
-export async function DELETE(req: Request): Promise<Response> {
-    const t = await getTransport();
-    return t.handleRequest(req);
-}
+export async function POST(req: Request): Promise<Response> { return handleMcpRequest(req); }
+export async function GET(req: Request): Promise<Response> { return handleMcpRequest(req); }
+export async function DELETE(req: Request): Promise<Response> { return handleMcpRequest(req); }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -72,6 +72,8 @@ try {
     console.error("Warning: Could not initialize snapshot repo:", e);
 }
 
+function createServer(): McpServer {
+
 const server = new McpServer({
     name: "word-coach-annie",
     version: "1.0.0",
@@ -901,6 +903,8 @@ for (const skillMeta of availableSkills) {
     );
 }
 
-console.error(`Registered ${availableSkills.length} skill(s) as MCP prompts`);
+return server;
 
-export { server };
+} // end createServer
+
+export { createServer };


### PR DESCRIPTION
## Summary

Automated merge from polecat branch.

- **Issue**: an-rtg
- **Polecat**: furiosa
- **Branch**: polecat/furiosa/an-rtg@mmro481j
- **Tests**: Passed (verified by refinery)

---
*Created by Gas Town Refinery*