### PR TITLE
feat: GitHub feedback link in user menu

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,18 @@
+---
+name: Feedback
+about: Report a bug, suggest a feature, or share your thoughts
+title: "[Feedback] "
+labels: feedback
+---
+
+## What happened?
+
+<!-- Describe the issue or suggestion -->
+
+## What did you expect?
+
+<!-- If reporting a bug, what should have happened instead? -->
+
+## Any other details?
+
+<!-- Screenshots, steps to reproduce, device info, etc. -->


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/feedback.md` for users who want to file feedback directly on GitHub
- The in-app feedback dialog (`FeedbackDialog`), API route (`/api/feedback`), and user menu integration were already fully implemented with tests

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Existing feedback route tests cover the API
- [ ] Verify the issue template appears at https://github.com/alexsiri7/word-coach-annie/issues/new/choose

Part of #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)