### PR TITLE
feat: Editorial Cabin Phase 2 — keycap buttons, stamp chips, underline inputs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -192,21 +192,22 @@
     background: hsl(var(--surface-raised) / 0.85);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border: none;
-    border-radius: 1rem;
+    border: 1px solid hsl(var(--border) / 0.15);
+    border-radius: 0.25rem;
     transition: all 0.2s ease;
   }
 
   .glass-card:hover {
-    box-shadow: 0 8px 32px hsl(var(--text-primary) / 0.04);
+    box-shadow: 0 24px 40px hsl(var(--text-primary) / 0.05);
   }
 
   .dark .glass-card {
     background: hsl(var(--surface-raised) / 0.7);
+    border-color: hsl(var(--border) / 0.15);
   }
 
   .dark .glass-card:hover {
-    box-shadow: 0 8px 32px hsl(0 0% 0% / 0.15);
+    box-shadow: 0 24px 40px hsl(0 0% 0% / 0.12);
   }
 
   /* Ghost border — accessibility boundary at 15% opacity */
@@ -222,14 +223,52 @@
         hsl(var(--accent)));
   }
 
-  /* Tag pill */
+  /* Tag pill — stamp chip style (square, not rounded pills) */
   .tag-pill {
     background: hsl(var(--surface-overlay));
     color: hsl(var(--text-secondary));
     padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
+    border-radius: 0;
     font-size: 0.75rem;
     font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border: 1px solid hsl(var(--border) / 0.15);
+  }
+
+  /* Stamp chip — square metadata tags */
+  .stamp-chip {
+    display: inline-flex;
+    align-items: center;
+    background: hsl(var(--surface-overlay));
+    color: hsl(var(--text-secondary));
+    padding: 0.125rem 0.5rem;
+    border-radius: 0;
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border: 1px solid hsl(var(--border) / 0.15);
+  }
+
+  /* Annie's coaching cards — no dividers, tonal differentiation */
+  .coaching-card-intense {
+    background: hsl(var(--surface-sunken));
+    border: none;
+    border-radius: 0.25rem;
+    padding: 1.5rem;
+  }
+
+  .coaching-card-positive {
+    background: hsl(var(--accent-muted));
+    border: none;
+    border-radius: 0.25rem;
+    padding: 1.5rem;
+  }
+
+  .coaching-card-intense > * + *,
+  .coaching-card-positive > * + * {
+    margin-top: 1.5rem;
   }
 
   /* Status dots */

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -3,14 +3,14 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface",
+  "inline-flex items-center rounded-none border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-[0.05em] transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface",
   {
     variants: {
       variant: {
-        default: "border-transparent bg-accent text-white",
-        secondary: "border-transparent bg-surface-overlay text-text-secondary",
-        destructive: "border-transparent bg-danger text-white",
-        outline: "text-text-primary border-border",
+        default: "border-accent/15 bg-accent text-white",
+        secondary: "border-border/15 bg-surface-overlay text-text-secondary",
+        destructive: "border-danger/15 bg-danger text-white",
+        outline: "text-text-primary border-border/15",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,26 +4,26 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium uppercase tracking-[0.05em] transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default:
-          "bg-accent text-white shadow-md shadow-accent/20 hover:bg-accent-hover hover:shadow-lg hover:shadow-accent/30 active:scale-[0.98]",
+          "bg-gradient-to-b from-accent to-accent-hover text-white shadow-[0_2px_0_0_hsl(var(--accent-hover))] hover:brightness-110 active:shadow-none active:translate-y-[1px]",
         destructive:
-          "bg-danger text-white shadow-sm hover:bg-danger-hover active:scale-[0.98]",
+          "bg-gradient-to-b from-danger to-danger-hover text-white shadow-[0_2px_0_0_hsl(var(--danger-hover))] hover:brightness-110 active:shadow-none active:translate-y-[1px]",
         outline:
-          "border border-border bg-surface-raised text-text-primary shadow-sm hover:bg-surface-overlay hover:border-border/80",
+          "border border-border/15 bg-surface-raised text-text-primary shadow-[0_2px_0_0_hsl(var(--border))] hover:bg-surface-overlay active:shadow-none active:translate-y-[1px]",
         secondary:
-          "bg-surface-overlay text-text-primary shadow-sm hover:bg-surface-overlay/80",
+          "bg-surface-overlay text-text-primary shadow-[0_2px_0_0_hsl(var(--border))] hover:bg-surface-overlay/80 active:shadow-none active:translate-y-[1px]",
         ghost:
           "text-text-secondary hover:bg-surface-overlay hover:text-text-primary",
-        link: "text-accent underline-offset-4 hover:underline",
+        link: "text-accent underline-offset-4 hover:underline normal-case tracking-normal",
       },
       size: {
         default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-lg px-8",
+        sm: "h-8 rounded-sm px-3 text-xs",
+        lg: "h-10 rounded-sm px-8",
         icon: "h-9 w-9",
       },
     },

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/30 backdrop-blur-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -34,7 +34,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-surface-raised p-6 shadow-2xl shadow-black/40 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-xl",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border/15 bg-surface-raised p-6 shadow-[0_24px_40px_hsl(var(--text-primary)/0.05)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-sm",
         className
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-lg border border-border bg-surface-raised px-3 py-1 text-sm text-text-primary shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:border-accent/50 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-9 w-full rounded-none border-0 border-b-2 border-b-border/60 bg-transparent px-3 py-1 text-sm text-text-primary transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-text-muted focus-visible:outline-none focus-visible:border-b-accent focus-visible:bg-surface-overlay/40 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- **Buttons**: Keycap style — `rounded-sm`, 2px bottom shadow, gradient primary, uppercase tracking, snappy 200ms transitions
- **Inputs**: Underline-only style — bottom border with outline token, focus shifts background instead of ring
- **Badges**: Stamp chip style — `rounded-none` (square), ghost border at 15% opacity, uppercase tracking
- **Glass cards**: Ghost border (15% opacity), ambient shadows (24px blur, 5% tinted), reduced border-radius
- **Dialog/Modal**: Semi-transparent backdrop with `backdrop-blur-md`, ambient tinted shadow, ghost border
- **Coaching cards**: New `.coaching-card-intense` and `.coaching-card-positive` utility classes for Annie's feedback
- **Tag pills**: Restyled from rounded pills to square stamp chips with ghost borders

All changes are styling-only — no component API or prop changes. Both light and dark modes supported.

Part of #206, fixes #210

## Test plan
- [x] `npx tsc --noEmit` passes (pre-existing unrelated errors only)
- [x] Screenshot tests: 6/6 passing tests updated, 6 pre-existing failures (project editor/focus mode timeout — same on master)
- [ ] Visual check: verify buttons, inputs, badges, cards, dialogs render correctly in both themes

Generated with [Claude Code](https://claude.com/claude-code)