### PR TITLE
feat: add invite-only access control via ALLOWED_EMAILS env var (an-z30)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ AI_MODEL=gpt-4o
 # REQUESTY_API_KEY=
 # REQUESTY_MODEL=
 
+# Invite-only access control (optional)
+# Comma-separated list of Google email addresses allowed to sign in.
+# When set, all other emails are rejected at OAuth with a friendly message.
+# When unset, any Google account can sign in.
+ALLOWED_EMAILS=
+
 # API Authentication (REQUIRED when exposed to the internet)
 # Set this to a strong random token. All API and page requests will require it.
 # Generate one with: openssl rand -hex 32

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -50,6 +50,19 @@ export async function GET(request: NextRequest) {
         );
     }
 
+    // Enforce invite-only allowlist (when configured)
+    if (env.ALLOWED_EMAILS) {
+        const allowed = env.ALLOWED_EMAILS.split(",").map((e) =>
+            e.trim().toLowerCase()
+        );
+        if (!allowed.includes(userInfo.email.toLowerCase())) {
+            const baseUrl = new URL(redirectUri).origin;
+            return NextResponse.redirect(
+                new URL("/login?error=invite_only", baseUrl)
+            );
+        }
+    }
+
     // Upsert user in database
     const user = await prisma.user.upsert({
         where: { googleId: userInfo.id },

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -39,8 +39,16 @@ function LoginForm() {
         }
     };
 
+    const authError = searchParams.get("error");
+
     return (
         <div className="space-y-4">
+            {authError === "invite_only" && (
+                <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-center text-sm text-destructive">
+                    Sorry, this app is invite-only. Your email is not on the
+                    access list. Please contact the admin for an invitation.
+                </div>
+            )}
             <Button
                 variant="outline"
                 className="w-full"

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -32,6 +32,9 @@ const envSchema = z.object({
   JWT_SECRET: z.string().optional(),
   ENCRYPTION_KEY: z.string().optional(),
 
+  // Access control — invite-only allowlist (comma-separated emails)
+  ALLOWED_EMAILS: z.string().optional(),
+
   // Feedback (GitHub issue creation)
   GITHUB_FEEDBACK_TOKEN: z.string().optional(),
   GITHUB_FEEDBACK_REPO: z.string().optional(), // format: "owner/repo"


### PR DESCRIPTION
## Summary
- Adds invite-only access control: only emails in `ALLOWED_EMAILS` env var can sign in via Google OAuth
- Rejects unauthorized users at OAuth callback with friendly "invite-only" message on login page
- Configurable via comma-separated email list; empty = open access (no restriction)

Resolves an-z30.

## Test plan
- [x] All 186 tests pass
- [x] Typecheck passes
- [x] Lint passes (warnings only, pre-existing)
- [x] Docker build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)