### PR TITLE
fix: restrict OAuth redirect URIs to localhost only

### DIFF
--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -40,13 +40,27 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+    let parsed: URL;
     try {
-      new URL(uri);
+      parsed = new URL(uri);
     } catch {
       return NextResponse.json(
         {
           error: "invalid_client_metadata",
           error_description: `Invalid redirect_uri: ${uri}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Only allow localhost redirect URIs (standard for MCP clients)
+    const host = parsed.hostname;
+    if (host !== "localhost" && host !== "127.0.0.1" && host !== "::1") {
+      return NextResponse.json(
+        {
+          error: "invalid_client_metadata",
+          error_description:
+            "redirect_uris must use localhost (localhost, 127.0.0.1, or ::1)",
         },
         { status: 400 }
       );


### PR DESCRIPTION
## Summary
- Validates that all `redirect_uris` in the dynamic client registration endpoint (`POST /oauth/register`) resolve to localhost (`localhost`, `127.0.0.1`, or `::1`)
- Returns a 400 error with `invalid_client_metadata` if any redirect URI points to a non-localhost host
- Standard security measure for MCP clients which always use localhost callbacks

Fixes #183

## Test plan
- [ ] Register a client with `http://localhost:3000/callback` — should succeed
- [ ] Register a client with `http://127.0.0.1:8080/callback` — should succeed
- [ ] Register a client with `http://evil.com/callback` — should get 400 error
- [ ] Verify existing MCP client flows (Claude Code) still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)