### PR TITLE
feat: wire trace context through ADK agent and tool calls (an-053)

### DIFF
--- a/src/lib/ai/adk-agent.ts
+++ b/src/lib/ai/adk-agent.ts
@@ -18,6 +18,8 @@ import type { Content } from "@google/genai";
 import { DynamicToolset } from "./adk-tools";
 import type { ToolCategory } from "./adk-tools";
 import { OpenAICompatibleLlm } from "./adk-openai-llm";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { getTracer } from "@/lib/telemetry";
 
 const AGENT_NAME = "writing_assistant";
 
@@ -36,105 +38,138 @@ export async function runChatAgent(params: {
   userMessage: string;
   aiConfig: { baseUrl: string; apiKey: string; model: string };
 }): Promise<ChatAgentResult> {
-  const llm = new OpenAICompatibleLlm({
-    model: params.aiConfig.model,
-    apiKey: params.aiConfig.apiKey,
-    baseUrl: params.aiConfig.baseUrl,
-  });
+  const tracer = getTracer();
 
-  const toolset = new DynamicToolset();
+  return tracer.startActiveSpan("agent.run", async (span) => {
+    try {
+      span.setAttribute("agent.name", AGENT_NAME);
+      span.setAttribute("agent.model", params.aiConfig.model);
+      span.setAttribute("agent.history_length", params.chatHistory.length);
+      span.setAttribute(
+        "agent.user_message_length",
+        params.userMessage.length,
+      );
 
-  const agent = new LlmAgent({
-    name: AGENT_NAME,
-    model: llm,
-    instruction: params.systemPrompt,
-    tools: [toolset],
-    afterToolCallback: async ({ tool, args }) => {
-      // When load_toolset is called, expand the DynamicToolset so subsequent
-      // LLM turns see the newly loaded category's tools.
-      if (tool.name === "load_toolset") {
-        const { category } = args as { category: string };
-        toolset.loadCategory(category as ToolCategory);
-      }
-      return undefined;
-    },
-  });
+      const llm = new OpenAICompatibleLlm({
+        model: params.aiConfig.model,
+        apiKey: params.aiConfig.apiKey,
+        baseUrl: params.aiConfig.baseUrl,
+      });
 
-  const runner = new InMemoryRunner({ agent, appName: "word-coach-annie" });
+      const toolset = new DynamicToolset();
 
-  // Create session and populate with chat history
-  const session = await runner.sessionService.createSession({
-    appName: "word-coach-annie",
-    userId: "default",
-  });
-
-  for (const msg of params.chatHistory) {
-    if (msg.role === "system") continue; // Skip tool log system messages
-    await runner.sessionService.appendEvent({
-      session,
-      event: createEvent({
-        author: msg.role === "assistant" ? AGENT_NAME : "user",
-        content: {
-          role: msg.role === "assistant" ? "model" : "user",
-          parts: [{ text: msg.content }],
+      const agent = new LlmAgent({
+        name: AGENT_NAME,
+        model: llm,
+        instruction: params.systemPrompt,
+        tools: [toolset],
+        afterToolCallback: async ({ tool, args }) => {
+          // When load_toolset is called, expand the DynamicToolset so subsequent
+          // LLM turns see the newly loaded category's tools.
+          if (tool.name === "load_toolset") {
+            const { category } = args as { category: string };
+            toolset.loadCategory(category as ToolCategory);
+          }
+          return undefined;
         },
-        actions: createEventActions(),
-        invocationId: "history",
-      }),
-    });
-  }
+      });
 
-  // Run the agent with the new user message
-  const newMessage: Content = {
-    role: "user",
-    parts: [{ text: params.userMessage }],
-  };
+      const runner = new InMemoryRunner({
+        agent,
+        appName: "word-coach-annie",
+      });
 
-  const toolLog: ChatAgentResult["toolLog"] = [];
-  let finalContent = "";
-  const pendingCalls = new Map<
-    string,
-    { name: string; args: Record<string, unknown> }
-  >();
+      // Create session and populate with chat history
+      const session = await runner.sessionService.createSession({
+        appName: "word-coach-annie",
+        userId: "default",
+      });
 
-  for await (const event of runner.runAsync({
-    userId: "default",
-    sessionId: session.id,
-    newMessage,
-  })) {
-    // Collect tool calls
-    for (const call of getFunctionCalls(event)) {
-      if (call.id && call.name) {
-        pendingCalls.set(call.id, {
-          name: call.name,
-          args: (call.args ?? {}) as Record<string, unknown>,
+      for (const msg of params.chatHistory) {
+        if (msg.role === "system") continue; // Skip tool log system messages
+        await runner.sessionService.appendEvent({
+          session,
+          event: createEvent({
+            author: msg.role === "assistant" ? AGENT_NAME : "user",
+            content: {
+              role: msg.role === "assistant" ? "model" : "user",
+              parts: [{ text: msg.content }],
+            },
+            actions: createEventActions(),
+            invocationId: "history",
+          }),
         });
       }
-    }
 
-    // Match tool results to their calls
-    for (const resp of getFunctionResponses(event)) {
-      const callInfo = pendingCalls.get(resp.id ?? "");
-      if (callInfo) {
-        toolLog.push({
-          tool: callInfo.name,
-          args: callInfo.args,
-          result: JSON.stringify(resp.response ?? {}),
-        });
-        pendingCalls.delete(resp.id ?? "");
+      // Run the agent with the new user message
+      const newMessage: Content = {
+        role: "user",
+        parts: [{ text: params.userMessage }],
+      };
+
+      const toolLog: ChatAgentResult["toolLog"] = [];
+      let finalContent = "";
+      const pendingCalls = new Map<
+        string,
+        { name: string; args: Record<string, unknown> }
+      >();
+
+      for await (const event of runner.runAsync({
+        userId: "default",
+        sessionId: session.id,
+        newMessage,
+      })) {
+        // Collect tool calls
+        for (const call of getFunctionCalls(event)) {
+          if (call.id && call.name) {
+            pendingCalls.set(call.id, {
+              name: call.name,
+              args: (call.args ?? {}) as Record<string, unknown>,
+            });
+          }
+        }
+
+        // Match tool results to their calls
+        for (const resp of getFunctionResponses(event)) {
+          const callInfo = pendingCalls.get(resp.id ?? "");
+          if (callInfo) {
+            toolLog.push({
+              tool: callInfo.name,
+              args: callInfo.args,
+              result: JSON.stringify(resp.response ?? {}),
+            });
+            pendingCalls.delete(resp.id ?? "");
+          }
+        }
+
+        // Capture final text content from the agent (not tool call/result events)
+        if (
+          event.author === AGENT_NAME &&
+          getFunctionCalls(event).length === 0 &&
+          getFunctionResponses(event).length === 0
+        ) {
+          const text = stringifyContent(event);
+          if (text) finalContent = text;
+        }
       }
-    }
 
-    // Capture final text content from the agent (not tool call/result events)
-    if (
-      event.author === AGENT_NAME &&
-      getFunctionCalls(event).length === 0 &&
-      getFunctionResponses(event).length === 0
-    ) {
-      const text = stringifyContent(event);
-      if (text) finalContent = text;
-    }
-  }
+      // Record summary attributes
+      span.setAttribute("agent.tool_calls_total", toolLog.length);
+      span.setAttribute(
+        "agent.response_length",
+        finalContent.length,
+      );
+      span.setStatus({ code: SpanStatusCode.OK });
 
-  return { finalContent, toolLog };
+      return { finalContent, toolLog };
+    } catch (err) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/src/lib/ai/adk-openai-llm.ts
+++ b/src/lib/ai/adk-openai-llm.ts
@@ -19,6 +19,8 @@ import type {
   Tool,
 } from "@google/genai";
 import OpenAI from "openai";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { getTracer } from "@/lib/telemetry";
 
 // ─── OpenAI ↔ ADK type translations ─────────────────────────────────────────
 
@@ -214,40 +216,90 @@ export class OpenAICompatibleLlm extends BaseLlm {
     llmRequest: LlmRequest,
     _stream?: boolean,
   ): AsyncGenerator<LlmResponse, void> {
-    // Build OpenAI messages from ADK request
-    const messages: OpenAI.ChatCompletionMessageParam[] = [];
+    const tracer = getTracer();
+    const modelName = llmRequest.model ?? this.model;
+    const toolDefs = llmRequest.config?.tools as Tool[] | undefined;
+    const toolCount = toolDefs
+      ? toolDefs.reduce((n, t) => n + (t.functionDeclarations?.length ?? 0), 0)
+      : 0;
 
-    // System instruction
-    const systemInstruction = llmRequest.config?.systemInstruction;
-    const systemMsg = systemInstructionToOpenAI(
-      systemInstruction as Content | string | undefined,
-    );
-    if (systemMsg) {
-      messages.push(systemMsg);
+    const span = tracer.startSpan("llm.generate");
+    try {
+      span.setAttribute("llm.model", modelName);
+      span.setAttribute("llm.tool_count", toolCount);
+      span.setAttribute("llm.message_count", llmRequest.contents.length);
+
+      // Build OpenAI messages from ADK request
+      const messages: OpenAI.ChatCompletionMessageParam[] = [];
+
+      // System instruction
+      const systemInstruction = llmRequest.config?.systemInstruction;
+      const systemMsg = systemInstructionToOpenAI(
+        systemInstruction as Content | string | undefined,
+      );
+      if (systemMsg) {
+        messages.push(systemMsg);
+      }
+
+      // Conversation contents
+      messages.push(...contentsToOpenAI(llmRequest.contents));
+
+      // Tools
+      const tools = toolsToOpenAI(toolDefs);
+
+      // Make the API call (non-streaming for now — streaming can be added later)
+      const response = await this.client.chat.completions.create({
+        model: modelName,
+        messages,
+        tools,
+        temperature: llmRequest.config?.temperature ?? undefined,
+        top_p: llmRequest.config?.topP ?? undefined,
+        max_tokens:
+          (llmRequest.config as Record<string, unknown>)?.maxOutputTokens as
+            | number
+            | undefined,
+      });
+
+      // Record response metadata
+      if (response.usage) {
+        span.setAttribute(
+          "llm.usage.prompt_tokens",
+          response.usage.prompt_tokens,
+        );
+        span.setAttribute(
+          "llm.usage.completion_tokens",
+          response.usage.completion_tokens,
+        );
+        span.setAttribute(
+          "llm.usage.total_tokens",
+          response.usage.total_tokens,
+        );
+      }
+
+      const choice = response.choices[0];
+      if (choice) {
+        span.setAttribute(
+          "llm.finish_reason",
+          choice.finish_reason ?? "unknown",
+        );
+        span.setAttribute(
+          "llm.tool_calls_count",
+          choice.message.tool_calls?.length ?? 0,
+        );
+      }
+
+      span.setStatus({ code: SpanStatusCode.OK });
+
+      yield openAIResponseToLlmResponse(response);
+    } catch (err) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    } finally {
+      span.end();
     }
-
-    // Conversation contents
-    messages.push(...contentsToOpenAI(llmRequest.contents));
-
-    // Tools
-    const tools = toolsToOpenAI(
-      llmRequest.config?.tools as Tool[] | undefined,
-    );
-
-    // Make the API call (non-streaming for now — streaming can be added later)
-    const response = await this.client.chat.completions.create({
-      model: llmRequest.model ?? this.model,
-      messages,
-      tools,
-      temperature: llmRequest.config?.temperature ?? undefined,
-      top_p: llmRequest.config?.topP ?? undefined,
-      max_tokens:
-        (llmRequest.config as Record<string, unknown>)?.maxOutputTokens as
-          | number
-          | undefined,
-    });
-
-    yield openAIResponseToLlmResponse(response);
   }
 
   async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {

--- a/src/lib/ai/adk-tools.ts
+++ b/src/lib/ai/adk-tools.ts
@@ -10,6 +10,8 @@ import { FunctionTool, BaseToolset } from "@google/adk";
 import type { BaseTool, ToolPredicate, ToolInputParameters } from "@google/adk";
 import type { ReadonlyContext } from "@google/adk";
 import { z, ZodObject, ZodRawShape } from "zod";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { getTracer } from "@/lib/telemetry";
 
 // ADK bundles its own zod v3 copy. The project's zod is structurally identical
 // but TypeScript treats them as separate types due to private fields. We cast
@@ -775,7 +777,31 @@ function toAdkTool(def: ToolDefinition): FunctionTool {
     // Cast: project zod v3 ↔ ADK's bundled zod v3 are structurally identical
     parameters: def.parameters as unknown as AdkParams,
     execute: async (input) => {
-      return executor(input as Record<string, unknown>);
+      const tracer = getTracer();
+      return tracer.startActiveSpan(`tool.${def.name}`, async (span) => {
+        try {
+          span.setAttribute("tool.name", def.name);
+          span.setAttribute("tool.category", def.category);
+          const inputStr = JSON.stringify(input);
+          // Cap at 4KB to avoid bloating traces
+          span.setAttribute("tool.input", inputStr.slice(0, 4096));
+
+          const result = await executor(input as Record<string, unknown>);
+
+          const resultStr = JSON.stringify(result);
+          span.setAttribute("tool.output", resultStr.slice(0, 4096));
+          span.setStatus({ code: SpanStatusCode.OK });
+          return result;
+        } catch (err) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: err instanceof Error ? err.message : String(err),
+          });
+          throw err;
+        } finally {
+          span.end();
+        }
+      });
     },
   });
 }

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -13,6 +13,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
+import { trace, type Tracer } from "@opentelemetry/api";
 
 let sdk: NodeSDK | null = null;
 
@@ -34,6 +35,11 @@ export function initTelemetry() {
   });
 
   sdk.start();
+}
+
+/** Get a tracer for the given instrumentation scope. */
+export function getTracer(name = "word-coach-annie"): Tracer {
+  return trace.getTracer(name);
 }
 
 export async function shutdownTelemetry() {


### PR DESCRIPTION
## Summary

- Adds OpenTelemetry span instrumentation to ADK agent runner, LLM provider, and tool execution
- Traces LLM calls, tool invocations, and agent lifecycle through Phoenix/OTel
- Captures token usage, tool names, and error states as span attributes

**Issue**: an-053
**Polecat**: furiosa
**Tests**: Pending CI

---
*Created by Gas Town Refinery*