### PR TITLE
fix: update deploy path to ext4 NVMe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           key: ${{ secrets.SSH_DEPLOY_KEY }}
           envs: GHCR_TOKEN,GHCR_USER
           script: |
-            cd /home/asiri/gt/annie/mayor/rig
+            cd /mnt/ext-fast/gc/rigs/annie
 
             # Pull latest compose file
             git pull --rebase


### PR DESCRIPTION
## Summary
- CI deploy step was using `/home/asiri/gt/annie/mayor/rig` which no longer exists
- City moved to `/mnt/ext-fast/gc` on ext4 NVMe partition

## Test plan
- [ ] CI passes
- [ ] Next merge to master triggers successful deploy