### PR TITLE
feat: convert chat route agent loop to ADK agent with tools (an-wx3)

### DIFF
--- a/src/__tests__/chat-tools.test.ts
+++ b/src/__tests__/chat-tools.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Hoist mocks so they're available in vi.mock factories
-const { mockCreate, mockPrisma, mockExecuteTool, mockGetAiConfig } = vi.hoisted(() => ({
-  mockCreate: vi.fn(),
+const { mockRunChatAgent, mockPrisma, mockGetAiConfig } = vi.hoisted(() => ({
+  mockRunChatAgent: vi.fn(),
   mockPrisma: {
     project: { findUnique: vi.fn() },
     chatMessage: {
@@ -11,22 +11,15 @@ const { mockCreate, mockPrisma, mockExecuteTool, mockGetAiConfig } = vi.hoisted(
       deleteMany: vi.fn(),
     },
   },
-  mockExecuteTool: vi.fn(),
   mockGetAiConfig: vi.fn(),
 }));
 
-vi.mock("openai", () => ({
-  default: class {
-    chat = { completions: { create: mockCreate } };
-  },
+vi.mock("@/lib/ai/adk-agent", () => ({
+  runChatAgent: (...args: unknown[]) => mockRunChatAgent(...args),
 }));
 
 vi.mock("@/lib/db", () => ({
   prisma: mockPrisma,
-}));
-
-vi.mock("@/lib/ai/tool-executor", () => ({
-  executeTool: (...args: unknown[]) => mockExecuteTool(...args),
 }));
 
 vi.mock("@/lib/ai/settings", () => ({
@@ -85,68 +78,31 @@ beforeEach(() => {
 });
 
 describe("Chat route with tool use", () => {
-  it("includes tool definitions in LLM request", async () => {
-    // LLM responds with no tool calls
-    mockCreate.mockResolvedValueOnce({
-      choices: [
-        {
-          message: { content: "Hello! How can I help?", tool_calls: null },
-          finish_reason: "stop",
-        },
-      ],
-    });
+  it("calls ADK agent with correct parameters", async () => {
+    mockRunChatAgent.mockResolvedValueOnce({ finalContent: "Hello!", toolLog: [] });
 
     const req = makeRequest({ projectId: "proj-1", message: "Hi" });
     await POST(req as any);
 
-    // Verify tools were passed to the LLM
-    expect(mockCreate).toHaveBeenCalledTimes(1);
-    const callArgs = mockCreate.mock.calls[0][0];
-    expect(callArgs.tools).toBeDefined();
-    expect(Array.isArray(callArgs.tools)).toBe(true);
-    expect(callArgs.tools.length).toBeGreaterThanOrEqual(8);
-
-    // Should include core tools
-    const toolNames = callArgs.tools.map((t: any) => t.function.name);
-    expect(toolNames).toContain("list_projects");
-    expect(toolNames).toContain("get_outline");
-    expect(toolNames).toContain("load_toolset");
+    expect(mockRunChatAgent).toHaveBeenCalledTimes(1);
+    const args = mockRunChatAgent.mock.calls[0][0];
+    expect(args.systemPrompt).toContain("Test Novel");
+    expect(args.userMessage).toBe("Hi");
+    expect(args.aiConfig).toEqual({
+      baseUrl: "https://test.example.com/v1",
+      apiKey: "test-key",
+      model: "test-model",
+    });
   });
 
-  it("executes tool calls and feeds results back to LLM", async () => {
-    // First call: LLM wants to call a tool
-    mockCreate.mockResolvedValueOnce({
-      choices: [
+  it("streams tool events and content via SSE", async () => {
+    mockRunChatAgent.mockResolvedValueOnce({
+      finalContent: "Based on the outline, Chapter 1 looks great!",
+      toolLog: [
         {
-          message: {
-            content: null,
-            tool_calls: [
-              {
-                id: "call-1",
-                type: "function",
-                function: {
-                  name: "get_outline",
-                  arguments: JSON.stringify({ projectId: "proj-1" }),
-                },
-              },
-            ],
-          },
-          finish_reason: "tool_calls",
-        },
-      ],
-    });
-
-    // Mock the tool execution
-    mockExecuteTool.mockResolvedValueOnce(
-      JSON.stringify({ chapters: [{ title: "Chapter 1" }] })
-    );
-
-    // Second call: LLM responds with text
-    mockCreate.mockResolvedValueOnce({
-      choices: [
-        {
-          message: { content: "Based on the outline, Chapter 1 looks great!", tool_calls: null },
-          finish_reason: "stop",
+          tool: "get_outline",
+          args: { projectId: "proj-1" },
+          result: JSON.stringify({ chapters: [{ title: "Chapter 1" }] }),
         },
       ],
     });
@@ -155,142 +111,65 @@ describe("Chat route with tool use", () => {
     const response = await POST(req as any);
     const chunks = await readSSE(response);
 
-    // Tool was executed
-    expect(mockExecuteTool).toHaveBeenCalledWith("get_outline", { projectId: "proj-1" });
+    // Tool call event
+    const toolCall = chunks.find((c: any) => c.type === "tool_call");
+    expect(toolCall).toBeDefined();
+    expect(toolCall.name).toBe("get_outline");
 
-    // LLM was called twice (initial + after tool result)
-    expect(mockCreate).toHaveBeenCalledTimes(2);
+    // Tool result event
+    const toolResult = chunks.find((c: any) => c.type === "tool_result");
+    expect(toolResult).toBeDefined();
 
-    // Second call should include tool result
-    const secondCallMessages = mockCreate.mock.calls[1][0].messages;
-    const toolResultMsg = secondCallMessages.find((m: any) => m.role === "tool");
-    expect(toolResultMsg).toBeDefined();
-    expect(toolResultMsg.tool_call_id).toBe("call-1");
-
-    // Final response was streamed
+    // Content
     const allContent = chunks
-      .filter((c: any) => c.content)
+      .filter((c: any) => c.type === "content")
       .map((c: any) => c.content)
       .join("");
     expect(allContent).toContain("Chapter 1 looks great");
   });
 
-  it("handles load_toolset — adds new tools to available set", async () => {
-    // First call: LLM calls load_toolset
-    mockCreate.mockResolvedValueOnce({
-      choices: [
+  it("handles load_toolset via ADK agent", async () => {
+    mockRunChatAgent.mockResolvedValueOnce({
+      finalContent: "I created a new chapter for you.",
+      toolLog: [
         {
-          message: {
-            content: null,
-            tool_calls: [
-              {
-                id: "call-lt",
-                type: "function",
-                function: {
-                  name: "load_toolset",
-                  arguments: JSON.stringify({ category: "structure" }),
-                },
-              },
-            ],
-          },
-          finish_reason: "tool_calls",
+          tool: "load_toolset",
+          args: { category: "structure" },
+          result: JSON.stringify({ loaded: "structure", toolCount: 11, tools: ["create_node"] }),
         },
-      ],
-    });
-
-    // Second call: LLM uses a structure tool (create_node)
-    mockCreate.mockResolvedValueOnce({
-      choices: [
         {
-          message: {
-            content: null,
-            tool_calls: [
-              {
-                id: "call-cn",
-                type: "function",
-                function: {
-                  name: "create_node",
-                  arguments: JSON.stringify({
-                    projectId: "proj-1",
-                    type: "CHAPTER",
-                    title: "New Chapter",
-                  }),
-                },
-              },
-            ],
-          },
-          finish_reason: "tool_calls",
-        },
-      ],
-    });
-
-    mockExecuteTool.mockResolvedValueOnce(JSON.stringify({ id: "node-1", title: "New Chapter" }));
-
-    // Third call: final response
-    mockCreate.mockResolvedValueOnce({
-      choices: [
-        {
-          message: { content: "I created a new chapter for you.", tool_calls: null },
-          finish_reason: "stop",
+          tool: "create_node",
+          args: { projectId: "proj-1", type: "CHAPTER", title: "New Chapter" },
+          result: JSON.stringify({ id: "node-1", title: "New Chapter" }),
         },
       ],
     });
 
     const req = makeRequest({ projectId: "proj-1", message: "Add a new chapter" });
-    await POST(req as any);
+    const response = await POST(req as any);
+    const chunks = await readSSE(response);
 
-    // LLM was called 3 times
-    expect(mockCreate).toHaveBeenCalledTimes(3);
+    // Both tool calls were streamed
+    const toolCalls = chunks.filter((c: any) => c.type === "tool_call");
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0].name).toBe("load_toolset");
+    expect(toolCalls[1].name).toBe("create_node");
 
-    // Second call should have structure tools available
-    const secondCallTools = mockCreate.mock.calls[1][0].tools;
-    const secondToolNames = secondCallTools.map((t: any) => t.function.name);
-    expect(secondToolNames).toContain("create_node");
-    expect(secondToolNames).toContain("update_node");
-
-    // executeTool was called for create_node (not for load_toolset)
-    expect(mockExecuteTool).toHaveBeenCalledTimes(1);
-    expect(mockExecuteTool).toHaveBeenCalledWith("create_node", {
-      projectId: "proj-1",
-      type: "CHAPTER",
-      title: "New Chapter",
-    });
+    const allContent = chunks
+      .filter((c: any) => c.type === "content")
+      .map((c: any) => c.content)
+      .join("");
+    expect(allContent).toContain("created a new chapter");
   });
 
   it("handles tool execution errors gracefully", async () => {
-    // LLM calls a tool
-    mockCreate.mockResolvedValueOnce({
-      choices: [
+    mockRunChatAgent.mockResolvedValueOnce({
+      finalContent: "I couldn't find that project.",
+      toolLog: [
         {
-          message: {
-            content: null,
-            tool_calls: [
-              {
-                id: "call-err",
-                type: "function",
-                function: {
-                  name: "get_project",
-                  arguments: JSON.stringify({ projectId: "nonexistent" }),
-                },
-              },
-            ],
-          },
-          finish_reason: "tool_calls",
-        },
-      ],
-    });
-
-    // Tool returns an error
-    mockExecuteTool.mockResolvedValueOnce(
-      JSON.stringify({ error: true, tool: "get_project", message: "Project not found" })
-    );
-
-    // LLM handles the error gracefully
-    mockCreate.mockResolvedValueOnce({
-      choices: [
-        {
-          message: { content: "I couldn't find that project.", tool_calls: null },
-          finish_reason: "stop",
+          tool: "get_project",
+          args: { projectId: "nonexistent" },
+          result: JSON.stringify({ error: true, message: "Project not found" }),
         },
       ],
     });
@@ -307,35 +186,13 @@ describe("Chat route with tool use", () => {
   });
 
   it("saves tool interactions as system messages in chat history", async () => {
-    // LLM calls a tool then responds
-    mockCreate.mockResolvedValueOnce({
-      choices: [
+    mockRunChatAgent.mockResolvedValueOnce({
+      finalContent: "You have one project.",
+      toolLog: [
         {
-          message: {
-            content: null,
-            tool_calls: [
-              {
-                id: "call-save",
-                type: "function",
-                function: {
-                  name: "list_projects",
-                  arguments: JSON.stringify({}),
-                },
-              },
-            ],
-          },
-          finish_reason: "tool_calls",
-        },
-      ],
-    });
-
-    mockExecuteTool.mockResolvedValueOnce(JSON.stringify([{ id: "p1", title: "Novel" }]));
-
-    mockCreate.mockResolvedValueOnce({
-      choices: [
-        {
-          message: { content: "You have one project.", tool_calls: null },
-          finish_reason: "stop",
+          tool: "list_projects",
+          args: {},
+          result: JSON.stringify([{ id: "p1", title: "Novel" }]),
         },
       ],
     });
@@ -359,95 +216,42 @@ describe("Chat route with tool use", () => {
     expect(createCalls[2][0].data.role).toBe("assistant");
   });
 
-  it("handles multiple tool calls in a single LLM response", async () => {
-    // LLM calls two tools at once
-    mockCreate.mockResolvedValueOnce({
-      choices: [
+  it("handles multiple tool calls in agent response", async () => {
+    mockRunChatAgent.mockResolvedValueOnce({
+      finalContent: "Here's your project overview.",
+      toolLog: [
         {
-          message: {
-            content: null,
-            tool_calls: [
-              {
-                id: "call-a",
-                type: "function",
-                function: {
-                  name: "get_outline",
-                  arguments: JSON.stringify({ projectId: "proj-1" }),
-                },
-              },
-              {
-                id: "call-b",
-                type: "function",
-                function: {
-                  name: "list_story_objects",
-                  arguments: JSON.stringify({ projectId: "proj-1" }),
-                },
-              },
-            ],
-          },
-          finish_reason: "tool_calls",
+          tool: "get_outline",
+          args: { projectId: "proj-1" },
+          result: JSON.stringify({ chapters: [] }),
         },
-      ],
-    });
-
-    mockExecuteTool
-      .mockResolvedValueOnce(JSON.stringify({ chapters: [] }))
-      .mockResolvedValueOnce(JSON.stringify([{ name: "Hero" }]));
-
-    mockCreate.mockResolvedValueOnce({
-      choices: [
         {
-          message: { content: "Here's your project overview.", tool_calls: null },
-          finish_reason: "stop",
+          tool: "list_story_objects",
+          args: { projectId: "proj-1" },
+          result: JSON.stringify([{ name: "Hero" }]),
         },
       ],
     });
 
     const req = makeRequest({ projectId: "proj-1", message: "Give me an overview" });
-    await POST(req as any);
+    const response = await POST(req as any);
+    const chunks = await readSSE(response);
 
-    // Both tools were executed
-    expect(mockExecuteTool).toHaveBeenCalledTimes(2);
-
-    // Second LLM call has both tool results
-    const secondCallMessages = mockCreate.mock.calls[1][0].messages;
-    const toolResults = secondCallMessages.filter((m: any) => m.role === "tool");
-    expect(toolResults).toHaveLength(2);
-    expect(toolResults[0].tool_call_id).toBe("call-a");
-    expect(toolResults[1].tool_call_id).toBe("call-b");
+    const toolCalls = chunks.filter((c: any) => c.type === "tool_call");
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0].name).toBe("get_outline");
+    expect(toolCalls[1].name).toBe("list_story_objects");
   });
 
-  it("respects MAX_TOOL_ITERATIONS to prevent infinite loops", async () => {
-    // Make the LLM always call a tool (simulating a loop)
-    for (let i = 0; i < 12; i++) {
-      mockCreate.mockResolvedValueOnce({
-        choices: [
-          {
-            message: {
-              content: null,
-              tool_calls: [
-                {
-                  id: `call-loop-${i}`,
-                  type: "function",
-                  function: {
-                    name: "list_projects",
-                    arguments: JSON.stringify({}),
-                  },
-                },
-              ],
-            },
-            finish_reason: "tool_calls",
-          },
-        ],
-      });
-      mockExecuteTool.mockResolvedValueOnce(JSON.stringify([]));
-    }
+  it("passes chat history to ADK agent", async () => {
+    mockRunChatAgent.mockResolvedValueOnce({ finalContent: "Response", toolLog: [] });
 
-    const req = makeRequest({ projectId: "proj-1", message: "infinite loop test" });
-    const response = await POST(req as any);
+    const req = makeRequest({ projectId: "proj-1", message: "test" });
+    await POST(req as any);
 
-    // Should have stopped at MAX_TOOL_ITERATIONS (10)
-    expect(mockCreate).toHaveBeenCalledTimes(10);
-    expect(response.status).toBe(200);
+    const args = mockRunChatAgent.mock.calls[0][0];
+    expect(args.chatHistory).toEqual([
+      { role: "user", content: "Hello" },
+    ]);
   });
 });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,19 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import OpenAI from "openai";
 import { prisma } from "@/lib/db";
-import {
-  getCoreTools,
-  getToolDefinitions,
-  type ToolCategory,
-  type OpenAIToolDefinition,
-} from "@/lib/ai/tool-registry";
-import { executeTool } from "@/lib/ai/tool-executor";
 import { getAiConfig } from "@/lib/ai/settings";
 import { getCurrentUserId } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 import { sanitizeInput } from "@/lib/sanitize-server";
-
-const MAX_TOOL_ITERATIONS = 10;
+import { runChatAgent } from "@/lib/ai/adk-agent";
 
 async function buildSystemPrompt(projectId: string): Promise<string> {
   const project = await prisma.project.findUnique({
@@ -79,36 +70,6 @@ Your role:
 - You have tools available to read and modify the project. Use them when the user asks you to look up details, make changes, or explore the story structure.`;
 }
 
-/** Build the current tool list from loaded categories */
-function buildToolList(loadedCategories: Set<ToolCategory>): OpenAIToolDefinition[] {
-  const extraCategories = Array.from(loadedCategories).filter((c) => c !== "core");
-  return [...getCoreTools(), ...getToolDefinitions(extraCategories)];
-}
-
-/** Handle the load_toolset meta-tool: add the requested category's tools */
-function handleLoadToolset(
-  args: Record<string, unknown>,
-  loadedCategories: Set<ToolCategory>,
-): string {
-  const category = args.category as ToolCategory;
-  const validCategories: ToolCategory[] = [
-    "structure", "characters", "world_building", "export", "admin", "skills",
-  ];
-  if (!validCategories.includes(category)) {
-    return JSON.stringify({
-      error: true,
-      message: `Invalid category: ${category}. Valid: ${validCategories.join(", ")}`,
-    });
-  }
-  loadedCategories.add(category);
-  const newTools = getToolDefinitions([category]);
-  return JSON.stringify({
-    loaded: category,
-    toolCount: newTools.length,
-    tools: newTools.map((t) => t.function.name),
-  });
-}
-
 // GET /api/chat?projectId=X — load chat history
 export async function GET(request: NextRequest) {
   try {
@@ -169,15 +130,6 @@ export async function POST(request: NextRequest) {
     });
     recentMessages.reverse();
 
-    const chatHistory: OpenAI.ChatCompletionMessageParam[] = recentMessages.map((m) => ({
-      role: m.role as "user" | "assistant",
-      content: m.content,
-    }));
-
-    // Track loaded tool categories and tool interaction log
-    const loadedCategories = new Set<ToolCategory>(["core"]);
-    const toolLog: { tool: string; args: Record<string, unknown>; result: string }[] = [];
-
     // Load AI provider config (user DB > global DB > env vars > defaults)
     const userId = getCurrentUserId(request);
     const aiConfig = await getAiConfig(userId);
@@ -187,71 +139,14 @@ export async function POST(request: NextRequest) {
         { status: 503 }
       );
     }
-    const openai = new OpenAI({
-      baseURL: aiConfig.baseUrl || undefined,
-      apiKey: aiConfig.apiKey,
+
+    // Run ADK agent (handles tool loop, dynamic tool loading internally)
+    const { finalContent, toolLog } = await runChatAgent({
+      systemPrompt: systemPrompt + sceneNote,
+      chatHistory: recentMessages.map((m) => ({ role: m.role, content: m.content })),
+      userMessage: sanitizedMessage,
+      aiConfig,
     });
-
-    // Build messages array for the LLM
-    const llmMessages: OpenAI.ChatCompletionMessageParam[] = [
-      { role: "system", content: systemPrompt + sceneNote },
-      ...chatHistory,
-    ];
-
-    // Tool use loop: call LLM non-streaming, execute tools, repeat
-    let finalContent = "";
-    for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
-      const tools = buildToolList(loadedCategories);
-
-      const response = await openai.chat.completions.create({
-        model: aiConfig.model,
-        messages: llmMessages,
-        tools,
-      });
-
-      const choice = response.choices[0];
-      if (!choice) break;
-
-      const assistantMessage = choice.message;
-
-      // If no tool calls, we have the final response
-      if (!assistantMessage.tool_calls || assistantMessage.tool_calls.length === 0) {
-        finalContent = assistantMessage.content || "";
-        break;
-      }
-
-      // Add assistant message with tool calls to conversation
-      llmMessages.push(assistantMessage);
-
-      // Execute each tool call
-      for (const toolCall of assistantMessage.tool_calls) {
-        if (toolCall.type !== "function") continue;
-        const fnName = toolCall.function.name;
-        const fnArgs = JSON.parse(toolCall.function.arguments);
-
-        let result: string;
-        if (fnName === "load_toolset") {
-          result = handleLoadToolset(fnArgs, loadedCategories);
-        } else {
-          result = await executeTool(fnName, fnArgs);
-        }
-
-        toolLog.push({ tool: fnName, args: fnArgs, result });
-
-        // Add tool result to messages
-        llmMessages.push({
-          role: "tool",
-          tool_call_id: toolCall.id,
-          content: result,
-        });
-      }
-
-      // If finish_reason is "stop" despite having tool_calls, break
-      if (choice.finish_reason === "stop") {
-        finalContent = assistantMessage.content || "";
-        break;
-      }
-    }
 
     // Save tool interactions as a system message if any tools were used
     if (toolLog.length > 0) {

--- a/src/lib/ai/adk-agent.ts
+++ b/src/lib/ai/adk-agent.ts
@@ -1,0 +1,140 @@
+/**
+ * ADK agent runner — replaces the manual tool loop with ADK's native agent execution.
+ *
+ * Creates an LlmAgent with DynamicToolset (for load_toolset pattern) and
+ * OpenAICompatibleLlm (for provider flexibility). Returns the final content
+ * and tool log in the same format as the previous manual loop.
+ */
+import {
+  LlmAgent,
+  InMemoryRunner,
+  createEvent,
+  createEventActions,
+  getFunctionCalls,
+  getFunctionResponses,
+  stringifyContent,
+} from "@google/adk";
+import type { Content } from "@google/genai";
+import { DynamicToolset } from "./adk-tools";
+import type { ToolCategory } from "./tool-registry";
+import { OpenAICompatibleLlm } from "./adk-openai-llm";
+
+const AGENT_NAME = "writing_assistant";
+
+export interface ChatAgentResult {
+  finalContent: string;
+  toolLog: { tool: string; args: Record<string, unknown>; result: string }[];
+}
+
+/**
+ * Run the writing assistant agent using ADK's native agent loop.
+ * Manages the tool loop internally, including dynamic tool loading.
+ */
+export async function runChatAgent(params: {
+  systemPrompt: string;
+  chatHistory: { role: string; content: string }[];
+  userMessage: string;
+  aiConfig: { baseUrl: string; apiKey: string; model: string };
+}): Promise<ChatAgentResult> {
+  const llm = new OpenAICompatibleLlm({
+    model: params.aiConfig.model,
+    apiKey: params.aiConfig.apiKey,
+    baseUrl: params.aiConfig.baseUrl,
+  });
+
+  const toolset = new DynamicToolset();
+
+  const agent = new LlmAgent({
+    name: AGENT_NAME,
+    model: llm,
+    instruction: params.systemPrompt,
+    tools: [toolset],
+    afterToolCallback: async ({ tool, args }) => {
+      // When load_toolset is called, expand the DynamicToolset so subsequent
+      // LLM turns see the newly loaded category's tools.
+      if (tool.name === "load_toolset") {
+        const { category } = args as { category: string };
+        toolset.loadCategory(category as ToolCategory);
+      }
+      return undefined;
+    },
+  });
+
+  const runner = new InMemoryRunner({ agent, appName: "word-coach-annie" });
+
+  // Create session and populate with chat history
+  const session = await runner.sessionService.createSession({
+    appName: "word-coach-annie",
+    userId: "default",
+  });
+
+  for (const msg of params.chatHistory) {
+    if (msg.role === "system") continue; // Skip tool log system messages
+    await runner.sessionService.appendEvent({
+      session,
+      event: createEvent({
+        author: msg.role === "assistant" ? AGENT_NAME : "user",
+        content: {
+          role: msg.role === "assistant" ? "model" : "user",
+          parts: [{ text: msg.content }],
+        },
+        actions: createEventActions(),
+        invocationId: "history",
+      }),
+    });
+  }
+
+  // Run the agent with the new user message
+  const newMessage: Content = {
+    role: "user",
+    parts: [{ text: params.userMessage }],
+  };
+
+  const toolLog: ChatAgentResult["toolLog"] = [];
+  let finalContent = "";
+  const pendingCalls = new Map<
+    string,
+    { name: string; args: Record<string, unknown> }
+  >();
+
+  for await (const event of runner.runAsync({
+    userId: "default",
+    sessionId: session.id,
+    newMessage,
+  })) {
+    // Collect tool calls
+    for (const call of getFunctionCalls(event)) {
+      if (call.id && call.name) {
+        pendingCalls.set(call.id, {
+          name: call.name,
+          args: (call.args ?? {}) as Record<string, unknown>,
+        });
+      }
+    }
+
+    // Match tool results to their calls
+    for (const resp of getFunctionResponses(event)) {
+      const callInfo = pendingCalls.get(resp.id ?? "");
+      if (callInfo) {
+        toolLog.push({
+          tool: callInfo.name,
+          args: callInfo.args,
+          result: JSON.stringify(resp.response ?? {}),
+        });
+        pendingCalls.delete(resp.id ?? "");
+      }
+    }
+
+    // Capture final text content from the agent (not tool call/result events)
+    if (
+      event.author === AGENT_NAME &&
+      getFunctionCalls(event).length === 0 &&
+      getFunctionResponses(event).length === 0
+    ) {
+      const text = stringifyContent(event);
+      if (text) finalContent = text;
+    }
+  }
+
+  return { finalContent, toolLog };
+}


### PR DESCRIPTION
## Summary

- Replaces manual OpenAI tool loop in `/api/chat/route.ts` with ADK `LlmAgent` + `InMemoryRunner`
- New `adk-agent.ts` module: creates agent with `DynamicToolset` and `OpenAICompatibleLlm`
- `afterToolCallback` handles dynamic category loading when `load_toolset` is called
- Returns same `{ finalContent, toolLog }` format for backwards compatibility
- Net -161 lines (400 removed, 239 added)

**Issue**: an-wx3
**Polecat**: furiosa
**Tests**: Pending CI

---
*Created by Gas Town Refinery*