### PR TITLE
feat: add custom OTEL spans for MCP tool operations (an-go6)

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -4,10 +4,19 @@
  * Designed to avoid repeated DB queries during a single agent session.
  * The cache lives in the Node.js process — it resets when the MCP server restarts.
  */
+import { trace } from "@opentelemetry/api";
 
 interface CacheEntry<T> {
     value: T;
     expiresAt: number;
+}
+
+/** Add a cache event to the current active span (if any). */
+function addCacheEvent(eventName: string, attrs: Record<string, string | number>) {
+    const span = trace.getActiveSpan();
+    if (span) {
+        span.addEvent(eventName, attrs);
+    }
 }
 
 export class TTLCache {
@@ -23,11 +32,16 @@ export class TTLCache {
 
     get<T>(key: string): T | undefined {
         const entry = this.store.get(key);
-        if (!entry) return undefined;
-        if (Date.now() > entry.expiresAt) {
-            this.store.delete(key);
+        if (!entry) {
+            addCacheEvent("cache.miss", { "cache.key": key });
             return undefined;
         }
+        if (Date.now() > entry.expiresAt) {
+            this.store.delete(key);
+            addCacheEvent("cache.miss", { "cache.key": key, "cache.reason": "expired" });
+            return undefined;
+        }
+        addCacheEvent("cache.hit", { "cache.key": key });
         return entry.value as T;
     }
 
@@ -57,16 +71,25 @@ export class TTLCache {
 
     /** Invalidate all keys matching a prefix. */
     invalidatePrefix(prefix: string): void {
+        let count = 0;
         for (const key of this.store.keys()) {
             if (key.startsWith(prefix)) {
                 this.store.delete(key);
+                count++;
             }
+        }
+        if (count > 0) {
+            addCacheEvent("cache.invalidate", { "cache.prefix": prefix, "cache.invalidated_count": count });
         }
     }
 
     /** Invalidate everything. */
     clear(): void {
+        const count = this.store.size;
         this.store.clear();
+        if (count > 0) {
+            addCacheEvent("cache.clear", { "cache.invalidated_count": count });
+        }
     }
 
     /** Number of entries (including expired ones not yet evicted). */

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,8 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { SpanStatusCode } from "@opentelemetry/api";
 import { initSnapshotRepo } from "./snapshot";
 import { listSkills, loadSkill } from "./skills";
 import { env } from "@/lib/env";
+import { getTracer } from "@/lib/telemetry";
 
 // Tool implementations
 import { listProjects, getProject, createProject, updateProject } from "./tools/projects";
@@ -92,6 +94,39 @@ const server = new McpServer({
     name: "word-coach-annie",
     version: "1.0.0",
 });
+
+// Instrument all MCP tool handlers with OTEL spans.
+// Wraps the original server.tool() so every handler runs inside an `mcp.tool.<name>` span.
+const _originalTool = server.tool.bind(server);
+server.tool = ((...args: unknown[]) => {
+    // server.tool() has multiple overloads; the handler is always the last arg
+    // and the tool name is always the first.
+    const toolName = args[0] as string;
+    const handlerIdx = args.length - 1;
+    const originalHandler = args[handlerIdx] as (...a: unknown[]) => Promise<unknown>;
+
+    args[handlerIdx] = async (...handlerArgs: unknown[]) => {
+        const tracer = getTracer();
+        return tracer.startActiveSpan(`mcp.tool.${toolName}`, async (span) => {
+            try {
+                span.setAttribute("mcp.tool.name", toolName);
+                const result = await originalHandler(...handlerArgs);
+                span.setStatus({ code: SpanStatusCode.OK });
+                return result;
+            } catch (err) {
+                span.setStatus({
+                    code: SpanStatusCode.ERROR,
+                    message: err instanceof Error ? err.message : String(err),
+                });
+                throw err;
+            } finally {
+                span.end();
+            }
+        });
+    };
+
+    return (_originalTool as (...a: unknown[]) => unknown)(...args);
+}) as typeof server.tool;
 
 /** Guard for destructive tools — returns error if not allowed. */
 function destructiveGuard(): { content: [{ type: "text"; text: string }]; isError: true } | null {

--- a/src/mcp/tools/story-objects.ts
+++ b/src/mcp/tools/story-objects.ts
@@ -1,4 +1,5 @@
 import { StoryObjectController } from "@/lib/controllers/story-objects";
+import { trace } from "@opentelemetry/api";
 import { mcpCache } from "@/lib/cache";
 
 function storyObjectsKey(params: { projectId: string; type?: string; search?: string; limit?: number; offset?: number }): string {
@@ -78,7 +79,12 @@ export async function batchCreateStoryObjects(
         tags?: string;
     }>
 ) {
+    const span = trace.getActiveSpan();
+    span?.setAttribute("batch.size", objects.length);
+    span?.setAttribute("batch.operation", "create_story_objects");
     const result = await StoryObjectController.batchCreateStoryObjects(projectId, objects);
+    span?.setAttribute("batch.total_created", result.totalCreated ?? 0);
+    span?.setAttribute("batch.total_errors", result.totalErrors ?? 0);
     mcpCache.invalidatePrefix(`storyObjects:${projectId}:`);
     mcpCache.invalidatePrefix("projects:");
     mcpCache.delete(`projectSummary:${projectId}`);
@@ -95,7 +101,12 @@ export async function batchUpdateStoryObjects(
         tags?: string;
     }>
 ) {
+    const span = trace.getActiveSpan();
+    span?.setAttribute("batch.size", updates.length);
+    span?.setAttribute("batch.operation", "update_story_objects");
     const result = await StoryObjectController.batchUpdateStoryObjects(updates);
+    span?.setAttribute("batch.total_updated", result.totalUpdated ?? 0);
+    span?.setAttribute("batch.total_errors", result.totalErrors ?? 0);
     mcpCache.invalidatePrefix("storyObjects:");
     for (const u of updates) {
         mcpCache.delete(`storyObject:${u.objectId}`);
@@ -104,7 +115,12 @@ export async function batchUpdateStoryObjects(
 }
 
 export async function batchDeleteStoryObjects(objectIds: string[]) {
+    const span = trace.getActiveSpan();
+    span?.setAttribute("batch.size", objectIds.length);
+    span?.setAttribute("batch.operation", "delete_story_objects");
     const result = await StoryObjectController.batchDeleteStoryObjects(objectIds);
+    span?.setAttribute("batch.total_deleted", result.totalDeleted ?? 0);
+    span?.setAttribute("batch.total_errors", result.totalErrors ?? 0);
     mcpCache.invalidatePrefix("storyObjects:");
     mcpCache.invalidatePrefix("projects:");
     mcpCache.invalidatePrefix("projectSummary:");

--- a/src/mcp/tools/structure.ts
+++ b/src/mcp/tools/structure.ts
@@ -1,4 +1,5 @@
 import { StructureController } from "@/lib/controllers/structure";
+import { trace } from "@opentelemetry/api";
 import { mcpCache } from "@/lib/cache";
 
 /** Invalidate caches affected by structure/content changes. */
@@ -115,7 +116,12 @@ export async function batchCreateNodes(
         status?: string;
     }>
 ) {
+    const span = trace.getActiveSpan();
+    span?.setAttribute("batch.size", nodes.length);
+    span?.setAttribute("batch.operation", "create_nodes");
     const result = await StructureController.batchCreateNodes(projectId, nodes);
+    span?.setAttribute("batch.total_created", result.totalCreated ?? 0);
+    span?.setAttribute("batch.total_errors", result.totalErrors ?? 0);
     invalidateStructureCaches(projectId);
     return result;
 }
@@ -130,13 +136,23 @@ export async function batchUpdateNodes(
         parentId?: string | null;
     }>
 ) {
+    const span = trace.getActiveSpan();
+    span?.setAttribute("batch.size", updates.length);
+    span?.setAttribute("batch.operation", "update_nodes");
     const result = await StructureController.batchUpdateNodes(updates);
+    span?.setAttribute("batch.total_updated", result.totalUpdated ?? 0);
+    span?.setAttribute("batch.total_errors", result.totalErrors ?? 0);
     invalidateStructureCaches();
     return result;
 }
 
 export async function batchDeleteNodes(nodeIds: string[]) {
+    const span = trace.getActiveSpan();
+    span?.setAttribute("batch.size", nodeIds.length);
+    span?.setAttribute("batch.operation", "delete_nodes");
     const result = await StructureController.batchDeleteNodes(nodeIds);
+    span?.setAttribute("batch.total_deleted", result.totalDeleted ?? 0);
+    span?.setAttribute("batch.total_errors", result.totalErrors ?? 0);
     invalidateStructureCaches();
     return result;
 }


### PR DESCRIPTION
## Summary

- Adds OpenTelemetry span instrumentation to MCP tool handlers and cache operations
- Traces individual tool calls, cache hits/misses, and invalidation in Phoenix

**Issue**: an-go6
**Polecat**: furiosa
**Tests**: Pending CI

---
*Created by Gas Town Refinery*