### PR TITLE
fix: add authorization checks to 15 unprotected API routes

### DIFF
--- a/src/__tests__/focus-route.test.ts
+++ b/src/__tests__/focus-route.test.ts
@@ -13,8 +13,13 @@ vi.mock("next/server", () => {
             return { data, status: init?.status || 200, async json() { return data; } };
         }
     };
-    return { NextResponse: nr };
+    return { NextResponse: nr, NextRequest: class {} };
 });
+
+vi.mock("@/lib/api-auth", () => ({
+    getCurrentUserId: vi.fn().mockReturnValue(null),
+    verifyProjectAccessByNode: vi.fn().mockResolvedValue({ authorized: true, projectId: "test" }),
+}));
 
 function mockParams<T>(params: T): { params: Promise<T> } {
     return { params: Promise.resolve(params) };
@@ -36,7 +41,7 @@ describe("Focus API route", () => {
         const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1", parentId: ch.id });
 
         const { GET } = await import("@/app/api/focus/[sceneId]/route");
-        const res = await GET(new Request("http://localhost"), mockParams({ sceneId: scene.id }));
+        const res = await GET(new Request("http://localhost") as any, mockParams({ sceneId: scene.id }));
 
         expect((res as any).status || 200).toBe(200);
         const body = await (res as any).json();
@@ -47,7 +52,7 @@ describe("Focus API route", () => {
 
     it("GET returns 500 for non-existent scene", async () => {
         const { GET } = await import("@/app/api/focus/[sceneId]/route");
-        const res = await GET(new Request("http://localhost"), mockParams({ sceneId: "nonexistent" }));
+        const res = await GET(new Request("http://localhost") as any, mockParams({ sceneId: "nonexistent" }));
 
         expect((res as any).status).toBe(500);
     });

--- a/src/__tests__/sessions-progress.test.ts
+++ b/src/__tests__/sessions-progress.test.ts
@@ -28,6 +28,11 @@ vi.mock("next/server", () => ({
   },
 }));
 
+vi.mock("@/lib/api-auth", () => ({
+  getCurrentUserId: vi.fn().mockReturnValue(null),
+  verifyProjectAccess: vi.fn().mockResolvedValue({ authorized: true, project: { id: "test", userId: null }, role: null }),
+}));
+
 function mockParams<T>(params: T): { params: Promise<T> } {
   return { params: Promise.resolve(params) };
 }
@@ -195,7 +200,7 @@ describe("Sessions API routes", () => {
 
   it("GET /api/sessions/heatmap returns 28 days", async () => {
     const { GET } = await import("@/app/api/sessions/heatmap/route");
-    const res = await GET();
+    const res = await GET(new MockNextRequest("http://localhost/api/sessions/heatmap") as any);
     expect((res as any).status || 200).toBe(200);
     const body = await (res as any).json();
     expect(Array.isArray(body)).toBe(true);

--- a/src/app/api/annotations/[id]/route.ts
+++ b/src/app/api/annotations/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
+import { getCurrentUserId, verifyProjectAccessByNode } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function PATCH(
@@ -9,6 +10,18 @@ export async function PATCH(
     const { id } = await params;
 
     try {
+        // Verify access via parent node
+        const annotation = await prisma.annotation.findUnique({
+            where: { id },
+            select: { nodeId: true },
+        });
+        if (!annotation) {
+            return NextResponse.json({ error: "Annotation not found" }, { status: 404 });
+        }
+        const userId = getCurrentUserId(request);
+        const access = await verifyProjectAccessByNode(annotation.nodeId, userId);
+        if (!access.authorized) return access.response;
+
         const body = await request.json();
         const { content, resolved } = body;
 
@@ -23,12 +36,12 @@ export async function PATCH(
             );
         }
 
-        const annotation = await prisma.annotation.update({
+        const updated = await prisma.annotation.update({
             where: { id },
             data: updateData,
         });
 
-        return NextResponse.json(annotation);
+        return NextResponse.json(updated);
     } catch (error) {
         logger.error("Failed to update annotation", error);
         return NextResponse.json(
@@ -45,6 +58,18 @@ export async function DELETE(
     const { id } = await params;
 
     try {
+        // Verify access via parent node
+        const annotation = await prisma.annotation.findUnique({
+            where: { id },
+            select: { nodeId: true },
+        });
+        if (!annotation) {
+            return NextResponse.json({ error: "Annotation not found" }, { status: 404 });
+        }
+        const userId = getCurrentUserId(request);
+        const access = await verifyProjectAccessByNode(annotation.nodeId, userId);
+        if (!access.authorized) return access.response;
+
         await prisma.annotation.delete({
             where: { id },
         });

--- a/src/app/api/annotations/route.ts
+++ b/src/app/api/annotations/route.ts
@@ -1,11 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { StructureController } from "@/lib/controllers/structure";
+import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function GET(request: NextRequest) {
     try {
         const searchParams = request.nextUrl.searchParams;
         const projectId = searchParams.get("projectId") || undefined;
+
+        if (projectId) {
+            const userId = getCurrentUserId(request);
+            const access = await verifyProjectAccess(projectId, userId);
+            if (!access.authorized) return access.response;
+        }
 
         // getOpenAnnotations returns unresolved by default
         const annotations = await StructureController.getOpenAnnotations(projectId);

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { getAiConfig } from "@/lib/ai/settings";
-import { getCurrentUserId } from "@/lib/api-auth";
+import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 import { sanitizeInput } from "@/lib/sanitize-server";
 import { runChatAgent } from "@/lib/ai/adk-agent";
@@ -78,6 +78,10 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "projectId is required" }, { status: 400 });
     }
 
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccess(projectId, userId);
+    if (!access.authorized) return access.response;
+
     const messages = await prisma.chatMessage.findMany({
       where: { projectId },
       orderBy: { createdAt: "asc" },
@@ -108,6 +112,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccess(projectId, userId);
+    if (!access.authorized) return access.response;
+
     // Sanitize user input to prevent stored XSS
     const sanitizedMessage = sanitizeInput(message);
 
@@ -131,7 +139,6 @@ export async function POST(request: NextRequest) {
     recentMessages.reverse();
 
     // Load AI provider config (user DB > global DB > env vars > defaults)
-    const userId = getCurrentUserId(request);
     const aiConfig = await getAiConfig(userId);
     if (!aiConfig.apiKey) {
       return NextResponse.json(
@@ -241,6 +248,10 @@ export async function DELETE(request: NextRequest) {
     if (!projectId) {
       return NextResponse.json({ error: "projectId is required" }, { status: 400 });
     }
+
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccess(projectId, userId);
+    if (!access.authorized) return access.response;
 
     await prisma.chatMessage.deleteMany({ where: { projectId } });
     return NextResponse.json({ success: true });

--- a/src/app/api/focus/[sceneId]/route.ts
+++ b/src/app/api/focus/[sceneId]/route.ts
@@ -1,15 +1,19 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { FocusController } from "@/lib/controllers/focus";
+import { getCurrentUserId, verifyProjectAccessByNode } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function GET(
-    request: Request,
+    request: NextRequest,
     { params }: { params: Promise<{ sceneId: string }> }
 ) {
     try {
         const { sceneId } = await params;
         if (!sceneId) return new NextResponse("Scene ID required", { status: 400 });
 
+        const userId = getCurrentUserId(request);
+        const access = await verifyProjectAccessByNode(sceneId, userId);
+        if (!access.authorized) return access.response;
 
         const context = await FocusController.getSceneContext(sceneId);
         const related = await FocusController.getRelatedElements(sceneId);

--- a/src/app/api/nodes/[id]/annotations/route.ts
+++ b/src/app/api/nodes/[id]/annotations/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { StructureController } from "@/lib/controllers/structure";
+import { getCurrentUserId, verifyProjectAccessByNode } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function GET(
@@ -10,6 +11,10 @@ export async function GET(
     const { id: nodeId } = await params;
 
     try {
+        const userId = getCurrentUserId(request);
+        const access = await verifyProjectAccessByNode(nodeId, userId);
+        if (!access.authorized) return access.response;
+
         const annotations = await prisma.annotation.findMany({
             where: { nodeId },
             orderBy: { createdAt: "desc" },
@@ -32,6 +37,10 @@ export async function POST(
     const { id: nodeId } = await params;
 
     try {
+        const userId = getCurrentUserId(request);
+        const access = await verifyProjectAccessByNode(nodeId, userId);
+        if (!access.authorized) return access.response;
+
         const body = await request.json();
         const { content, range, selectedText } = body;
 

--- a/src/app/api/nodes/[id]/content/route.ts
+++ b/src/app/api/nodes/[id]/content/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { StructureController } from "@/lib/controllers/structure";
+import { getCurrentUserId, verifyProjectAccessByNode } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function GET(
@@ -10,6 +11,10 @@ export async function GET(
   const { id: nodeId } = await params;
 
   try {
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccessByNode(nodeId, userId);
+    if (!access.authorized) return access.response;
+
     const searchParams = request.nextUrl.searchParams;
     const versionId = searchParams.get("versionId");
 
@@ -59,6 +64,10 @@ export async function POST(
   const { id: nodeId } = await params;
 
   try {
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccessByNode(nodeId, userId);
+    if (!access.authorized) return access.response;
+
     const body = await request.json();
     const { content } = body;
 
@@ -87,6 +96,10 @@ export async function PATCH(
   const { id: nodeId } = await params;
 
   try {
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccessByNode(nodeId, userId);
+    if (!access.authorized) return access.response;
+
     const body = await request.json();
     const { versionId } = body;
 

--- a/src/app/api/nodes/move/route.ts
+++ b/src/app/api/nodes/move/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
+import { getCurrentUserId, verifyProjectAccessByNode } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 /**
@@ -18,6 +19,10 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccessByNode(nodeId, userId);
+    if (!access.authorized) return access.response;
 
     const node = await prisma.structureNode.findUnique({
       where: { id: nodeId },

--- a/src/app/api/projects/[id]/progress/route.ts
+++ b/src/app/api/projects/[id]/progress/route.ts
@@ -1,13 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ProgressController } from "@/lib/controllers/progress";
+import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function GET(
-  _req: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id: projectId } = await params;
   try {
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccess(projectId, userId);
+    if (!access.authorized) return access.response;
+
     const progress = await ProgressController.getProjectProgress(projectId);
     return NextResponse.json(progress);
   } catch (error) {

--- a/src/app/api/projects/[id]/sessions/route.ts
+++ b/src/app/api/projects/[id]/sessions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { SessionsController } from "@/lib/controllers/sessions";
+import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function POST(
@@ -8,6 +9,10 @@ export async function POST(
 ) {
   const { id: projectId } = await params;
   try {
+    const userId = getCurrentUserId(req);
+    const access = await verifyProjectAccess(projectId, userId);
+    if (!access.authorized) return access.response;
+
     const body = await req.json();
     const session = await SessionsController.createSession({
       projectId,

--- a/src/app/api/sessions/heatmap/route.ts
+++ b/src/app/api/sessions/heatmap/route.ts
@@ -1,10 +1,12 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { SessionsController } from "@/lib/controllers/sessions";
+import { getCurrentUserId } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const heatmap = await SessionsController.getGlobalHeatmap(28);
+    const userId = getCurrentUserId(request);
+    const heatmap = await SessionsController.getGlobalHeatmap(28, userId);
     return NextResponse.json(heatmap);
   } catch (error) {
     logger.error("Failed to get heatmap", { error });

--- a/src/app/api/story-objects/[id]/route.ts
+++ b/src/app/api/story-objects/[id]/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
+import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -34,6 +35,10 @@ export async function GET(
       );
     }
 
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccess(storyObject.projectId, userId);
+    if (!access.authorized) return access.response;
+
     return NextResponse.json(storyObject);
   } catch (error) {
     logger.error("GET /api/story-objects/[id] error", error);
@@ -54,7 +59,7 @@ export async function PATCH(
     // Verify story object exists
     const existing = await prisma.storyObject.findUnique({
       where: { id },
-      select: { id: true },
+      select: { id: true, projectId: true },
     });
 
     if (!existing) {
@@ -63,6 +68,10 @@ export async function PATCH(
         { status: 404 }
       );
     }
+
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccess(existing.projectId, userId);
+    if (!access.authorized) return access.response;
 
     let body: Record<string, unknown>;
     try {
@@ -120,7 +129,7 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -128,7 +137,7 @@ export async function DELETE(
 
     const existing = await prisma.storyObject.findUnique({
       where: { id },
-      select: { id: true },
+      select: { id: true, projectId: true },
     });
 
     if (!existing) {
@@ -137,6 +146,10 @@ export async function DELETE(
         { status: 404 }
       );
     }
+
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectAccess(existing.projectId, userId);
+    if (!access.authorized) return access.response;
 
     await prisma.storyObject.delete({ where: { id } });
 

--- a/src/app/api/timeline/[projectId]/route.ts
+++ b/src/app/api/timeline/[projectId]/route.ts
@@ -1,5 +1,6 @@
 import { TimelineController } from "@/lib/controllers/timeline";
 import { NextRequest, NextResponse } from "next/server";
+import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function GET(
@@ -8,6 +9,11 @@ export async function GET(
 ) {
     try {
         const { projectId } = await params;
+
+        const userId = getCurrentUserId(request);
+        const access = await verifyProjectAccess(projectId, userId);
+        if (!access.authorized) return access.response;
+
         const data = await TimelineController.getTimelineData(projectId);
         return NextResponse.json(data);
     } catch (error) {

--- a/src/app/api/universes/transfer-object/route.ts
+++ b/src/app/api/universes/transfer-object/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { UniversesController } from "@/lib/controllers/universes";
+import { getCurrentUserId, verifyUniverseAccess } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 export async function POST(request: NextRequest) {
@@ -13,6 +14,11 @@ export async function POST(request: NextRequest) {
                 { status: 400 }
             );
         }
+
+        // Verify user has access to the target universe
+        const userId = getCurrentUserId(request);
+        const access = await verifyUniverseAccess(universeId, userId);
+        if (!access.authorized) return access.response;
 
         const result = await UniversesController.transferStoryObjectToUniverse(
             storyObjectId,

--- a/src/app/api/world-objects/[id]/route.ts
+++ b/src/app/api/world-objects/[id]/route.ts
@@ -1,12 +1,29 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
 import { UniversesController } from "@/lib/controllers/universes";
+import { getCurrentUserId, verifyUniverseAccess } from "@/lib/api-auth";
+
+async function verifyWorldObjectAccess(worldObjectId: string, userId: string | null) {
+    const wo = await prisma.worldObject.findUnique({
+        where: { id: worldObjectId },
+        select: { universeId: true },
+    });
+    if (!wo) {
+        return { authorized: false as const, response: NextResponse.json({ error: "World object not found" }, { status: 404 }) };
+    }
+    return verifyUniverseAccess(wo.universeId, userId);
+}
 
 export async function GET(
-    request: Request,
+    request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
         const { id } = await params;
+        const userId = getCurrentUserId(request);
+        const access = await verifyWorldObjectAccess(id, userId);
+        if (!access.authorized) return access.response;
+
         const worldObject = await UniversesController.getWorldObject(id);
         return NextResponse.json(worldObject);
     } catch (error: unknown) {
@@ -15,11 +32,15 @@ export async function GET(
 }
 
 export async function PATCH(
-    request: Request,
+    request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
         const { id } = await params;
+        const userId = getCurrentUserId(request);
+        const access = await verifyWorldObjectAccess(id, userId);
+        if (!access.authorized) return access.response;
+
         const body = await request.json();
         const worldObject = await UniversesController.updateWorldObject(id, body);
         return NextResponse.json(worldObject);
@@ -29,11 +50,15 @@ export async function PATCH(
 }
 
 export async function DELETE(
-    request: Request,
+    request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
         const { id } = await params;
+        const userId = getCurrentUserId(request);
+        const access = await verifyWorldObjectAccess(id, userId);
+        if (!access.authorized) return access.response;
+
         await UniversesController.deleteWorldObject(id);
         return NextResponse.json({ success: true });
     } catch (error: unknown) {

--- a/src/app/api/world-objects/[id]/timeline/route.ts
+++ b/src/app/api/world-objects/[id]/timeline/route.ts
@@ -1,12 +1,29 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
 import { UniversesController } from "@/lib/controllers/universes";
+import { getCurrentUserId, verifyUniverseAccess } from "@/lib/api-auth";
+
+async function verifyWorldObjectAccess(worldObjectId: string, userId: string | null) {
+    const wo = await prisma.worldObject.findUnique({
+        where: { id: worldObjectId },
+        select: { universeId: true },
+    });
+    if (!wo) {
+        return { authorized: false as const, response: NextResponse.json({ error: "World object not found" }, { status: 404 }) };
+    }
+    return verifyUniverseAccess(wo.universeId, userId);
+}
 
 export async function GET(
-    request: Request,
+    request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
         const { id } = await params;
+        const userId = getCurrentUserId(request);
+        const access = await verifyWorldObjectAccess(id, userId);
+        if (!access.authorized) return access.response;
+
         const worldObject = await UniversesController.getWorldObject(id);
         return NextResponse.json(worldObject.timeline);
     } catch (error: unknown) {
@@ -15,11 +32,15 @@ export async function GET(
 }
 
 export async function POST(
-    request: Request,
+    request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
         const { id } = await params;
+        const userId = getCurrentUserId(request);
+        const access = await verifyWorldObjectAccess(id, userId);
+        if (!access.authorized) return access.response;
+
         const body = await request.json();
         const entry = await UniversesController.addTimelineEntry({
             ...body,

--- a/src/lib/controllers/sessions.ts
+++ b/src/lib/controllers/sessions.ts
@@ -61,13 +61,18 @@ export class SessionsController {
     return aggregateHeatmap(sessions, days);
   }
 
-  static async getGlobalHeatmap(days = 28): Promise<HeatmapDay[]> {
+  static async getGlobalHeatmap(days = 28, userId?: string | null): Promise<HeatmapDay[]> {
     const since = new Date();
     since.setDate(since.getDate() - days);
     const sinceDate = since.toISOString().slice(0, 10);
 
+    const where: Record<string, unknown> = { date: { gte: sinceDate } };
+    if (userId) {
+      where.project = { userId };
+    }
+
     const sessions = await prisma.writingSession.findMany({
-      where: { date: { gte: sinceDate } },
+      where,
       select: { date: true, wordsWritten: true },
     });
 


### PR DESCRIPTION
## Summary
- Adds `getCurrentUserId()` + `verifyProjectAccess()` / `verifyProjectAccessByNode()` / `verifyUniverseAccess()` checks to all 15 unprotected API routes identified in #181
- Scopes the global heatmap query by userId through the project relation in `SessionsController.getGlobalHeatmap()`
- Updates test mocks for focus-route and sessions-progress tests to account for new auth checks

## Routes fixed
1. `POST/GET/DELETE /api/chat` — `verifyProjectAccess`
2. `GET/POST/PATCH /api/nodes/[id]/content` — `verifyProjectAccessByNode`
3. `GET/POST /api/nodes/[id]/annotations` — `verifyProjectAccessByNode`
4. `POST /api/nodes/move` — `verifyProjectAccessByNode`
5. `GET /api/annotations` — `verifyProjectAccess` (when projectId provided)
6. `PATCH/DELETE /api/annotations/[id]` — `verifyProjectAccessByNode` via parent node
7. `GET /api/focus/[sceneId]` — `verifyProjectAccessByNode`
8. `GET /api/timeline/[projectId]` — `verifyProjectAccess`
9. `GET /api/projects/[id]/progress` — `verifyProjectAccess`
10. `GET /api/sessions/heatmap` — scoped by userId
11. `POST /api/projects/[id]/sessions` — `verifyProjectAccess`
12. `GET/PATCH/DELETE /api/story-objects/[id]` — `verifyProjectAccess` via parent project
13. `GET/PATCH/DELETE /api/world-objects/[id]` — `verifyUniverseAccess` via parent universe
14. `GET/POST /api/world-objects/[id]/timeline` — `verifyUniverseAccess` via parent universe
15. `POST /api/universes/transfer-object` — `verifyUniverseAccess` on target universe

Fixes #181

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Verify existing tests pass with updated mocks
- [ ] Manual: authenticated user can only access their own projects/universes
- [ ] Manual: API_TOKEN / dev mode (null userId) still allows all access

🤖 Generated with [Claude Code](https://claude.com/claude-code)