### PR TITLE
feat: add batch operations to MCP server — bulk scene/object CRUD (an-3bk)

### DIFF
--- a/src/lib/controllers/story-objects.ts
+++ b/src/lib/controllers/story-objects.ts
@@ -258,4 +258,136 @@ export class StoryObjectController {
 
         return { deleted: true, id: objectId, name: obj.name, type: obj.type };
     }
+
+    static async batchCreateStoryObjects(
+        projectId: string,
+        objects: Array<{
+            type: string;
+            name: string;
+            description?: string;
+            notes?: string;
+            role?: string;
+            tags?: string;
+        }>
+    ) {
+        if (objects.length === 0) throw new Error("objects array must not be empty");
+        if (objects.length > 50) throw new Error("Maximum 50 objects per batch");
+
+        const project = await prisma.project.findUnique({
+            where: { id: projectId },
+            select: { id: true },
+        });
+        if (!project) throw new Error(`Project not found: ${projectId}`);
+
+        const results = [];
+        const errors = [];
+
+        for (let i = 0; i < objects.length; i++) {
+            const obj = objects[i];
+            try {
+                if (!VALID_TYPES.includes(obj.type as StoryObjectType)) {
+                    throw new Error(`Invalid type "${obj.type}". Must be one of: ${VALID_TYPES.join(", ")}`);
+                }
+                if (!obj.name || obj.name.trim().length === 0) {
+                    throw new Error("name is required");
+                }
+
+                const created = await prisma.storyObject.create({
+                    data: {
+                        projectId,
+                        type: obj.type,
+                        name: obj.name.trim(),
+                        ...(obj.description !== undefined && { description: obj.description }),
+                        ...(obj.notes !== undefined && { notes: obj.notes }),
+                        ...(obj.role !== undefined && { role: obj.role }),
+                        ...(obj.tags !== undefined && { tags: obj.tags }),
+                    },
+                });
+
+                results.push({
+                    index: i,
+                    success: true,
+                    id: created.id,
+                    type: created.type,
+                    name: created.name,
+                });
+            } catch (e) {
+                errors.push({
+                    index: i,
+                    success: false,
+                    name: obj.name,
+                    error: e instanceof Error ? e.message : String(e),
+                });
+            }
+        }
+
+        return { created: results, errors, totalCreated: results.length, totalErrors: errors.length };
+    }
+
+    static async batchUpdateStoryObjects(
+        updates: Array<{
+            objectId: string;
+            name?: string;
+            description?: string;
+            notes?: string;
+            role?: string | null;
+            tags?: string;
+        }>
+    ) {
+        if (updates.length === 0) throw new Error("updates array must not be empty");
+        if (updates.length > 50) throw new Error("Maximum 50 updates per batch");
+
+        const results = [];
+        const errors = [];
+
+        for (let i = 0; i < updates.length; i++) {
+            const { objectId, ...data } = updates[i];
+            try {
+                const result = await StoryObjectController.updateStoryObject(objectId, data);
+                results.push({ index: i, success: true, id: result.id, name: result.name });
+            } catch (e) {
+                errors.push({
+                    index: i,
+                    success: false,
+                    objectId,
+                    error: e instanceof Error ? e.message : String(e),
+                });
+            }
+        }
+
+        return { updated: results, errors, totalUpdated: results.length, totalErrors: errors.length };
+    }
+
+    static async batchDeleteStoryObjects(objectIds: string[]) {
+        if (objectIds.length === 0) throw new Error("objectIds array must not be empty");
+        if (objectIds.length > 50) throw new Error("Maximum 50 deletions per batch");
+
+        try {
+            autoSnapshot("batch_delete_story_objects", `${objectIds.length} objects`);
+        } catch (e) {
+            // ignore snapshot issues
+        }
+
+        const results = [];
+        const errors = [];
+
+        for (let i = 0; i < objectIds.length; i++) {
+            const objectId = objectIds[i];
+            try {
+                const obj = await prisma.storyObject.findUnique({ where: { id: objectId } });
+                if (!obj) throw new Error(`Story object not found: ${objectId}`);
+                await prisma.storyObject.delete({ where: { id: objectId } });
+                results.push({ index: i, success: true, id: objectId, name: obj.name });
+            } catch (e) {
+                errors.push({
+                    index: i,
+                    success: false,
+                    objectId,
+                    error: e instanceof Error ? e.message : String(e),
+                });
+            }
+        }
+
+        return { deleted: results, errors, totalDeleted: results.length, totalErrors: errors.length };
+    }
 }

