### PR TITLE
fix: update migration script for Prisma 7 adapter API

### DIFF
--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -9,16 +9,16 @@
  */
 
 import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { createHash, randomUUID } from 'crypto';
 import { join } from 'path';
 
 // Use DIRECT_DATABASE_URL for migrations (bypasses PgBouncer transaction mode
 // which doesn't support multi-statement operations or advisory locks)
-const databaseUrl = process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
-const prisma = new PrismaClient({
-  datasources: { db: { url: databaseUrl } },
-});
+const connectionString = process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
+const adapter = new PrismaPg({ connectionString });
+const prisma = new PrismaClient({ adapter });
 
 async function ensureMigrationsTable() {
   await prisma.$executeRawUnsafe(`


### PR DESCRIPTION
## Summary
Prisma 7 removed `datasources` from the PrismaClient constructor. The migration
script was still using the old API, causing `PrismaClientConstructorValidationError`
on container startup.

Now uses `PrismaPg` adapter matching the main app's pattern in `src/lib/db.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)