### PR TITLE
fix: resolve test timeouts in api-routes and structure-controller

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -10,18 +10,22 @@ export const testPrisma = new PrismaClient({
   datasources: { db: { url: TEST_DATABASE_URL } },
 });
 
-// Clean all tables before each test
+// Clean all tables before each test using raw SQL in a transaction for speed.
+// A single transaction with raw DELETEs is much faster than 12 sequential
+// Prisma deleteMany calls, especially in constrained environments (Docker, CI).
 beforeEach(async () => {
-  await testPrisma.googleDocExport.deleteMany();
-  await testPrisma.googleCredential.deleteMany();
-  await testPrisma.relationship.deleteMany();
-  await testPrisma.annotation.deleteMany();
-  await testPrisma.contentVersion.deleteMany();
-  await testPrisma.storyObject.deleteMany();
-  await testPrisma.structureNode.deleteMany();
-  await testPrisma.worldObjectTimelineEntry.deleteMany();
-  await testPrisma.worldObject.deleteMany();
-  await testPrisma.project.deleteMany();
-  await testPrisma.universe.deleteMany();
-  await testPrisma.user.deleteMany();
+  await testPrisma.$transaction([
+    testPrisma.$executeRawUnsafe('DELETE FROM "GoogleDocExport"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "GoogleCredential"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "Relationship"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "Annotation"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "ContentVersion"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "StoryObject"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "StructureNode"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "WorldObjectTimelineEntry"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "WorldObject"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "Project"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "Universe"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "User"'),
+  ]);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
     exclude: ["e2e/**", "node_modules/**"],
     environment: "node",
     globals: true,
+    testTimeout: 15000,
+    hookTimeout: 15000,
     globalSetup: ["./src/__tests__/globalSetup.ts"],
     setupFiles: ["./src/__tests__/setup.ts"],
     // Run test files sequentially to avoid shared DB conflicts


### PR DESCRIPTION
## Summary
- Replaced 12 sequential Prisma `deleteMany()` calls in test `beforeEach` with a single `$transaction` of raw SQL `DELETE` statements, significantly reducing per-test cleanup overhead
- Raised `testTimeout` and `hookTimeout` from default 5s to 15s in vitest config as a safety margin for slower environments (Docker, CI)
- Full test suite duration dropped ~35% (97s → 63s) with all 485 tests passing

## Test plan
- [x] All 485 tests pass locally
- [x] The 6 previously-timing-out tests now complete well under timeout
- [x] Typecheck passes
- [x] Lint passes (0 errors, only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)