--- a/src/lib/controllers/structure.ts
+++ b/src/lib/controllers/structure.ts
@@ -485,6 +485,113 @@ export class StructureController {
             where: { id: annotationId },
         });
     }
+    static async batchCreateNodes(
+        projectId: string,
+        nodes: Array<{
+            type: string;
+            title: string;
+            parentId?: string;
+            synopsis?: string;
+            status?: string;
+        }>
+    ) {
+        if (nodes.length === 0) throw new Error("nodes array must not be empty");
+        if (nodes.length > 50) throw new Error("Maximum 50 nodes per batch");
+
+        const project = await prisma.project.findUnique({
+            where: { id: projectId },
+            select: { id: true },
+        });
+        if (!project) throw new Error(`Project not found: ${projectId}`);
+
+        const results = [];
+        const errors = [];
+
+        for (let i = 0; i < nodes.length; i++) {
+            try {
+                const result = await StructureController.createNode({
+                    projectId,
+                    ...nodes[i],
+                });
+                results.push({ index: i, success: true, ...result });
+            } catch (e) {
+                errors.push({
+                    index: i,
+                    success: false,
+                    title: nodes[i].title,
+                    error: e instanceof Error ? e.message : String(e),
+                });
+            }
+        }
+
+        return { created: results, errors, totalCreated: results.length, totalErrors: errors.length };
+    }
+
+    static async batchUpdateNodes(
+        updates: Array<{
+            nodeId: string;
+            title?: string;
+            synopsis?: string;
+            status?: string;
+            orderIndex?: number;
+            parentId?: string | null;
+        }>
+    ) {
+        if (updates.length === 0) throw new Error("updates array must not be empty");
+        if (updates.length > 50) throw new Error("Maximum 50 updates per batch");
+
+        const results = [];
+        const errors = [];
+
+        for (let i = 0; i < updates.length; i++) {
+            const { nodeId, ...data } = updates[i];
+            try {
+                const result = await StructureController.updateNode(nodeId, data);
+                results.push({ index: i, success: true, ...result });
+            } catch (e) {
+                errors.push({
+                    index: i,
+                    success: false,
+                    nodeId,
+                    error: e instanceof Error ? e.message : String(e),
+                });
+            }
+        }
+
+        return { updated: results, errors, totalUpdated: results.length, totalErrors: errors.length };
+    }
+
+    static async batchDeleteNodes(nodeIds: string[]) {
+        if (nodeIds.length === 0) throw new Error("nodeIds array must not be empty");
+        if (nodeIds.length > 50) throw new Error("Maximum 50 deletions per batch");
+
+        try {
+            autoSnapshot("batch_delete_nodes", `${nodeIds.length} nodes`);
+        } catch (e) {
+            logger.warn("Snapshot failed or not available", e);
+        }
+
+        const results = [];
+        const errors = [];
+
+        for (let i = 0; i < nodeIds.length; i++) {
+            const nodeId = nodeIds[i];
+            try {
+                const result = await StructureController.deleteNode(nodeId);
+                results.push({ index: i, success: true, ...result });
+            } catch (e) {
+                errors.push({
+                    index: i,
+                    success: false,
+                    nodeId,
+                    error: e instanceof Error ? e.message : String(e),
+                });
+            }
+        }
+
+        return { deleted: results, errors, totalDeleted: results.length, totalErrors: errors.length };
+    }
+
     static async getOpenAnnotations(projectId?: string) {
         const where: Record<string, unknown> = { resolved: false };
         if (projectId) {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -21,6 +21,9 @@ import {
     deleteAnnotation,
     resolveAnnotation,
     getOpenAnnotations,
+    batchCreateNodes,
+    batchUpdateNodes,
+    batchDeleteNodes,
 } from "./tools/structure";
 import {
     listStoryObjects,
@@ -28,6 +31,9 @@ import {
     createStoryObject,
     updateStoryObject,
     deleteStoryObject,
+    batchCreateStoryObjects,
+    batchUpdateStoryObjects,
+    batchDeleteStoryObjects,
 } from "./tools/story-objects";
 import {
     listRelationships,
@@ -474,6 +480,111 @@ server.tool(
     async ({ objectId }) => {
         const guard = destructiveGuard(); if (guard) return guard;
         const result = await deleteStoryObject(objectId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+// ─── Batch Tools ────────────────────────────────────────────────────────────
+
+server.tool(
+    "batch_create_story_objects",
+    "Create multiple story objects in a single operation. Returns per-item results with successes and errors. Max 50 per batch.",
+    {
+        projectId: z.string().describe("The project ID"),
+        objects: z.array(z.object({
+            type: z.enum(["CHARACTER", "LOCATION", "PLOTLINE", "WORLD_ELEMENT", "NOTE"]).describe("Object type"),
+            name: z.string().describe("Object name"),
+            description: z.string().optional().describe("Description"),
+            notes: z.string().optional().describe("Additional notes"),
+            role: z.string().optional().describe("Role (for characters)"),
+            tags: z.string().optional().describe("Comma-separated tags"),
+        })).describe("Array of story objects to create"),
+    },
+    async ({ projectId, objects }) => {
+        const result = await batchCreateStoryObjects(projectId, objects);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "batch_update_story_objects",
+    "Update multiple story objects in a single operation. Returns per-item results with successes and errors. Max 50 per batch.",
+    {
+        updates: z.array(z.object({
+            objectId: z.string().describe("The story object ID"),
+            name: z.string().optional().describe("New name"),
+            description: z.string().optional().describe("New description"),
+            notes: z.string().optional().describe("New notes"),
+            role: z.string().nullable().optional().describe("New role (null to clear)"),
+            tags: z.string().optional().describe("New comma-separated tags"),
+        })).describe("Array of updates to apply"),
+    },
+    async ({ updates }) => {
+        const result = await batchUpdateStoryObjects(updates);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "batch_delete_story_objects",
+    "Delete multiple story objects and their relationships in a single operation. A snapshot is created before deletion. Max 50 per batch.",
+    {
+        objectIds: z.array(z.string()).describe("Array of story object IDs to delete"),
+    },
+    async ({ objectIds }) => {
+        const guard = destructiveGuard(); if (guard) return guard;
+        const result = await batchDeleteStoryObjects(objectIds);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "batch_create_nodes",
+    "Create multiple structure nodes (PART, CHAPTER, SCENE) in a single operation. Nodes are created sequentially, so earlier entries can serve as parents for later ones. Max 50 per batch.",
+    {
+        projectId: z.string().describe("The project ID"),
+        nodes: z.array(z.object({
+            type: z.enum(["PART", "CHAPTER", "SCENE"]).describe("Node type"),
+            title: z.string().describe("Node title"),
+            parentId: z.string().optional().describe("Parent node ID"),
+            synopsis: z.string().optional().describe("Brief synopsis"),
+            status: z.enum(["OUTLINE", "DRAFT", "REVISED", "FINAL"]).optional().describe("Scene status (default OUTLINE)"),
+        })).describe("Array of nodes to create"),
+    },
+    async ({ projectId, nodes }) => {
+        const result = await batchCreateNodes(projectId, nodes);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "batch_update_nodes",
+    "Update multiple structure nodes in a single operation. Returns per-item results with successes and errors. Max 50 per batch.",
+    {
+        updates: z.array(z.object({
+            nodeId: z.string().describe("The node ID to update"),
+            title: z.string().optional().describe("New title"),
+            synopsis: z.string().optional().describe("New synopsis"),
+            status: z.enum(["OUTLINE", "DRAFT", "REVISED", "FINAL"]).optional().describe("New status"),
+            orderIndex: z.number().optional().describe("New order index"),
+            parentId: z.string().nullable().optional().describe("New parent node ID (null to make top-level)"),
+        })).describe("Array of updates to apply"),
+    },
+    async ({ updates }) => {
+        const result = await batchUpdateNodes(updates);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "batch_delete_nodes",
+    "Delete multiple structure nodes and their children in a single operation. A snapshot is created before deletion. Max 50 per batch.",
+    {
+        nodeIds: z.array(z.string()).describe("Array of node IDs to delete"),
+    },
+    async ({ nodeIds }) => {
+        const guard = destructiveGuard(); if (guard) return guard;
+        const result = await batchDeleteNodes(nodeIds);
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     }
 );

--- a/src/mcp/tools/story-objects.ts
+++ b/src/mcp/tools/story-objects.ts
@@ -66,3 +66,51 @@ export async function deleteStoryObject(objectId: string) {
     mcpCache.invalidatePrefix("relationships:");
     return result;
 }
+
+export async function batchCreateStoryObjects(
+    projectId: string,
+    objects: Array<{
+        type: string;
+        name: string;
+        description?: string;
+        notes?: string;
+        role?: string;
+        tags?: string;
+    }>
+) {
+    const result = await StoryObjectController.batchCreateStoryObjects(projectId, objects);
+    mcpCache.invalidatePrefix(`storyObjects:${projectId}:`);
+    mcpCache.invalidatePrefix("projects:");
+    mcpCache.delete(`projectSummary:${projectId}`);
+    return result;
+}
+
+export async function batchUpdateStoryObjects(
+    updates: Array<{
+        objectId: string;
+        name?: string;
+        description?: string;
+        notes?: string;
+        role?: string | null;
+        tags?: string;
+    }>
+) {
+    const result = await StoryObjectController.batchUpdateStoryObjects(updates);
+    mcpCache.invalidatePrefix("storyObjects:");
+    for (const u of updates) {
+        mcpCache.delete(`storyObject:${u.objectId}`);
+    }
+    return result;
+}
+
+export async function batchDeleteStoryObjects(objectIds: string[]) {
+    const result = await StoryObjectController.batchDeleteStoryObjects(objectIds);
+    mcpCache.invalidatePrefix("storyObjects:");
+    mcpCache.invalidatePrefix("projects:");
+    mcpCache.invalidatePrefix("projectSummary:");
+    mcpCache.invalidatePrefix("relationships:");
+    for (const id of objectIds) {
+        mcpCache.delete(`storyObject:${id}`);
+    }
+    return result;
+}

--- a/src/mcp/tools/structure.ts
+++ b/src/mcp/tools/structure.ts
@@ -105,6 +105,42 @@ export async function resolveAnnotation(annotationId: string, resolved: boolean)
     return StructureController.resolveAnnotation(annotationId, resolved);
 }
 
+export async function batchCreateNodes(
+    projectId: string,
+    nodes: Array<{
+        type: string;
+        title: string;
+        parentId?: string;
+        synopsis?: string;
+        status?: string;
+    }>
+) {
+    const result = await StructureController.batchCreateNodes(projectId, nodes);
+    invalidateStructureCaches(projectId);
+    return result;
+}
+
+export async function batchUpdateNodes(
+    updates: Array<{
+        nodeId: string;
+        title?: string;
+        synopsis?: string;
+        status?: string;
+        orderIndex?: number;
+        parentId?: string | null;
+    }>
+) {
+    const result = await StructureController.batchUpdateNodes(updates);
+    invalidateStructureCaches();
+    return result;
+}
+
+export async function batchDeleteNodes(nodeIds: string[]) {
+    const result = await StructureController.batchDeleteNodes(nodeIds);
+    invalidateStructureCaches();
+    return result;
+}
+
 export async function getOpenAnnotations(projectId?: string) {
     return StructureController.getOpenAnnotations(projectId);
 }


### PR DESCRIPTION
## Summary

- Adds 6 batch MCP tools: batch_create/update/delete for both structure nodes and story objects
- Max 50 items per batch with per-item error handling (partial success supported)
- Destructive guard on batch deletes, auto-snapshot before deletion
- Proper cache invalidation via mcpCache on all batch operations

Part of #73

**Issue**: an-3bk
**Polecat**: furiosa
**Tests**: Pending CI

---
*Created by Gas Town Refinery*