### PR TITLE
fix: share dialog crashes — API returns {shares:[]} not []

### DIFF
--- a/src/components/share-dialog.tsx
+++ b/src/components/share-dialog.tsx
@@ -46,7 +46,7 @@ export function ShareDialog({
       const res = await fetch(`/api/projects/${projectId}/share`);
       if (res.ok) {
         const data = await res.json();
-        setShares(data);
+        setShares(data.shares || data);
       }
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
The GET `/api/projects/[id]/share` returns `{ shares: [...] }` but the dialog
did `setShares(data)` instead of `setShares(data.shares)`, causing `.map()` to
fail on the object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)