### PR TITLE
fix: OAuth callback redirect uses Docker container hostname

### DIFF
--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -74,7 +74,9 @@ export async function GET(request: NextRequest) {
     });
 
     // Redirect to home with session cookie
-    const response = NextResponse.redirect(new URL("/", request.url));
+    // Use GOOGLE_REDIRECT_URI origin to avoid Docker container hostname in redirect
+    const baseUrl = new URL(redirectUri).origin;
+    const response = NextResponse.redirect(new URL("/", baseUrl));
     response.cookies.set(SESSION_COOKIE_NAME, jwt, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",


### PR DESCRIPTION
## Summary
- After Google OAuth, the callback redirected to the Docker container's internal hostname (e.g. `80cbf7c71f84:3000`) instead of the external domain
- Root cause: `new URL("/", request.url)` — inside Docker, `request.url` has the container hostname
- Fix: derive base URL from `GOOGLE_REDIRECT_URI` which always has the correct external hostname

## Test plan
- [ ] Login via Google OAuth redirects to the correct external URL, not a container ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)