### PR TITLE
fix: prevent error detail leakage in API responses

### DIFF
--- a/src/app/api/universes/[id]/route.ts
+++ b/src/app/api/universes/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { UniversesController } from "@/lib/controllers/universes";
 import { getCurrentUserId, verifyUniverseAccess } from "@/lib/api-auth";
+import { logger } from "@/lib/logger";
 
 export async function GET(
     request: NextRequest,
@@ -15,7 +16,8 @@ export async function GET(
         const universe = await UniversesController.getUniverse(id);
         return NextResponse.json(universe);
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }
 
@@ -33,7 +35,8 @@ export async function PATCH(
         const universe = await UniversesController.updateUniverse(id, body);
         return NextResponse.json(universe);
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }
 
@@ -50,6 +53,7 @@ export async function DELETE(
         await UniversesController.deleteUniverse(id);
         return NextResponse.json({ success: true });
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }

--- a/src/app/api/universes/[id]/world-objects/route.ts
+++ b/src/app/api/universes/[id]/world-objects/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { UniversesController } from "@/lib/controllers/universes";
+import { logger } from "@/lib/logger";
 
 export async function GET(
     request: Request,
@@ -12,7 +13,8 @@ export async function GET(
         const worldObjects = await UniversesController.listWorldObjects(id, type);
         return NextResponse.json(worldObjects);
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }
 
@@ -29,6 +31,7 @@ export async function POST(
         });
         return NextResponse.json(worldObject);
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }

--- a/src/app/api/world-objects/[id]/route.ts
+++ b/src/app/api/world-objects/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { UniversesController } from "@/lib/controllers/universes";
 import { getCurrentUserId, verifyUniverseAccess } from "@/lib/api-auth";
+import { logger } from "@/lib/logger";
 
 async function verifyWorldObjectAccess(worldObjectId: string, userId: string | null) {
     const wo = await prisma.worldObject.findUnique({
@@ -27,7 +28,8 @@ export async function GET(
         const worldObject = await UniversesController.getWorldObject(id);
         return NextResponse.json(worldObject);
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }
 
@@ -45,7 +47,8 @@ export async function PATCH(
         const worldObject = await UniversesController.updateWorldObject(id, body);
         return NextResponse.json(worldObject);
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }
 
@@ -62,6 +65,7 @@ export async function DELETE(
         await UniversesController.deleteWorldObject(id);
         return NextResponse.json({ success: true });
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }

--- a/src/app/api/world-objects/[id]/timeline/[entryId]/route.ts
+++ b/src/app/api/world-objects/[id]/timeline/[entryId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { UniversesController } from "@/lib/controllers/universes";
+import { logger } from "@/lib/logger";
 
 export async function PATCH(
     request: Request,
@@ -11,7 +12,8 @@ export async function PATCH(
         const entry = await UniversesController.updateTimelineEntry(entryId, body);
         return NextResponse.json(entry);
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }
 
@@ -24,6 +26,7 @@ export async function DELETE(
         await UniversesController.deleteTimelineEntry(entryId);
         return NextResponse.json({ success: true });
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }

--- a/src/app/api/world-objects/[id]/timeline/route.ts
+++ b/src/app/api/world-objects/[id]/timeline/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { UniversesController } from "@/lib/controllers/universes";
 import { getCurrentUserId, verifyUniverseAccess } from "@/lib/api-auth";
+import { logger } from "@/lib/logger";
 
 async function verifyWorldObjectAccess(worldObjectId: string, userId: string | null) {
     const wo = await prisma.worldObject.findUnique({
@@ -27,7 +28,8 @@ export async function GET(
         const worldObject = await UniversesController.getWorldObject(id);
         return NextResponse.json(worldObject.timeline);
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }
 
@@ -48,6 +50,7 @@ export async function POST(
         });
         return NextResponse.json(entry);
     } catch (error: unknown) {
-        return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+        logger.error("Route error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }


### PR DESCRIPTION
## Summary
- Replace `error.message` / `String(error)` in catch blocks with generic "Internal server error" across 5 universe/world-object API routes
- Add `logger.error()` calls before returning so full error details are still logged server-side
- Prevents SQL/schema details from leaking to API clients

Fixes #189

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] API routes return generic error messages on failure
- [ ] Server logs still contain full error details

🤖 Generated with [Claude Code](https://claude.com/claude-code)