### PR TITLE
fix: migration script uses DIRECT_DATABASE_URL

### DIFF
--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -13,7 +13,12 @@ import { readFileSync, readdirSync, existsSync } from 'fs';
 import { createHash, randomUUID } from 'crypto';
 import { join } from 'path';
 
-const prisma = new PrismaClient();
+// Use DIRECT_DATABASE_URL for migrations (bypasses PgBouncer transaction mode
+// which doesn't support multi-statement operations or advisory locks)
+const databaseUrl = process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
+const prisma = new PrismaClient({
+  datasources: { db: { url: databaseUrl } },
+});
 
 async function ensureMigrationsTable() {
   await prisma.$executeRawUnsafe(`


### PR DESCRIPTION
## Summary
The migration runner was using `DATABASE_URL` (transaction mode PgBouncer, port 6543)
which doesn't support the operations migrations need. Now uses `DIRECT_DATABASE_URL`
(direct Supabase connection) with fallback to `DATABASE_URL`.

This will allow the `OAuthClient` migration from #204 to apply automatically on next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)