### PR TITLE
fix: resolve test timeouts in api-routes and structure-controller (an-1pw)

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -10,18 +10,22 @@ export const testPrisma = new PrismaClient({
   datasources: { db: { url: TEST_DATABASE_URL } },
 });
 
-// Clean all tables before each test
+// Clean all tables before each test using raw SQL in a transaction for speed.
+// A single transaction with raw DELETEs is much faster than 12 sequential
+// Prisma deleteMany calls, especially in constrained environments (Docker, CI).
 beforeEach(async () => {
-  await testPrisma.googleDocExport.deleteMany();
-  await testPrisma.googleCredential.deleteMany();
-  await testPrisma.relationship.deleteMany();
-  await testPrisma.annotation.deleteMany();
-  await testPrisma.contentVersion.deleteMany();
-  await testPrisma.storyObject.deleteMany();
-  await testPrisma.structureNode.deleteMany();
-  await testPrisma.worldObjectTimelineEntry.deleteMany();
-  await testPrisma.worldObject.deleteMany();
-  await testPrisma.project.deleteMany();
-  await testPrisma.universe.deleteMany();
-  await testPrisma.user.deleteMany();
+  await testPrisma.$transaction([
+    testPrisma.$executeRawUnsafe('DELETE FROM "GoogleDocExport"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "GoogleCredential"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "Relationship"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "Annotation"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "ContentVersion"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "StoryObject"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "StructureNode"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "WorldObjectTimelineEntry"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "WorldObject"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "Project"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "Universe"'),
+    testPrisma.$executeRawUnsafe('DELETE FROM "User"'),
+  ]);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
     exclude: ["e2e/**", "node_modules/**"],
     environment: "node",
     globals: true,
+    testTimeout: 15000,
+    hookTimeout: 15000,
     globalSetup: ["./src/__tests__/globalSetup.ts"],
     setupFiles: ["./src/__tests__/setup.ts"],
     // Run test files sequentially to avoid shared DB conflicts


### PR DESCRIPTION
## Summary
- Replaces 12 sequential Prisma `deleteMany` calls in test setup with a single raw SQL transaction for faster cleanup
- Increases `testTimeout` and `hookTimeout` from 5000ms to 15000ms in vitest config to prevent flaky timeouts under load

Resolves an-1pw (pre-existing test timeouts).

## Test plan
- [x] All 186 tests pass
- [x] Typecheck passes
- [x] Lint passes (warnings only, pre-existing)
- [x] Docker build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)