### PR TITLE
fix: scope relationship query to project in story bible export

### DIFF
--- a/src/app/api/projects/[id]/export/route.ts
+++ b/src/app/api/projects/[id]/export/route.ts
@@ -268,21 +268,28 @@ async function exportStoryBible(projectId: string, projectTitle: string): Promis
     }
   }
 
-  // Add relationships
-  const relationships = await prisma.relationship.findMany({
+  // Add relationships scoped to this project's nodes and objects
+  const nodeIds = (await prisma.structureNode.findMany({
+    where: { projectId },
+    select: { id: true },
+  })).map((n) => n.id);
+  const objectIds = storyObjects.map((o) => o.id);
+
+  const projectRelationships = await prisma.relationship.findMany({
+    where: {
+      OR: [
+        { fromNodeId: { in: nodeIds } },
+        { toNodeId: { in: nodeIds } },
+        { fromObjectId: { in: objectIds } },
+        { toObjectId: { in: objectIds } },
+      ],
+    },
     include: {
       fromNode: true,
       fromObject: true,
       toNode: true,
       toObject: true,
     },
-  });
-
-  // Filter to only this project's relationships
-  const projectRelationships = relationships.filter((r: { fromNode?: { projectId: string } | null; fromObject?: { projectId: string } | null; toNode?: { projectId: string } | null; toObject?: { projectId: string } | null }) => {
-    const fromProjectId = r.fromNode?.projectId || r.fromObject?.projectId;
-    const toProjectId = r.toNode?.projectId || r.toObject?.projectId;
-    return fromProjectId === projectId || toProjectId === projectId;
   });
 
   if (projectRelationships.length > 0) {


### PR DESCRIPTION
## Summary
- Replaced unbounded `prisma.relationship.findMany()` in `exportStoryBible()` with a query scoped to the project's node and object IDs
- Previously fetched ALL relationships globally then filtered in JS; now uses a proper `WHERE` clause with `OR` on `fromNodeId`, `toNodeId`, `fromObjectId`, `toObjectId`
- Matches the pattern already used in `GET /api/projects/[id]/relationships`

Fixes #187

## Test plan
- [ ] Export story bible for a project and verify relationships section only contains that project's relationships
- [ ] Verify no relationships from other projects leak into the export

🤖 Generated with [Claude Code](https://claude.com/claude-code)