### PR TITLE
feat: export scene content as HTML and plain text (an-q4e)

### DIFF
--- a/src/__tests__/export.test.ts
+++ b/src/__tests__/export.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { stripBeatMarkers, htmlToPlainText } from "@/lib/export-json";
 
 // Test the HTML-to-Markdown conversion logic used in export
 function htmlToMarkdown(html: string): string {
@@ -80,5 +81,73 @@ describe("HTML to Markdown conversion", () => {
     expect(md).toContain("*dark*");
     expect(md).toContain("- A sword");
     expect(md).toContain("- A shield");
+  });
+});
+
+describe("stripBeatMarkers", () => {
+  it("strips HTML comment beats", () => {
+    const html = '<p>Hello</p><!-- beat: Action scene --><p>World</p>';
+    expect(stripBeatMarkers(html)).toBe("<p>Hello</p><p>World</p>");
+  });
+
+  it("strips editor beat divs", () => {
+    const html = '<p>Hello</p><div data-type="beat-annotation">Chase scene</div><p>World</p>';
+    expect(stripBeatMarkers(html)).toBe("<p>Hello</p><p>World</p>");
+  });
+
+  it("strips multiple beats", () => {
+    const html = '<!-- beat: First --><!-- beat: Second --><p>Content</p>';
+    expect(stripBeatMarkers(html)).toBe("<p>Content</p>");
+  });
+
+  it("returns HTML unchanged when no beats present", () => {
+    const html = "<p>No beats here</p>";
+    expect(stripBeatMarkers(html)).toBe(html);
+  });
+
+  it("strips multiline beat comments", () => {
+    const html = '<p>Before</p><!-- beat: This is\na multiline\nbeat --><p>After</p>';
+    expect(stripBeatMarkers(html)).toBe("<p>Before</p><p>After</p>");
+  });
+});
+
+describe("htmlToPlainText", () => {
+  it("converts empty or minimal HTML", () => {
+    expect(htmlToPlainText("")).toBe("");
+    expect(htmlToPlainText("<p></p>")).toBe("");
+  });
+
+  it("converts paragraphs to plain text", () => {
+    expect(htmlToPlainText("<p>Hello world</p>")).toBe("Hello world");
+    expect(htmlToPlainText("<p>First</p><p>Second</p>")).toBe("First\n\nSecond");
+  });
+
+  it("strips formatting tags", () => {
+    expect(htmlToPlainText("<p><strong>bold</strong> and <em>italic</em></p>")).toBe("bold and italic");
+  });
+
+  it("strips beat markers from plain text", () => {
+    const html = '<p>Before beat</p><!-- beat: Action --><p>After beat</p>';
+    const text = htmlToPlainText(html);
+    expect(text).toBe("Before beat\n\nAfter beat");
+    expect(text).not.toContain("beat:");
+    expect(text).not.toContain("Action");
+  });
+
+  it("strips editor beat divs from plain text", () => {
+    const html = '<p>Content</p><div data-type="beat-annotation">Chase</div><p>More</p>';
+    const text = htmlToPlainText(html);
+    expect(text).toBe("Content\n\nMore");
+    expect(text).not.toContain("Chase");
+  });
+
+  it("decodes HTML entities", () => {
+    expect(htmlToPlainText("<p>A &amp; B</p>")).toBe("A & B");
+    expect(htmlToPlainText("<p>&ldquo;Hello&rdquo;</p>")).toBe("\u201CHello\u201D");
+    expect(htmlToPlainText("<p>dash &mdash; here</p>")).toBe("dash \u2014 here");
+  });
+
+  it("handles line breaks", () => {
+    expect(htmlToPlainText("<p>Line one<br>Line two</p>")).toBe("Line one\nLine two");
   });
 });

--- a/src/lib/export-json.ts
+++ b/src/lib/export-json.ts
@@ -1,5 +1,49 @@
 import { prisma } from "@/lib/db";
 
+/** Strip beat markers (HTML comments and editor divs) from HTML content */
+export function stripBeatMarkers(html: string): string {
+  let result = html;
+  // Strip HTML comment beats: <!-- beat: ... -->
+  result = result.replace(/<!-- beat: [\s\S]*?-->/g, "");
+  // Strip editor beat divs: <div data-type="beat-annotation">...</div>
+  result = result.replace(/<div[^>]*data-type="beat-annotation"[^>]*>[\s\S]*?<\/div>/g, "");
+  return result;
+}
+
+/** Convert HTML content to plain text, stripping all tags and beat markers */
+export function htmlToPlainText(html: string): string {
+  if (!html || html === "<p></p>") return "";
+
+  let text = stripBeatMarkers(html);
+
+  // Convert block elements to newlines
+  text = text.replace(/<br\s*\/?>/gi, "\n");
+  text = text.replace(/<\/p>/gi, "\n\n");
+  text = text.replace(/<\/h[1-6]>/gi, "\n\n");
+  text = text.replace(/<\/li>/gi, "\n");
+  text = text.replace(/<\/(?:ul|ol|blockquote)>/gi, "\n");
+
+  // Strip all remaining HTML tags
+  text = text.replace(/<[^>]+>/g, "");
+
+  // Decode HTML entities
+  text = text.replace(/&amp;/g, "&");
+  text = text.replace(/&lt;/g, "<");
+  text = text.replace(/&gt;/g, ">");
+  text = text.replace(/&quot;/g, '"');
+  text = text.replace(/&#39;/g, "'");
+  text = text.replace(/&ldquo;/g, "\u201C");
+  text = text.replace(/&rdquo;/g, "\u201D");
+  text = text.replace(/&mdash;/g, "\u2014");
+  text = text.replace(/&ndash;/g, "\u2013");
+  text = text.replace(/&nbsp;/g, " ");
+
+  // Clean up whitespace
+  text = text.replace(/\n{3,}/g, "\n\n");
+
+  return text.trim();
+}
+
 export async function exportProjectJson(projectId: string) {
   const project = await prisma.project.findUnique({ where: { id: projectId } });
   if (!project) throw new Error(`Project not found: ${projectId}`);
@@ -82,6 +126,8 @@ export async function exportProjectJson(projectId: string) {
       id: v.id,
       nodeId: v.nodeId,
       content: v.content,
+      contentHtml: stripBeatMarkers(v.content),
+      contentPlainText: htmlToPlainText(v.content),
       wordCount: v.wordCount,
       createdAt: v.createdAt.toISOString(),
     })),


### PR DESCRIPTION
## Summary

- Export scene content as rich text (HTML) and plain text formats

**Issue**: an-q4e
**Polecat**: furiosa
**Tests**: All gates passed

Part of #69

---
*Created by Gas Town Refinery*