### PR TITLE
feat: persist OAuth client registrations to database

### DIFF
--- a/prisma/migrations/20260330_add_oauth_client/migration.sql
+++ b/prisma/migrations/20260330_add_oauth_client/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "OAuthClient" (
+    "id" TEXT NOT NULL,
+    "clientName" TEXT NOT NULL DEFAULT '',
+    "redirectUris" TEXT NOT NULL,
+    "grantTypes" TEXT NOT NULL DEFAULT '["authorization_code","refresh_token"]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OAuthClient_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -270,3 +270,11 @@ model WritingSession {
   @@index([projectId, date])
   @@index([date])
 }
+
+model OAuthClient {
+  id           String   @id
+  clientName   String   @default("")
+  redirectUris String   // JSON array stored as string
+  grantTypes   String   @default("[\"authorization_code\",\"refresh_token\"]")
+  createdAt    DateTime @default(now())
+}

--- a/src/app/oauth/authorize/route.ts
+++ b/src/app/oauth/authorize/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { SESSION_COOKIE_NAME, verifySessionToken } from "@/lib/auth";
-import { clients, createAuthCode } from "@/lib/oauth-store";
+import { getClient, createAuthCode } from "@/lib/oauth-store";
 
 /**
  * GET /oauth/authorize
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
   }
 
   // Validate client_id
-  const client = clients.get(clientId);
+  const client = await getClient(clientId);
   if (!client) {
     return NextResponse.json(
       { error: "invalid_client", error_description: "Unknown client_id" },

--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { clients, type ClientRegistration } from "@/lib/oauth-store";
+import { registerClient, type ClientRegistration } from "@/lib/oauth-store";
 
 /**
  * POST /oauth/register
@@ -82,7 +82,7 @@ export async function POST(request: NextRequest) {
     registered_at: Date.now(),
   };
 
-  clients.set(clientId, registration);
+  await registerClient(registration);
 
   return NextResponse.json(
     {

--- a/src/app/oauth/token/route.ts
+++ b/src/app/oauth/token/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { consumeAuthCode, clients } from "@/lib/oauth-store";
+import { consumeAuthCode, getClient } from "@/lib/oauth-store";
 import {
   createMcpToken,
   verifyMcpToken,
@@ -76,7 +76,8 @@ async function handleAuthorizationCode(body: Record<string, string>) {
   }
 
   // Validate client exists
-  if (!clients.has(client_id)) {
+  const client = await getClient(client_id);
+  if (!client) {
     return errorResponse("invalid_client", "Unknown client_id");
   }
 
@@ -134,7 +135,8 @@ async function handleRefreshToken(body: Record<string, string>) {
   }
 
   // Validate client exists
-  if (!clients.has(client_id)) {
+  const client = await getClient(client_id);
+  if (!client) {
     return errorResponse("invalid_client", "Unknown client_id");
   }
 

--- a/src/lib/oauth-store.ts
+++ b/src/lib/oauth-store.ts
@@ -1,10 +1,11 @@
 /**
- * In-memory OAuth 2.0 storage for MCP remote access.
+ * OAuth 2.0 storage for MCP remote access.
  *
- * Stores dynamic client registrations and pending authorization codes.
- * Suitable for a single Railway instance. Data is lost on restart,
- * which is acceptable — clients will re-register automatically.
+ * Client registrations are persisted to the database so they survive
+ * Railway deploys. Auth codes remain in-memory (short-lived, 5 min).
  */
+
+import { prisma } from "@/lib/db";
 
 export interface ClientRegistration {
   client_id: string;
@@ -25,8 +26,36 @@ export interface AuthCode {
   expiresAt: number;
 }
 
-/** Registered OAuth clients (client_id -> registration). */
-export const clients = new Map<string, ClientRegistration>();
+/** Register an OAuth client (persisted to database). */
+export async function registerClient(
+  registration: ClientRegistration
+): Promise<void> {
+  await prisma.oAuthClient.create({
+    data: {
+      id: registration.client_id,
+      clientName: registration.client_name,
+      redirectUris: JSON.stringify(registration.redirect_uris),
+      grantTypes: JSON.stringify(registration.grant_types),
+    },
+  });
+}
+
+/** Look up a registered OAuth client by ID. Returns null if not found. */
+export async function getClient(
+  clientId: string
+): Promise<ClientRegistration | null> {
+  const row = await prisma.oAuthClient.findUnique({
+    where: { id: clientId },
+  });
+  if (!row) return null;
+  return {
+    client_id: row.id,
+    client_name: row.clientName,
+    redirect_uris: JSON.parse(row.redirectUris) as string[],
+    grant_types: JSON.parse(row.grantTypes) as string[],
+    registered_at: row.createdAt.getTime(),
+  };
+}
 
 /** Pending authorization codes (code -> auth code details). Expire after 5 min. */
 export const authCodes = new Map<string, AuthCode>();


### PR DESCRIPTION
## Summary
- Adds `OAuthClient` Prisma model to persist MCP client registrations across deploys
- Replaces in-memory `clients` Map with async `registerClient()`/`getClient()` backed by PostgreSQL
- Keeps auth codes in-memory (short-lived, 5 min TTL -- fine to lose on restart)
- Includes migration SQL for the new table

## Migration

The migration at `prisma/migrations/20260330_add_oauth_client/migration.sql` should auto-apply via `prisma migrate deploy` on next deploy. If not, run in Supabase SQL editor:

```sql
CREATE TABLE "OAuthClient" (
    "id" TEXT NOT NULL,
    "clientName" TEXT NOT NULL DEFAULT '',
    "redirectUris" TEXT NOT NULL,
    "grantTypes" TEXT NOT NULL DEFAULT '["authorization_code","refresh_token"]',
    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
    CONSTRAINT "OAuthClient_pkey" PRIMARY KEY ("id")
);
```

## Test plan
- [ ] Deploy to Railway and verify MCP client registration persists across restarts
- [ ] Verify OAuth flow works end-to-end (register -> authorize -> token)
- [ ] Verify refresh token flow still works after deploy
- [ ] TypeScript type-check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)