### PR TITLE
fix: remove JWT annie-dev-secret fallback when auth is enabled

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -24,11 +24,28 @@ export interface SessionPayload {
 }
 
 /**
+ * Resolve the raw JWT secret string.
+ * Falls back to "annie-dev-secret" only when auth is disabled (local dev).
+ * Throws if auth is enabled but no secret is configured.
+ */
+export function resolveJwtSecret(): string {
+    const secret = env.JWT_SECRET || env.API_TOKEN || env.ENCRYPTION_KEY;
+    if (secret) return secret;
+    if (isAuthEnabled()) {
+        throw new Error(
+            "JWT secret is required when auth is enabled. " +
+            "Set JWT_SECRET, API_TOKEN, or ENCRYPTION_KEY."
+        );
+    }
+    return "annie-dev-secret";
+}
+
+/**
  * Get the JWT signing key. Uses API_TOKEN, ENCRYPTION_KEY, or a fallback.
  * Returns a CryptoKey suitable for jose sign/verify.
  */
 async function getJwtKey(): Promise<CryptoKey> {
-    const secret = env.JWT_SECRET || env.API_TOKEN || env.ENCRYPTION_KEY || "annie-dev-secret";
+    const secret = resolveJwtSecret();
     const encoder = new TextEncoder();
     return crypto.subtle.importKey(
         "raw",

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -13,9 +13,20 @@ const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12; // 96 bits for GCM
 const PREFIX = "enc:v1:";
 
+let encryptionWarningLogged = false;
+
 function getEncryptionKey(): Buffer | null {
     const keySource = env.ENCRYPTION_KEY || env.API_TOKEN;
-    if (!keySource) return null;
+    if (!keySource) {
+        if (!encryptionWarningLogged) {
+            console.warn(
+                "[crypto] No ENCRYPTION_KEY or API_TOKEN set — " +
+                "encryption is disabled, values stored as plaintext."
+            );
+            encryptionWarningLogged = true;
+        }
+        return null;
+    }
     // Derive a 256-bit key from the source using SHA-256
     return createHash("sha256").update(keySource).digest();
 }

--- a/src/lib/oauth-tokens.ts
+++ b/src/lib/oauth-tokens.ts
@@ -6,6 +6,7 @@
  */
 import { SignJWT, jwtVerify } from "jose";
 import { env } from "@/lib/env";
+import { resolveJwtSecret } from "@/lib/auth";
 
 // Access token: 1 hour
 export const ACCESS_TOKEN_TTL = 60 * 60;
@@ -17,8 +18,7 @@ export const REFRESH_TOKEN_TTL = 60 * 60 * 24 * 30;
  * Same derivation as src/lib/auth.ts getJwtKey().
  */
 async function getMcpJwtKey(): Promise<CryptoKey> {
-  const secret =
-    env.JWT_SECRET || env.API_TOKEN || env.ENCRYPTION_KEY || "annie-dev-secret";
+  const secret = resolveJwtSecret();
   return crypto.subtle.importKey(
     "raw",
     new TextEncoder().encode(secret),


### PR DESCRIPTION
## Summary
- Extracts `resolveJwtSecret()` in `src/lib/auth.ts` that throws an error when auth is enabled but no JWT secret (JWT_SECRET, API_TOKEN, or ENCRYPTION_KEY) is configured, instead of silently falling back to the hardcoded `"annie-dev-secret"` string
- Updates `src/lib/oauth-tokens.ts` to use the shared `resolveJwtSecret()` instead of duplicating the fallback logic
- Adds a one-time warning log in `src/lib/crypto.ts` when no encryption key is available (dev mode)
- The `"annie-dev-secret"` fallback is still used when auth is disabled (local dev), so local development is unaffected

Fixes #182

## Test plan
- [ ] Existing auth tests pass (they set JWT_SECRET explicitly)
- [ ] Local dev without any secrets still works (auth disabled, fallback used)
- [ ] Production with auth enabled but missing secrets throws clear error at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)