### PR TITLE
feat: add user context to Sentry error reports (an-7v3)

### DIFF
--- a/src/__tests__/api-auth.test.ts
+++ b/src/__tests__/api-auth.test.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db";
 
 vi.mock("@sentry/nextjs", () => ({
     setUser: vi.fn(),
+    setTag: vi.fn(),
 }));
 
 import {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -7,6 +7,7 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
   captureMessage: vi.fn(),
   setUser: vi.fn(),
+  setTag: vi.fn(),
   replayIntegration: vi.fn(),
   browserTracingIntegration: vi.fn(),
   captureRequestError: vi.fn(),

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import * as Sentry from "@sentry/nextjs";
 
 export interface AuthUser {
     userId: string;
@@ -32,15 +33,22 @@ export function useAuth(): AuthState {
                 setAuthenticated(data.authenticated);
                 setAuthMethod(data.authMethod || null);
                 setUser(data.user || null);
+                if (data.user) {
+                    Sentry.setUser({ id: data.user.userId, email: data.user.email });
+                } else {
+                    Sentry.setUser(null);
+                }
             } else {
                 setAuthenticated(false);
                 setAuthMethod(null);
                 setUser(null);
+                Sentry.setUser(null);
             }
         } catch {
             setAuthenticated(false);
             setAuthMethod(null);
             setUser(null);
+            Sentry.setUser(null);
         } finally {
             setLoading(false);
         }
@@ -51,6 +59,7 @@ export function useAuth(): AuthState {
         setAuthenticated(false);
         setAuthMethod(null);
         setUser(null);
+        Sentry.setUser(null);
         window.location.href = "/login";
     }, []);
 

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -42,6 +42,7 @@ export async function verifyProjectAccess(
 
     // No user scoping in API_TOKEN / dev mode
     if (!userId) {
+        Sentry.setTag("projectId", projectId);
         return { authorized: true, project };
     }
 
@@ -52,6 +53,7 @@ export async function verifyProjectAccess(
         };
     }
 
+    Sentry.setTag("projectId", projectId);
     return { authorized: true, project };
 }
 


### PR DESCRIPTION
## Summary

- Add Sentry user context (id, email) on auth so errors are attributed to users
- Include project ID as tag for better error filtering

**Issue**: an-7v3
**Polecat**: furiosa
**Tests**: All gates passed (setup, typecheck, lint, build, test)

Fixes #71

---
*Merged by Gas Town Refinery*