### PR TITLE
fix: backfill legacy NULL userId and remove access fallback (an-82p)

### DIFF
--- a/prisma/migrations/backfill_null_userid.sql
+++ b/prisma/migrations/backfill_null_userid.sql
@@ -1,0 +1,15 @@
+-- Backfill legacy NULL userId — assign unowned projects/universes to admin
+-- an-82p: Critical for multi-tenant data separation
+--
+-- Assigns all projects and universes with NULL userId to the earliest-created
+-- user (admin). If no users exist yet, these are no-ops (subquery returns NULL).
+
+UPDATE "Project"
+SET "userId" = (SELECT "id" FROM "User" ORDER BY "createdAt" ASC LIMIT 1),
+    "updatedAt" = CURRENT_TIMESTAMP
+WHERE "userId" IS NULL;
+
+UPDATE "Universe"
+SET "userId" = (SELECT "id" FROM "User" ORDER BY "createdAt" ASC LIMIT 1),
+    "updatedAt" = CURRENT_TIMESTAMP
+WHERE "userId" IS NULL;

--- a/src/__tests__/api-auth.test.ts
+++ b/src/__tests__/api-auth.test.ts
@@ -35,11 +35,14 @@ describe("api-auth", () => {
             expect(result.authorized).toBe(true);
         });
 
-        it("allows access when project has no owner (legacy)", async () => {
+        it("denies access when project has no owner and user is authenticated", async () => {
             const project = await ProjectsController.createProject({ title: "Legacy" });
-            // Project created without userId is legacy
+            // Unowned projects are not accessible to authenticated users
             const result = await verifyProjectAccess(project.id, "some-user");
-            expect(result.authorized).toBe(true);
+            expect(result.authorized).toBe(false);
+            if (!result.authorized) {
+                expect(result.response.status).toBe(403);
+            }
         });
 
         it("allows access when userId matches project owner", async () => {
@@ -81,12 +84,15 @@ describe("api-auth", () => {
             expect(result.authorized).toBe(true);
         });
 
-        it("allows access when universe has no owner (legacy)", async () => {
+        it("denies access when universe has no owner and user is authenticated", async () => {
             const universe = await prisma.universe.create({
                 data: { title: "Legacy Universe" },
             });
             const result = await verifyUniverseAccess(universe.id, "some-user");
-            expect(result.authorized).toBe(true);
+            expect(result.authorized).toBe(false);
+            if (!result.authorized) {
+                expect(result.response.status).toBe(403);
+            }
         });
 
         it("allows access when userId matches universe owner", async () => {

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -9,8 +9,8 @@ export async function GET(request: NextRequest) {
   const offset = parseInt(searchParams.get("offset") || "0");
   const userId = getCurrentUserId(request);
 
-  // Scope by userId when available; include unowned (legacy) projects
-  const where = userId ? { OR: [{ userId }, { userId: null }] } : {};
+  // Scope by userId when authenticated; show all in API_TOKEN/dev mode
+  const where = userId ? { userId } : {};
 
   const [projects, total] = await Promise.all([
     prisma.project.findMany({

--- a/src/app/api/universes/route.ts
+++ b/src/app/api/universes/route.ts
@@ -8,9 +8,9 @@ export async function GET(request: NextRequest) {
         const userId = getCurrentUserId(request);
 
         if (userId) {
-            // Scoped query: user's universes + unowned (legacy) universes
+            // Scoped query: only this user's universes
             const universes = await prisma.universe.findMany({
-                where: { OR: [{ userId }, { userId: null }] },
+                where: { userId },
                 orderBy: { updatedAt: "desc" },
                 include: {
                     _count: {

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -15,6 +15,7 @@ export function getCurrentUserId(request: NextRequest): string | null {
  * Verify that a project belongs to the current user.
  * Returns the project if accessible, or a 403/404 response.
  * When userId is null (API_TOKEN/dev mode), all projects are accessible.
+ * Unowned projects (NULL userId) are denied to authenticated users.
  */
 export async function verifyProjectAccess(
     projectId: string,
@@ -37,11 +38,6 @@ export async function verifyProjectAccess(
         return { authorized: true, project };
     }
 
-    // Project has no owner (legacy data) — allow access
-    if (!project.userId) {
-        return { authorized: true, project };
-    }
-
     if (project.userId !== userId) {
         return {
             authorized: false,
@@ -56,6 +52,7 @@ export async function verifyProjectAccess(
  * Verify that a universe belongs to the current user.
  * Returns the universe if accessible, or a 403/404 response.
  * When userId is null (API_TOKEN/dev mode), all universes are accessible.
+ * Unowned universes (NULL userId) are denied to authenticated users.
  */
 export async function verifyUniverseAccess(
     universeId: string,
@@ -74,10 +71,6 @@ export async function verifyUniverseAccess(
     }
 
     if (!userId) {
-        return { authorized: true, universe };
-    }
-
-    if (!universe.userId) {
         return { authorized: true, universe };
     }
 


### PR DESCRIPTION
## Summary

Automated merge from polecat branch.

- **Issue**: an-82p
- **Polecat**: furiosa
- **Branch**: polecat/furiosa/an-82p@mmsxb8vb
- **Tests**: Passed (verified by refinery)

---
*Created by Gas Town Refinery*