### PR TITLE
feat: add source maps upload to Sentry build pipeline (an-pyx)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,14 @@ GITHUB_FEEDBACK_TOKEN=
 # Repository to file feedback issues in, e.g. "myorg/myrepo"
 GITHUB_FEEDBACK_REPO=
 
+# Sentry Error Monitoring (optional)
+# DSN from Sentry project settings (Client Keys)
+NEXT_PUBLIC_SENTRY_DSN=
+# Auth token for source map uploads during build
+# Generate at: https://sentry.io/settings/auth-tokens/ (scope: org:read, project:releases, project:write)
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+
 # Cloudflare Tunnel (Optional, for public access during development)
 CLOUDFLARE_TUNNEL_TOKEN=

--- a/next.config.ts
+++ b/next.config.ts
@@ -145,15 +145,26 @@ const pwaConfig = withPWA({
 })(nextConfig);
 
 export default withSentryConfig(withAnalyzer(pwaConfig), {
-  // Suppresses source map upload logs during build
+  // Suppress source map upload logs during build
   silent: true,
 
-  // Upload source maps only when SENTRY_AUTH_TOKEN is set
+  // Sentry project identification
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
 
-  // Automatically tree-shake Sentry logger statements for smaller bundles
-  disableLogger: true,
+  // Tag each release with the git commit hash for accurate stack traces
+  release: { name: buildVersion },
+
+  // Upload source maps then delete them so they're never served to clients
+  sourcemaps: {
+    deleteSourcemapsAfterUpload: true,
+  },
+
+  // Tree-shake Sentry debug logging for smaller bundles
+  bundleSizeOptimizations: {
+    excludeDebugStatements: true,
+  },
 
   // Hides source maps from generated client bundles
   hideSourceMaps: true,


### PR DESCRIPTION
## Summary

- Configure Sentry webpack plugin to upload source maps during build
- Ensure source maps are not served to clients

**Issue**: an-pyx
**Polecat**: furiosa
**Tests**: All gates passed (setup, typecheck, lint, build pass; 2 pre-existing test timeouts in focus-controller.test.ts tracked as an-o04)

Part of #71

---
*Merged by Gas Town Refinery*