### PR TITLE
feat: add reader preview button + label Share button

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -19,6 +19,7 @@ import {
   MessageSquare,
   BookOpen,
   TrendingUp,
+  Eye,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -395,6 +396,16 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
           aria-label="Story graph"
         >
           <Network className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => router.push(`/read/${projectId}`)}
+          aria-label="Preview as reader"
+          title="Preview as reader"
+        >
+          <Eye className="h-4 w-4" />
         </Button>
         <ShareButton projectId={projectId} projectTitle={project.title} />
         <Button

--- a/src/components/share-dialog.tsx
+++ b/src/components/share-dialog.tsx
@@ -258,12 +258,13 @@ export function ShareButton({
     <>
       <Button
         variant="ghost"
-        size="icon"
-        className="h-8 w-8"
+        size="sm"
+        className="h-8 gap-1.5"
         onClick={() => setOpen(true)}
         aria-label="Share project"
       >
         <Share2 className="h-4 w-4" />
+        <span className="hidden sm:inline text-xs">Share</span>
       </Button>
       <ShareDialog
         projectId={projectId}


### PR DESCRIPTION
## Summary
- Eye icon button in project toolbar opens `/read/[id]` so authors can preview what readers see
- Share button now shows "Share" text label on desktop (icon-only on mobile) for discoverability

Part of #140

## Test plan
- [ ] Eye icon visible in project toolbar
- [ ] Clicking eye opens reader view
- [ ] Share button shows label on desktop
- [ ] Share button is icon-only on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)