### PR TITLE
fix: revert prisma migrate from Docker — get Annie back online

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,6 @@ COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=builder /app/.skills ./.skills
 
-# Prisma migrate deploy needs the CLI, engines, schema, and migrations
-COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
-COPY --from=builder /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
-COPY --from=builder /app/prisma ./prisma
-
 EXPOSE 3000
 
-CMD node node_modules/prisma/build/index.js migrate deploy && node server.js
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
Reverts the prisma migrate deploy from Docker CMD. The standalone Next.js output
doesn't include the full prisma dependency tree, causing crashes.

Restores the original clean `CMD ["node", "server.js"]`.

Migrations will be handled separately (Railway deploy command or manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)