### PR TITLE
fix: add CSRF state parameter to Google OAuth flow

### DIFF
--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -22,6 +22,19 @@ export async function GET(request: NextRequest) {
         );
     }
 
+    // Verify CSRF state parameter
+    const stateParam = request.nextUrl.searchParams.get("state");
+    const stateCookie = request.cookies.get("oauth_state")?.value;
+    if (!stateParam || !stateCookie || stateParam !== stateCookie) {
+        const redirectUri = env.GOOGLE_REDIRECT_URI;
+        const baseUrl = redirectUri
+            ? new URL(redirectUri).origin
+            : request.nextUrl.origin;
+        return NextResponse.redirect(
+            new URL("/login?error=invalid_state", baseUrl)
+        );
+    }
+
     const clientId = env.GOOGLE_CLIENT_ID;
     const clientSecret = env.GOOGLE_CLIENT_SECRET;
     const redirectUri = env.GOOGLE_REDIRECT_URI;
@@ -91,6 +104,14 @@ export async function GET(request: NextRequest) {
     // Use GOOGLE_REDIRECT_URI origin to avoid Docker container hostname in redirect
     const baseUrl = new URL(redirectUri).origin;
     const response = NextResponse.redirect(new URL("/", baseUrl));
+    // Clear the OAuth state cookie
+    response.cookies.set("oauth_state", "", {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 0,
+        path: "/",
+    });
     response.cookies.set(SESSION_COOKIE_NAME, jwt, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { google } from "googleapis";
+import crypto from "crypto";
 import { env } from "@/lib/env";
 
 /**
@@ -20,6 +21,8 @@ export async function GET() {
 
     const client = new google.auth.OAuth2(clientId, clientSecret, redirectUri);
 
+    const state = crypto.randomUUID();
+
     const authUrl = client.generateAuthUrl({
         access_type: "offline",
         scope: [
@@ -28,7 +31,17 @@ export async function GET() {
             "https://www.googleapis.com/auth/userinfo.profile",
         ],
         prompt: "consent",
+        state,
     });
 
-    return NextResponse.redirect(authUrl);
+    const response = NextResponse.redirect(authUrl);
+    response.cookies.set("oauth_state", state, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 600, // 10 minutes
+        path: "/",
+    });
+
+    return response;
 }


### PR DESCRIPTION
## Summary
- Generates a random `state` token via `crypto.randomUUID()` in the OAuth initiation route and stores it in a short-lived `oauth_state` httpOnly cookie (10 min max-age)
- Validates the `state` query parameter against the cookie in the callback route; redirects to `/login?error=invalid_state` on mismatch
- Clears the `oauth_state` cookie after successful verification

Fixes #185

## Test plan
- [ ] Initiate Google login and verify the auth URL includes a `state` parameter
- [ ] Confirm the `oauth_state` cookie is set on redirect
- [ ] Complete login flow end-to-end and verify it still works
- [ ] Tamper with or remove the `state` parameter and verify redirect to `/login?error=invalid_state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)