### PR TITLE
feat: OAuth 2.0 authorization server for MCP remote access

### DIFF
--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * GET /.well-known/oauth-authorization-server
+ *
+ * OAuth 2.0 Authorization Server Metadata (RFC 8414).
+ * Used by MCP clients (e.g. Claude Code) to discover endpoints.
+ */
+export function GET(request: NextRequest) {
+  const origin = new URL(request.url).origin;
+
+  return NextResponse.json({
+    issuer: origin,
+    authorization_endpoint: `${origin}/oauth/authorize`,
+    token_endpoint: `${origin}/oauth/token`,
+    registration_endpoint: `${origin}/oauth/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none"],
+  });
+}

--- a/src/app/oauth/authorize/route.ts
+++ b/src/app/oauth/authorize/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SESSION_COOKIE_NAME, verifySessionToken } from "@/lib/auth";
+import { clients, createAuthCode } from "@/lib/oauth-store";
+
+/**
+ * GET /oauth/authorize
+ *
+ * OAuth 2.0 Authorization Endpoint (RFC 6749 Section 3.1).
+ * Validates params, checks user session, and issues an authorization code.
+ *
+ * If the user is not logged in, redirects to /login with a return URL.
+ * If logged in, auto-approves and redirects back to the client with a code.
+ */
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+
+  const responseType = params.get("response_type");
+  const clientId = params.get("client_id");
+  const redirectUri = params.get("redirect_uri");
+  const state = params.get("state");
+  const codeChallenge = params.get("code_challenge");
+  const codeChallengeMethod = params.get("code_challenge_method");
+
+  // Validate required params
+  if (responseType !== "code") {
+    return NextResponse.json(
+      { error: "unsupported_response_type", error_description: "Only response_type=code is supported" },
+      { status: 400 }
+    );
+  }
+
+  if (!clientId) {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "client_id is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!redirectUri) {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "redirect_uri is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!codeChallenge || codeChallengeMethod !== "S256") {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "PKCE with S256 code_challenge is required" },
+      { status: 400 }
+    );
+  }
+
+  // Validate client_id
+  const client = clients.get(clientId);
+  if (!client) {
+    return NextResponse.json(
+      { error: "invalid_client", error_description: "Unknown client_id" },
+      { status: 400 }
+    );
+  }
+
+  // Validate redirect_uri matches registration
+  if (!client.redirect_uris.includes(redirectUri)) {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "redirect_uri does not match registered URIs" },
+      { status: 400 }
+    );
+  }
+
+  // Check user session
+  const sessionCookie = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+  if (!sessionCookie) {
+    return redirectToLogin(request);
+  }
+
+  const session = await verifySessionToken(sessionCookie);
+  if (!session) {
+    return redirectToLogin(request);
+  }
+
+  // User is authenticated — issue authorization code
+  const authCode = createAuthCode({
+    userId: session.userId,
+    email: session.email,
+    codeChallenge,
+    codeChallengeMethod,
+    redirectUri,
+    clientId,
+  });
+
+  // Redirect back to the client with code and state
+  const redirectUrl = new URL(redirectUri);
+  redirectUrl.searchParams.set("code", authCode.code);
+  if (state) {
+    redirectUrl.searchParams.set("state", state);
+  }
+
+  return NextResponse.redirect(redirectUrl.toString());
+}
+
+/** Redirect to login page, preserving the full authorize URL as return path. */
+function redirectToLogin(request: NextRequest): NextResponse {
+  const loginUrl = new URL("/login", request.url);
+  // Preserve the full authorize URL so the user returns here after login
+  const fullPath = request.nextUrl.pathname + request.nextUrl.search;
+  loginUrl.searchParams.set("from", fullPath);
+  return NextResponse.redirect(loginUrl.toString());
+}

--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { clients, type ClientRegistration } from "@/lib/oauth-store";
+
+/**
+ * POST /oauth/register
+ *
+ * OAuth 2.0 Dynamic Client Registration (RFC 7591).
+ * MCP clients call this to register before starting the auth flow.
+ */
+export async function POST(request: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const redirectUris = body.redirect_uris;
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
+    return NextResponse.json(
+      {
+        error: "invalid_client_metadata",
+        error_description: "redirect_uris is required and must be a non-empty array",
+      },
+      { status: 400 }
+    );
+  }
+
+  // Validate each redirect URI is a valid URL
+  for (const uri of redirectUris) {
+    if (typeof uri !== "string") {
+      return NextResponse.json(
+        {
+          error: "invalid_client_metadata",
+          error_description: "Each redirect_uri must be a string",
+        },
+        { status: 400 }
+      );
+    }
+    try {
+      new URL(uri);
+    } catch {
+      return NextResponse.json(
+        {
+          error: "invalid_client_metadata",
+          error_description: `Invalid redirect_uri: ${uri}`,
+        },
+        { status: 400 }
+      );
+    }
+  }
+
+  const clientId = crypto.randomUUID();
+  const clientName =
+    typeof body.client_name === "string" ? body.client_name : "Unknown Client";
+  const grantTypes = Array.isArray(body.grant_types)
+    ? (body.grant_types as string[])
+    : ["authorization_code", "refresh_token"];
+
+  const registration: ClientRegistration = {
+    client_id: clientId,
+    client_name: clientName,
+    redirect_uris: redirectUris as string[],
+    grant_types: grantTypes,
+    registered_at: Date.now(),
+  };
+
+  clients.set(clientId, registration);
+
+  return NextResponse.json(
+    {
+      client_id: registration.client_id,
+      client_name: registration.client_name,
+      redirect_uris: registration.redirect_uris,
+      grant_types: registration.grant_types,
+    },
+    { status: 201 }
+  );
+}

--- a/src/app/oauth/token/route.ts
+++ b/src/app/oauth/token/route.ts
@@ -1,0 +1,163 @@
+import { NextRequest, NextResponse } from "next/server";
+import { consumeAuthCode, clients } from "@/lib/oauth-store";
+import {
+  createMcpToken,
+  verifyMcpToken,
+  verifyPkce,
+  ACCESS_TOKEN_TTL,
+  REFRESH_TOKEN_TTL,
+} from "@/lib/oauth-tokens";
+
+/**
+ * Parse the request body. Supports both application/x-www-form-urlencoded
+ * and application/json, as required by OAuth 2.0.
+ */
+async function parseBody(
+  request: NextRequest
+): Promise<Record<string, string>> {
+  const contentType = request.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    const json = await request.json();
+    const result: Record<string, string> = {};
+    for (const [k, v] of Object.entries(json)) {
+      if (typeof v === "string") result[k] = v;
+    }
+    return result;
+  }
+  // Default: form-urlencoded
+  const text = await request.text();
+  const params = new URLSearchParams(text);
+  const result: Record<string, string> = {};
+  for (const [k, v] of params) result[k] = v;
+  return result;
+}
+
+function errorResponse(
+  error: string,
+  description: string,
+  status: number = 400
+) {
+  return NextResponse.json(
+    { error, error_description: description },
+    { status }
+  );
+}
+
+/**
+ * POST /oauth/token
+ *
+ * OAuth 2.0 Token Endpoint (RFC 6749 Section 3.2).
+ * Supports authorization_code and refresh_token grant types.
+ */
+export async function POST(request: NextRequest) {
+  const body = await parseBody(request);
+  const grantType = body.grant_type;
+
+  if (grantType === "authorization_code") {
+    return handleAuthorizationCode(body);
+  } else if (grantType === "refresh_token") {
+    return handleRefreshToken(body);
+  } else {
+    return errorResponse(
+      "unsupported_grant_type",
+      "Supported grant types: authorization_code, refresh_token"
+    );
+  }
+}
+
+async function handleAuthorizationCode(body: Record<string, string>) {
+  const { code, redirect_uri, client_id, code_verifier } = body;
+
+  if (!code || !redirect_uri || !client_id || !code_verifier) {
+    return errorResponse(
+      "invalid_request",
+      "code, redirect_uri, client_id, and code_verifier are required"
+    );
+  }
+
+  // Validate client exists
+  if (!clients.has(client_id)) {
+    return errorResponse("invalid_client", "Unknown client_id");
+  }
+
+  // Consume the authorization code (single use)
+  const authCode = consumeAuthCode(code);
+  if (!authCode) {
+    return errorResponse(
+      "invalid_grant",
+      "Invalid or expired authorization code"
+    );
+  }
+
+  // Validate redirect_uri matches
+  if (authCode.redirectUri !== redirect_uri) {
+    return errorResponse("invalid_grant", "redirect_uri mismatch");
+  }
+
+  // Validate client_id matches
+  if (authCode.clientId !== client_id) {
+    return errorResponse("invalid_grant", "client_id mismatch");
+  }
+
+  // Verify PKCE
+  const pkceValid = await verifyPkce(code_verifier, authCode.codeChallenge);
+  if (!pkceValid) {
+    return errorResponse("invalid_grant", "PKCE verification failed");
+  }
+
+  // Issue tokens
+  const accessToken = await createMcpToken(
+    { userId: authCode.userId, email: authCode.email, type: "mcp_access" },
+    ACCESS_TOKEN_TTL
+  );
+  const refreshToken = await createMcpToken(
+    { userId: authCode.userId, email: authCode.email, type: "mcp_refresh" },
+    REFRESH_TOKEN_TTL
+  );
+
+  return NextResponse.json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_TTL,
+    refresh_token: refreshToken,
+  });
+}
+
+async function handleRefreshToken(body: Record<string, string>) {
+  const { refresh_token, client_id } = body;
+
+  if (!refresh_token || !client_id) {
+    return errorResponse(
+      "invalid_request",
+      "refresh_token and client_id are required"
+    );
+  }
+
+  // Validate client exists
+  if (!clients.has(client_id)) {
+    return errorResponse("invalid_client", "Unknown client_id");
+  }
+
+  // Verify the refresh token
+  const tokenData = await verifyMcpToken(refresh_token, "mcp_refresh");
+  if (!tokenData) {
+    return errorResponse("invalid_grant", "Invalid or expired refresh token");
+  }
+
+  // Issue new tokens
+  const accessToken = await createMcpToken(
+    { userId: tokenData.userId, email: tokenData.email, type: "mcp_access" },
+    ACCESS_TOKEN_TTL
+  );
+  const newRefreshToken = await createMcpToken(
+    { userId: tokenData.userId, email: tokenData.email, type: "mcp_refresh" },
+    REFRESH_TOKEN_TTL
+  );
+
+  return NextResponse.json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_TTL,
+    refresh_token: newRefreshToken,
+  });
+}

--- a/src/lib/oauth-store.ts
+++ b/src/lib/oauth-store.ts
@@ -1,0 +1,70 @@
+/**
+ * In-memory OAuth 2.0 storage for MCP remote access.
+ *
+ * Stores dynamic client registrations and pending authorization codes.
+ * Suitable for a single Railway instance. Data is lost on restart,
+ * which is acceptable — clients will re-register automatically.
+ */
+
+export interface ClientRegistration {
+  client_id: string;
+  client_name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  registered_at: number;
+}
+
+export interface AuthCode {
+  code: string;
+  userId: string;
+  email: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  redirectUri: string;
+  clientId: string;
+  expiresAt: number;
+}
+
+/** Registered OAuth clients (client_id -> registration). */
+export const clients = new Map<string, ClientRegistration>();
+
+/** Pending authorization codes (code -> auth code details). Expire after 5 min. */
+export const authCodes = new Map<string, AuthCode>();
+
+const AUTH_CODE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Periodically clean up expired authorization codes. */
+function cleanupExpiredCodes() {
+  const now = Date.now();
+  for (const [code, data] of authCodes) {
+    if (data.expiresAt < now) {
+      authCodes.delete(code);
+    }
+  }
+}
+
+// Run cleanup every 60 seconds
+setInterval(cleanupExpiredCodes, 60_000).unref();
+
+/** Create an auth code entry that expires in 5 minutes. */
+export function createAuthCode(
+  params: Omit<AuthCode, "code" | "expiresAt">
+): AuthCode {
+  const code = crypto.randomUUID();
+  const entry: AuthCode = {
+    ...params,
+    code,
+    expiresAt: Date.now() + AUTH_CODE_TTL_MS,
+  };
+  authCodes.set(code, entry);
+  return entry;
+}
+
+/** Consume an auth code (single use). Returns null if not found or expired. */
+export function consumeAuthCode(code: string): AuthCode | null {
+  const entry = authCodes.get(code);
+  if (!entry) return null;
+  authCodes.delete(code);
+  if (entry.expiresAt < Date.now()) return null;
+  return entry;
+}

--- a/src/lib/oauth-tokens.ts
+++ b/src/lib/oauth-tokens.ts
@@ -1,0 +1,86 @@
+/**
+ * MCP OAuth token creation and verification.
+ *
+ * Shared between the /oauth/token endpoint and middleware.
+ * Uses the same JWT signing key as session tokens (src/lib/auth.ts).
+ */
+import { SignJWT, jwtVerify } from "jose";
+import { env } from "@/lib/env";
+
+// Access token: 1 hour
+export const ACCESS_TOKEN_TTL = 60 * 60;
+// Refresh token: 30 days
+export const REFRESH_TOKEN_TTL = 60 * 60 * 24 * 30;
+
+/**
+ * Get the JWT signing key for MCP OAuth tokens.
+ * Same derivation as src/lib/auth.ts getJwtKey().
+ */
+async function getMcpJwtKey(): Promise<CryptoKey> {
+  const secret =
+    env.JWT_SECRET || env.API_TOKEN || env.ENCRYPTION_KEY || "annie-dev-secret";
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"]
+  );
+}
+
+export interface McpTokenPayload {
+  userId: string;
+  email: string;
+  type: "mcp_access" | "mcp_refresh";
+}
+
+/** Create a signed MCP access or refresh token. */
+export async function createMcpToken(
+  payload: McpTokenPayload,
+  ttlSeconds: number
+): Promise<string> {
+  const key = await getMcpJwtKey();
+  return new SignJWT({ ...payload })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(`${ttlSeconds}s`)
+    .sign(key);
+}
+
+/** Verify an MCP token and return its payload, or null if invalid. */
+export async function verifyMcpToken(
+  token: string,
+  expectedType: "mcp_access" | "mcp_refresh"
+): Promise<{ userId: string; email: string } | null> {
+  try {
+    const key = await getMcpJwtKey();
+    const { payload } = await jwtVerify(token, key);
+    if (payload.type !== expectedType || !payload.userId || !payload.email) {
+      return null;
+    }
+    return { userId: payload.userId as string, email: payload.email as string };
+  } catch {
+    return null;
+  }
+}
+
+/** Base64url-encode a buffer. */
+export function base64urlEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** Verify PKCE: SHA256(code_verifier) must match code_challenge. */
+export async function verifyPkce(
+  codeVerifier: string,
+  codeChallenge: string
+): Promise<boolean> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(codeVerifier)
+  );
+  const computed = base64urlEncode(digest);
+  return computed === codeChallenge;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,7 @@ import {
     verifySessionToken,
     isAuthEnabled,
 } from "@/lib/auth";
+import { verifyMcpToken } from "@/lib/oauth-tokens";
 import { env } from "@/lib/env";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 
@@ -17,6 +18,9 @@ const PUBLIC_PATHS = [
     "/api/auth/google",
     "/api/auth/me",
     "/login",
+    "/.well-known/oauth-authorization-server",
+    "/oauth/register",
+    "/oauth/token",
 ];
 
 function isPublicPath(pathname: string): boolean {
@@ -76,19 +80,42 @@ export async function middleware(request: NextRequest) {
         return NextResponse.next();
     }
 
-    // Check Authorization header (programmatic / MCP access via API_TOKEN)
+    // Check Authorization header (programmatic / MCP access)
     const apiToken = env.API_TOKEN;
     const authHeader = request.headers.get("authorization");
-    if (authHeader && apiToken) {
+    if (authHeader) {
         const token = authHeader.startsWith("Bearer ")
             ? authHeader.slice(7)
             : null;
-        if (token && token === apiToken) {
-            // Rate limit API_TOKEN users by token (single shared identity)
+
+        // 1. Check static API_TOKEN
+        if (token && apiToken && token === apiToken) {
             const rateLimited = applyRateLimit(pathname, "apitoken");
             if (rateLimited) return rateLimited;
             return NextResponse.next();
         }
+
+        // 2. Check MCP OAuth access token (JWT with type: "mcp_access")
+        if (token) {
+            const mcpSession = await verifyMcpToken(token, "mcp_access");
+            if (mcpSession) {
+                const rateLimited = applyRateLimit(pathname, mcpSession.userId);
+                if (rateLimited) return rateLimited;
+
+                Sentry.setUser({
+                    id: mcpSession.userId,
+                    email: mcpSession.email,
+                });
+
+                const requestHeaders = new Headers(request.headers);
+                requestHeaders.set("x-user-id", mcpSession.userId);
+                requestHeaders.set("x-user-email", mcpSession.email);
+                return NextResponse.next({
+                    request: { headers: requestHeaders },
+                });
+            }
+        }
+
         // Invalid bearer token on API route → 401 immediately
         if (pathname.startsWith("/api/")) {
             return NextResponse.json(


### PR DESCRIPTION
## Summary

Implements OAuth 2.0 authorization server endpoints per the MCP spec, allowing Claude Code to connect to Annie's MCP server remotely.

- **Discovery**: `/.well-known/oauth-authorization-server` — returns server metadata with dynamic origin
- **Client registration**: `POST /oauth/register` — dynamic client registration (in-memory store)
- **Authorization**: `GET /oauth/authorize` — PKCE-required auth flow, redirects to login if needed
- **Token exchange**: `POST /oauth/token` — authorization_code + refresh_token grants, JWTs with 1h/30d expiry
- **Middleware**: MCP access tokens (JWT with `type: mcp_access`) accepted as Bearer tokens alongside API_TOKEN
- **In-memory storage**: OAuth clients + auth codes with automatic expiry cleanup

### Flow
1. Claude Code fetches `/.well-known/oauth-authorization-server`
2. Registers at `/oauth/register`
3. Opens browser to `/oauth/authorize` (user logs in via Google OAuth)
4. Exchanges code at `/oauth/token` (PKCE S256 verified)
5. Uses access token for MCP requests at `/api/mcp`

## Test plan
- [ ] Discovery endpoint returns valid JSON
- [ ] Client registration returns client_id
- [ ] Authorization redirects to login when not authenticated
- [ ] Authorization issues code when authenticated
- [ ] Token exchange with valid code + PKCE returns access/refresh tokens
- [ ] Refresh token grant issues new tokens
- [ ] MCP endpoint accepts OAuth access token
- [ ] Expired codes are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)