### PR TITLE
fix: run prisma CLI via node directly in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,11 @@ COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=builder /app/.skills ./.skills
 
-# Prisma migrate deploy needs the CLI, schema, and migrations
+# Prisma migrate deploy needs the CLI, engines, schema, and migrations
 COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
-COPY --from=builder /app/node_modules/.bin/prisma ./node_modules/.bin/prisma
+COPY --from=builder /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
 COPY --from=builder /app/prisma ./prisma
 
 EXPOSE 3000
 
-CMD node_modules/.bin/prisma migrate deploy && node server.js
+CMD node node_modules/prisma/build/index.js migrate deploy && node server.js


### PR DESCRIPTION
## Summary
The `.bin/prisma` symlink can't find its WASM files in the Docker standalone output.
Use `node node_modules/prisma/build/index.js` instead, which resolves WASM files
relative to its own directory. Also copies `@prisma/engines` for the schema engine.

Fixes the ENOENT crash on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)