### PR TITLE
feat: add uptime monitoring via GitHub Actions

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,20 @@
+name: Uptime Monitor
+
+on:
+  schedule:
+    - cron: '*/5 * * * *' # Every 5 minutes
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  check:
+    name: Health Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check health endpoint
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://annie.interstellarai.net/api/health)
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Health check failed with status $STATUS"
+            exit 1
+          fi
+          echo "Health check passed (HTTP $STATUS)"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that pings `/api/health` every 5 minutes
- GitHub sends email notifications on failure (HTTP non-200 or timeout)
- Can also be triggered manually via `workflow_dispatch`

Fixes #175

## Test plan
- [ ] Trigger manually from Actions tab to verify it passes
- [ ] Confirm GitHub notifications are enabled for workflow failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)