### PR TITLE
feat: service worker setup with font caching and lifecycle management (an-6gq)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,10 +49,10 @@ const nextConfig: NextConfig = {
             value: [
               "default-src 'self'",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-              "style-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' data: blob:",
-              "font-src 'self'",
-              "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io",
+              "font-src 'self' https://fonts.gstatic.com",
+              "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://fonts.googleapis.com https://fonts.gstatic.com",
               "object-src 'none'",
               "frame-ancestors 'none'",
               "base-uri 'self'",
@@ -89,6 +89,8 @@ const pwaConfig = withPWA({
     document: "/_offline",
   },
   workboxOptions: {
+    skipWaiting: true,
+    clientsClaim: true,
     runtimeCaching: [
       // Stale-while-revalidate for API GET requests
       {
@@ -106,7 +108,37 @@ const pwaConfig = withPWA({
           },
         },
       },
-      // Include the default caches (static assets, fonts, images, etc.)
+      // Cache Google Fonts stylesheets
+      {
+        urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "google-fonts-stylesheets",
+          expiration: {
+            maxEntries: 4,
+            maxAgeSeconds: 7 * 24 * 60 * 60, // 7 days
+          },
+          cacheableResponse: {
+            statuses: [0, 200],
+          },
+        },
+      },
+      // Cache Google Fonts webfont files
+      {
+        urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
+        handler: "CacheFirst",
+        options: {
+          cacheName: "google-fonts-webfonts",
+          expiration: {
+            maxEntries: 16,
+            maxAgeSeconds: 365 * 24 * 60 * 60, // 1 year
+          },
+          cacheableResponse: {
+            statuses: [0, 200],
+          },
+        },
+      },
+      // Include the default caches (static assets, images, etc.)
       ...runtimeCaching,
     ],
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { OfflineIndicator } from "@/components/offline-indicator";
 import { SyncToast } from "@/components/sync-toast";
 import { UpdateBanner } from "@/components/update-banner";
+import { SwLifecycle } from "@/components/sw-lifecycle";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ToastProvider } from "@/components/ui/toast";
 
@@ -65,6 +66,7 @@ export default function RootLayout({
             <SyncToast />
           </ToastProvider>
           <OfflineIndicator />
+          <SwLifecycle />
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/sw-lifecycle.tsx
+++ b/src/components/sw-lifecycle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Handles service worker lifecycle events.
+ * Listens for SW controller changes (after skipWaiting activates a new SW)
+ * and reloads the page to ensure the app uses the latest cached assets.
+ */
+export function SwLifecycle() {
+    useEffect(() => {
+        if (typeof window === "undefined" || !("serviceWorker" in navigator)) {
+            return;
+        }
+
+        // When a new SW takes over (after skipWaiting), reload to get fresh assets
+        let refreshing = false;
+        const handleControllerChange = () => {
+            if (refreshing) return;
+            refreshing = true;
+            window.location.reload();
+        };
+
+        navigator.serviceWorker.addEventListener(
+            "controllerchange",
+            handleControllerChange,
+        );
+
+        return () => {
+            navigator.serviceWorker.removeEventListener(
+                "controllerchange",
+                handleControllerChange,
+            );
+        };
+    }, []);
+
+    return null;
+}


### PR DESCRIPTION
## Summary
- Adds Google Fonts caching (StaleWhileRevalidate for stylesheets, CacheFirst for webfonts)
- Enables skipWaiting + clientsClaim for immediate SW activation
- Adds SwLifecycle component to auto-reload on SW controller change
- Updates CSP headers to allow Google Fonts resources

Part of #70

## Test plan
- [x] Typecheck passes
- [x] Lint passes (warnings only)
- [x] All tests pass
- [x] Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)