### PR TITLE
feat: Editorial Cabin reader view + manuscript progress redesign

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -385,16 +385,17 @@
   pointer-events: none;
 }
 
-/* Reader view prose */
+/* Reader view prose — Editorial Cabin manuscript feel */
 .reader-prose {
   font-family: 'Newsreader', Georgia, Cambria, serif;
-  font-size: 1.125rem;
-  line-height: 1.75;
-  color: hsl(var(--text-primary));
+  font-size: 1.25rem;
+  line-height: 1.7;
+  font-weight: 300;
+  color: hsl(var(--text-primary) / 0.9);
 }
 
 .reader-prose p {
-  margin-bottom: 0.875rem;
+  margin-bottom: 1.5rem;
   text-indent: 1.5em;
 }
 
@@ -430,11 +431,12 @@
 }
 
 .reader-prose blockquote {
-  border-left: 3px solid hsl(var(--accent) / 0.4);
-  padding-left: 1.25rem;
-  margin: 1.25rem 0;
-  color: hsl(var(--text-secondary));
+  border-left: 2px solid hsl(var(--accent) / 0.2);
+  padding-left: 2rem;
+  margin: 2.5rem 0;
+  color: hsl(var(--text-primary) / 0.7);
   font-style: italic;
+  font-weight: 400;
 }
 
 .reader-prose blockquote p {
@@ -474,8 +476,15 @@
 
 @media (min-width: 640px) {
   .reader-prose {
-    font-size: 1.1875rem;
-    line-height: 1.8;
+    font-size: 1.375rem;
+    line-height: 1.7;
+  }
+}
+
+@media (min-width: 768px) {
+  .reader-prose {
+    font-size: 1.5rem;
+    line-height: 1.7;
   }
 }
 

--- a/src/app/project/[id]/progress/page.tsx
+++ b/src/app/project/[id]/progress/page.tsx
@@ -2,26 +2,13 @@
 
 import { useEffect, useState, use } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, BookOpen, CheckCircle2, FileText, TrendingUp, Play } from "lucide-react";
+import { ArrowLeft, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { UserMenu } from "@/components/user-menu";
+import { WritingHeatmap } from "@/components/writing-heatmap";
 import type { ProjectProgress } from "@/lib/controllers/progress";
-
-const STATUS_COLORS = {
-  FINAL: "bg-success",
-  REVISED: "bg-blue-500",
-  DRAFT: "bg-amber-400",
-  OUTLINE: "bg-surface-overlay",
-} as const;
-
-const STATUS_LABELS = {
-  FINAL: "Final",
-  REVISED: "Revised",
-  DRAFT: "Draft",
-  OUTLINE: "Outline",
-} as const;
 
 function formatWords(n: number) {
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
@@ -30,31 +17,17 @@ function formatWords(n: number) {
 
 function ProgressBar({ part }: { part: ProjectProgress["parts"][0] }) {
   const total = part.totalScenes;
-  if (total === 0) return <div className="h-2 rounded-full bg-surface-overlay w-full" />;
+  if (total === 0) return <div className="h-3 bg-surface-overlay w-full" />;
+
+  const pct =
+    ((part.finalScenes + part.revisedScenes + part.draftedScenes) / total) * 100;
 
   return (
-    <div className="h-2 rounded-full bg-surface-overlay w-full overflow-hidden flex">
-      {part.finalScenes > 0 && (
-        <div
-          className="h-full bg-success transition-all"
-          style={{ width: `${(part.finalScenes / total) * 100}%` }}
-          title={`${part.finalScenes} Final`}
-        />
-      )}
-      {part.revisedScenes > 0 && (
-        <div
-          className="h-full bg-blue-500 transition-all"
-          style={{ width: `${(part.revisedScenes / total) * 100}%` }}
-          title={`${part.revisedScenes} Revised`}
-        />
-      )}
-      {part.draftedScenes > 0 && (
-        <div
-          className="h-full bg-amber-400 transition-all"
-          style={{ width: `${(part.draftedScenes / total) * 100}%` }}
-          title={`${part.draftedScenes} Draft`}
-        />
-      )}
+    <div className="h-3 bg-surface-overlay w-full relative overflow-hidden">
+      <div
+        className="absolute inset-y-0 left-0 bg-accent transition-all"
+        style={{ width: `${pct}%` }}
+      />
     </div>
   );
 }
@@ -86,7 +59,7 @@ export default function ProgressPage({ params }: { params: Promise<{ id: string 
     : 0;
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col h-screen bg-surface">
       <div className="h-0.5 accent-gradient flex-shrink-0" />
 
       {/* Header */}
@@ -114,144 +87,161 @@ export default function ProgressPage({ params }: { params: Promise<{ id: string 
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto">
-        <div className="max-w-3xl mx-auto px-6 py-10">
+        <div className="max-w-5xl mx-auto px-6 md:px-16 lg:px-24 py-10 md:py-12">
           {loading ? (
             <div className="space-y-6 animate-pulse">
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-                {[...Array(4)].map((_, i) => (
-                  <div key={i} className="glass-card p-5 h-24 bg-surface-overlay rounded-xl" />
-                ))}
-              </div>
+              <div className="h-16 bg-surface-overlay rounded w-2/3" />
               <div className="space-y-3">
                 {[...Array(3)].map((_, i) => (
-                  <div key={i} className="glass-card p-4 h-16 bg-surface-overlay rounded-xl" />
+                  <div key={i} className="h-16 bg-surface-overlay rounded" />
                 ))}
               </div>
             </div>
           ) : !progress ? null : (
-            <div className="space-y-8 animate-fade-in">
-              {/* Summary cards */}
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-                <div className="glass-card p-5">
-                  <div className="flex items-center gap-2 mb-2">
-                    <FileText className="h-4 w-4 text-accent" />
-                    <span className="text-xs text-text-muted uppercase tracking-wide">Words</span>
-                  </div>
-                  <p className="text-2xl font-bold text-text-primary tabular-nums">
-                    {formatWords(progress.totalWords)}
-                  </p>
-                </div>
-                <div className="glass-card p-5">
-                  <div className="flex items-center gap-2 mb-2">
-                    <BookOpen className="h-4 w-4 text-accent" />
-                    <span className="text-xs text-text-muted uppercase tracking-wide">Scenes</span>
-                  </div>
-                  <p className="text-2xl font-bold text-text-primary tabular-nums">
-                    {doneScenes}
-                    <span className="text-base text-text-muted font-normal">/{progress.totalScenes}</span>
-                  </p>
-                </div>
-                <div className="glass-card p-5">
-                  <div className="flex items-center gap-2 mb-2">
-                    <TrendingUp className="h-4 w-4 text-accent" />
-                    <span className="text-xs text-text-muted uppercase tracking-wide">Progress</span>
-                  </div>
-                  <p className="text-2xl font-bold text-text-primary tabular-nums">{pctDone}%</p>
-                </div>
-                <div className="glass-card p-5">
-                  <div className="flex items-center gap-2 mb-2">
-                    <CheckCircle2 className="h-4 w-4 text-success" />
-                    <span className="text-xs text-text-muted uppercase tracking-wide">Final</span>
-                  </div>
-                  <p className="text-2xl font-bold text-text-primary tabular-nums">
-                    {progress.finalScenes}
-                  </p>
-                </div>
-              </div>
+            <div className="animate-fade-in">
+              {/* Manuscript Progress headline */}
+              <header className="mb-14 space-y-3">
+                <h1 className="display-lg italic font-bold tracking-tight text-text-primary">
+                  Manuscript Progress
+                </h1>
+                <p className="label-md text-[11px] tracking-[0.2em] text-text-muted font-semibold">
+                  {projectTitle ? `Project: ${projectTitle}` : ""}
+                </p>
+              </header>
 
-              {/* Status legend */}
-              <div className="flex items-center gap-4 flex-wrap">
-                {(["FINAL", "REVISED", "DRAFT", "OUTLINE"] as const).map((s) => (
-                  <div key={s} className="flex items-center gap-1.5 text-xs text-text-muted">
-                    <div className={`h-2 w-4 rounded-full ${STATUS_COLORS[s]}`} />
-                    {STATUS_LABELS[s]}
-                  </div>
-                ))}
-              </div>
-
-              {/* Part-by-part breakdown */}
-              {progress.parts.length > 0 && (
-                <div className="space-y-4">
-                  <h2 className="text-sm font-semibold text-text-secondary uppercase tracking-wide">
-                    By {progress.parts[0]?.type === "PART" ? "Part" : "Chapter"}
-                  </h2>
-                  <div className="space-y-3">
-                    {progress.parts.map((part) => (
-                      <div key={part.id} className="glass-card p-4">
-                        <div className="flex items-center justify-between mb-2">
-                          <span className="font-medium text-text-primary text-sm">{part.title}</span>
-                          <span className="text-xs text-text-muted tabular-nums">
-                            {part.finalScenes + part.revisedScenes + part.draftedScenes}/
-                            {part.totalScenes} scenes · {formatWords(part.totalWords)} words
-                          </span>
-                        </div>
-                        <ProgressBar part={part} />
+              <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-14 items-start">
+                {/* Left column: progress bars + heatmap */}
+                <div className="lg:col-span-8 space-y-14">
+                  {/* Parts & Chapters section */}
+                  {progress.parts.length > 0 && (
+                    <section className="space-y-8">
+                      <div className="flex justify-between items-end border-b border-border/20 pb-4">
+                        <h3 className="font-editorial text-2xl font-semibold italic text-text-primary">
+                          Parts &amp; Chapters
+                        </h3>
+                        <span className="label-md text-[10px] font-bold tracking-widest text-accent">
+                          {pctDone}% Overall Completion
+                        </span>
                       </div>
-                    ))}
-                  </div>
-                </div>
-              )}
+                      <div className="space-y-8">
+                        {progress.parts.map((part) => {
+                          const partDone =
+                            part.finalScenes + part.revisedScenes + part.draftedScenes;
+                          const partPct =
+                            part.totalScenes > 0
+                              ? Math.round((partDone / part.totalScenes) * 100)
+                              : 0;
 
-              {/* Next up */}
-              {progress.nextScene && (
-                <div className="glass-card p-5 border-accent/30">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="flex-1 min-w-0">
-                      <p className="text-xs text-accent uppercase tracking-wide font-medium mb-1">
-                        Next Up
-                      </p>
-                      <h3 className="font-semibold text-text-primary">
-                        {progress.nextScene.parentTitle
-                          ? `${progress.nextScene.parentTitle} / `
-                          : ""}
-                        {progress.nextScene.title}
+                          return (
+                            <div key={part.id} className="space-y-3">
+                              <div className="flex justify-between items-center label-md text-[11px] font-bold tracking-wider text-text-primary">
+                                <span>{part.title}</span>
+                                <span>{partPct}%</span>
+                              </div>
+                              <ProgressBar part={part} />
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  )}
+
+                  {/* Writing Consistency heatmap section */}
+                  <section className="space-y-8">
+                    <div className="flex justify-between items-end border-b border-border/20 pb-4">
+                      <h3 className="font-editorial text-2xl font-semibold italic text-text-primary">
+                        Writing Consistency
                       </h3>
-                      {progress.nextScene.synopsis && (
-                        <p className="text-sm text-text-muted mt-1 line-clamp-2">
-                          {progress.nextScene.synopsis}
-                        </p>
-                      )}
-                      <span className="inline-block mt-2 text-xs px-2 py-0.5 rounded-full bg-surface-overlay text-text-muted">
-                        {STATUS_LABELS[progress.nextScene.status as keyof typeof STATUS_LABELS] ??
-                          progress.nextScene.status}
-                      </span>
+                      <div className="flex gap-2 items-center">
+                        <span className="label-md text-[9px] tracking-widest text-text-muted">Less</span>
+                        <div className="flex gap-1">
+                          <div className="w-3 h-3 bg-surface-overlay" />
+                          <div className="w-3 h-3 bg-accent/30" />
+                          <div className="w-3 h-3 bg-accent/60" />
+                          <div className="w-3 h-3 bg-accent" />
+                        </div>
+                        <span className="label-md text-[9px] tracking-widest text-text-muted">More</span>
+                      </div>
                     </div>
-                    <Button
-                      className="gap-2 shrink-0"
-                      onClick={() =>
-                        router.push(
-                          `/project/${projectId}?scene=${progress.nextScene!.id}`,
-                        )
-                      }
-                    >
-                      <Play className="h-4 w-4" />
-                      Start Writing
-                    </Button>
+                    <div className="bg-surface-overlay/50 p-6 md:p-8">
+                      <WritingHeatmap variant="embedded" />
+                    </div>
+                  </section>
+                </div>
+
+                {/* Right column: summary report */}
+                <div className="lg:col-span-4 lg:sticky lg:top-28">
+                  <section className="bg-surface-overlay/60 p-6 md:p-8 border-l-4 border-accent/20 relative">
+                    <div className="space-y-6">
+                      {/* Summary quote */}
+                      <div className="p-5 bg-surface-raised shadow-sm">
+                        <p className="font-editorial text-lg leading-relaxed text-text-primary italic">
+                          {pctDone === 100
+                            ? "Every scene is finalized. The manuscript is complete."
+                            : pctDone >= 75
+                              ? "The finish line is in sight. Keep the momentum going."
+                              : pctDone >= 50
+                                ? "Halfway there. The hardest part is behind you."
+                                : pctDone > 0
+                                  ? "The journey has begun. Stay consistent and the words will come."
+                                  : "Open a scene and start writing. The blank page awaits."
+                          }
+                        </p>
+                      </div>
+
+                      {/* Stats grid */}
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="p-4 bg-accent-muted">
+                          <p className="label-md text-[9px] font-bold tracking-widest text-accent opacity-80 mb-1">
+                            Total Words
+                          </p>
+                          <p className="font-editorial text-2xl font-bold text-accent">
+                            {formatWords(progress.totalWords)}
+                          </p>
+                        </div>
+                        <div className="p-4 bg-surface-sunken">
+                          <p className="label-md text-[9px] font-bold tracking-widest text-text-primary opacity-60 mb-1">
+                            Scenes Done
+                          </p>
+                          <p className="font-editorial text-2xl font-bold text-text-primary">
+                            {doneScenes}/{progress.totalScenes}
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Resume Writing CTA */}
+                      {progress.nextScene && (
+                        <div className="pt-4">
+                          <Button
+                            className="w-full gap-2 py-5 label-md text-[11px] font-bold tracking-[0.2em] shadow-[4px_4px_0px_hsl(var(--accent))] hover:translate-y-[-2px] hover:shadow-[6px_6px_0px_hsl(var(--accent))] transition-all"
+                            onClick={() =>
+                              router.push(
+                                `/project/${projectId}?scene=${progress.nextScene!.id}`,
+                              )
+                            }
+                          >
+                            <Play className="h-4 w-4" />
+                            Resume Writing
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  </section>
+
+                  {/* Stamp chips (metadata) */}
+                  <div className="mt-6 flex flex-wrap gap-2">
+                    <span className="stamp-chip">
+                      {formatWords(progress.totalWords)} total words
+                    </span>
+                    <span className="stamp-chip">
+                      {progress.parts.length} {progress.parts.length === 1 ? "part" : "parts"}
+                    </span>
+                    <span className="stamp-chip">
+                      {progress.totalScenes} scenes
+                    </span>
                   </div>
                 </div>
-              )}
-
-              {progress.totalScenes > 0 && progress.finalScenes === progress.totalScenes && (
-                <div className="text-center py-8">
-                  <CheckCircle2 className="h-12 w-12 text-success mx-auto mb-3" />
-                  <h3 className="text-lg font-semibold text-text-primary">
-                    All scenes finalized!
-                  </h3>
-                  <p className="text-text-muted mt-1">
-                    Every scene is marked as final. Great work.
-                  </p>
-                </div>
-              )}
+              </div>
             </div>
           )}
         </div>

--- a/src/app/read/[id]/reader-view.tsx
+++ b/src/app/read/[id]/reader-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { List, X as XIcon } from "lucide-react";
+import { List, X as XIcon, BookOpen, Clock, ArrowLeft } from "lucide-react";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
 
@@ -44,6 +44,11 @@ function countWords(outline: OutlineNode[]): number {
     count += countWords(node.children);
   }
   return count;
+}
+
+/** Estimate reading time in minutes (~250 wpm) */
+function estimateReadingTime(words: number): number {
+  return Math.max(1, Math.round(words / 250));
 }
 
 /** Collect chapters for TOC */
@@ -93,24 +98,29 @@ function SceneContent({ content }: { content: string }) {
 function ManuscriptNode({
   node,
   chapterCounter,
+  isFirst,
 }: {
   node: OutlineNode;
   chapterCounter: { value: number };
+  isFirst?: boolean;
 }) {
   if (node.type === "PART") {
     return (
-      <section id={node.id} className="mt-16 mb-8 first:mt-8">
-        <h2 className="font-sans text-3xl sm:text-4xl font-bold text-text-primary text-center tracking-tight mb-2">
+      <section id={node.id} className="mt-24 mb-12 first:mt-8">
+        <h2 className="font-editorial text-3xl sm:text-4xl font-bold text-text-primary text-center tracking-tight mb-2">
           {node.title}
         </h2>
-        <div className="flex justify-center my-6">
-          <div className="w-16 h-px bg-border" />
+        <div className="flex justify-center items-center gap-3 my-8">
+          <div className="h-px w-8 bg-border/40" />
+          <BookOpen className="h-3.5 w-3.5 text-text-muted/40" />
+          <div className="h-px w-8 bg-border/40" />
         </div>
-        {node.children.map((child) => (
+        {node.children.map((child, i) => (
           <ManuscriptNode
             key={child.id}
             node={child}
             chapterCounter={chapterCounter}
+            isFirst={i === 0 && isFirst}
           />
         ))}
       </section>
@@ -125,21 +135,26 @@ function ManuscriptNode({
     );
 
     return (
-      <section id={node.id} className="mt-12 mb-8">
-        <h3 className="font-sans text-xl sm:text-2xl font-semibold text-text-primary text-center tracking-tight mb-1">
-          <span className="block text-sm font-normal text-text-muted uppercase tracking-widest mb-1">
+      <section id={node.id} className="mt-20 mb-12">
+        {/* Chapter start typography */}
+        <div className="text-center mb-16">
+          <span className="label-md text-text-muted tracking-[0.3em] block mb-4">
             Chapter {chapterCounter.value}
           </span>
-          {node.title}
-        </h3>
-        <div className="flex justify-center my-6">
-          <div className="w-8 h-px bg-border" />
+          <h3 className="display-lg italic font-extralight tracking-tight text-text-primary leading-tight">
+            {node.title}
+          </h3>
+          <div className="flex justify-center items-center gap-3 mt-10">
+            <div className="h-px w-8 bg-border/40" />
+            <BookOpen className="h-3.5 w-3.5 text-text-muted/40" />
+            <div className="h-px w-8 bg-border/40" />
+          </div>
         </div>
         {hasAnyContent ? (
           scenes.map((scene, i) => (
             <div key={scene.id}>
               {i > 0 && scene.content && scene.content !== "<p></p>" && (
-                <div className="flex justify-center my-8">
+                <div className="flex justify-center my-10">
                   <span className="text-text-muted tracking-[0.5em] text-sm select-none">
                     * * *
                   </span>
@@ -173,6 +188,7 @@ export function ReaderView({ project, outline }: ReaderViewProps) {
   const [tocOpen, setTocOpen] = useState(false);
   const tocEntries = collectTocEntries(outline);
   const wordCount = countWords(outline);
+  const readingTime = estimateReadingTime(wordCount);
   const chapterCounter = { value: 0 };
 
   const handleTocClick = (id: string) => {
@@ -184,31 +200,50 @@ export function ReaderView({ project, outline }: ReaderViewProps) {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Top accent line */}
-      <div className="h-0.5 accent-gradient" />
-
-      {/* Floating controls */}
-      <div className="fixed top-3 right-3 z-50 flex items-center gap-1.5">
-        <ThemeToggle />
-        {tocEntries.length > 0 && (
-          <button
-            onClick={() => setTocOpen(!tocOpen)}
-            className={cn(
-              "h-9 w-9 rounded-lg flex items-center justify-center transition-colors",
-              "bg-surface-raised border border-border shadow-sm",
-              "hover:bg-surface-overlay text-text-secondary hover:text-text-primary"
+    <div className="min-h-screen bg-surface">
+      {/* Translucent top bar */}
+      <header className="fixed top-0 left-0 w-full z-40 bg-surface/40 backdrop-blur-sm transition-all duration-300">
+        <div className="flex justify-between items-center w-full px-6 md:px-8 py-4 max-w-full mx-auto">
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => window.history.back()}
+              className="p-2 text-text-primary hover:bg-surface-overlay rounded-full transition-colors duration-150 active:scale-95"
+              aria-label="Go back"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </button>
+            <div className="hidden md:block">
+              <h1 className="text-lg font-editorial italic font-bold text-text-primary leading-none tracking-tight">Annie</h1>
+              <p className="label-md text-[10px] text-text-muted opacity-60">Reader Mode</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-4 md:gap-6">
+            {wordCount > 0 && (
+              <div className="flex items-center gap-2 label-md text-[10px] font-bold tracking-wider text-text-muted">
+                <Clock className="h-3.5 w-3.5" />
+                <span>{readingTime}m read</span>
+              </div>
             )}
-            aria-label="Table of contents"
-          >
-            {tocOpen ? (
-              <XIcon className="h-4 w-4" />
-            ) : (
-              <List className="h-4 w-4" />
+            <ThemeToggle />
+            {tocEntries.length > 0 && (
+              <button
+                onClick={() => setTocOpen(!tocOpen)}
+                className={cn(
+                  "h-9 w-9 rounded-full flex items-center justify-center transition-colors",
+                  "hover:bg-surface-overlay text-text-secondary hover:text-text-primary"
+                )}
+                aria-label="Table of contents"
+              >
+                {tocOpen ? (
+                  <XIcon className="h-4 w-4" />
+                ) : (
+                  <List className="h-4 w-4" />
+                )}
+              </button>
             )}
-          </button>
-        )}
-      </div>
+          </div>
+        </div>
+      </header>
 
       {/* Table of contents drawer */}
       {tocOpen && (
@@ -217,10 +252,10 @@ export function ReaderView({ project, outline }: ReaderViewProps) {
             className="fixed inset-0 z-40 bg-background/60 backdrop-blur-sm animate-fade-in"
             onClick={() => setTocOpen(false)}
           />
-          <nav className="fixed top-0 right-0 z-50 h-full w-80 max-w-[85vw] bg-surface-raised border-l border-border shadow-2xl overflow-y-auto animate-slide-in-right">
+          <nav className="fixed top-0 right-0 z-50 h-full w-80 max-w-[85vw] bg-surface-raised border-l border-border/15 shadow-2xl overflow-y-auto animate-slide-in-right">
             <div className="p-6">
               <div className="flex items-center justify-between mb-6">
-                <h2 className="font-sans text-sm font-semibold uppercase tracking-wider text-text-muted">
+                <h2 className="label-md text-text-muted">
                   Contents
                 </h2>
                 <button
@@ -253,65 +288,101 @@ export function ReaderView({ project, outline }: ReaderViewProps) {
         </>
       )}
 
-      {/* Title page */}
-      <header className="pt-16 pb-12 sm:pt-24 sm:pb-16 px-4">
-        <div className="max-w-[700px] mx-auto text-center">
-          <h1 className="font-serif text-4xl sm:text-5xl font-bold text-text-primary leading-tight tracking-tight mb-4">
+      {/* Main manuscript canvas */}
+      <main className="relative pt-32 pb-64 px-6 md:px-0 max-w-2xl mx-auto">
+        {/* Title page */}
+        <section className="mb-24 text-center">
+          <span className="label-md text-[10px] tracking-[0.3em] text-text-muted block mb-4">
+            {project.author ? `by ${project.author}` : "A Manuscript"}
+          </span>
+          <h2 className="font-editorial text-5xl md:text-6xl italic font-extralight tracking-tight text-text-primary leading-tight">
             {project.title}
-          </h1>
-          {project.author && (
-            <p className="text-lg text-text-secondary mb-2">
-              by {project.author}
-            </p>
-          )}
-          {project.genre && (
-            <span className="tag-pill">{project.genre}</span>
-          )}
-          {wordCount > 0 && (
-            <p className="text-sm text-text-muted mt-4">
-              {wordCount.toLocaleString()} words
-            </p>
-          )}
-        </div>
-      </header>
+          </h2>
+          <div className="mt-12 flex justify-center items-center gap-3">
+            <div className="h-px w-8 bg-border/40" />
+            <BookOpen className="h-3.5 w-3.5 text-text-muted/40" />
+            <div className="h-px w-8 bg-border/40" />
+          </div>
+        </section>
 
-      {/* Divider */}
-      <div className="flex justify-center mb-8">
-        <div className="w-24 h-px bg-border" />
-      </div>
-
-      {/* Manuscript body */}
-      <main id="main-content" className="px-4 pb-16">
-        <article className="max-w-[700px] mx-auto">
+        {/* Manuscript body */}
+        <article className="space-y-10">
           {outline.length === 0 ? (
             <div className="text-center py-16">
-              <p className="text-text-muted italic">
+              <p className="text-text-muted italic font-editorial text-lg">
                 This manuscript has no content yet.
               </p>
             </div>
           ) : (
-            outline.map((node) => (
+            outline.map((node, i) => (
               <ManuscriptNode
                 key={node.id}
                 node={node}
                 chapterCounter={chapterCounter}
+                isFirst={i === 0}
               />
             ))
           )}
-
-          {/* End of manuscript */}
-          {outline.length > 0 && (
-            <footer className="mt-16 mb-8 text-center">
-              <div className="flex justify-center mb-6">
-                <div className="w-16 h-px bg-border" />
-              </div>
-              <p className="text-sm text-text-muted italic tracking-wide">
-                End of manuscript
-              </p>
-            </footer>
-          )}
         </article>
+
+        {/* Stamp chip footer */}
+        {outline.length > 0 && (
+          <footer className="mt-32 pt-16 border-t border-border/10 flex flex-wrap gap-4 justify-center">
+            {wordCount > 0 && (
+              <span className="stamp-chip gap-2">
+                <BookOpen className="h-3 w-3" />
+                <span>{wordCount.toLocaleString()} Words</span>
+              </span>
+            )}
+            {project.genre && (
+              <span className="stamp-chip gap-2">
+                {project.genre}
+              </span>
+            )}
+            <span className="stamp-chip gap-2 text-accent">
+              <Clock className="h-3 w-3" />
+              <span>{readingTime} min read</span>
+            </span>
+          </footer>
+        )}
       </main>
+
+      {/* Bottom navigation bar */}
+      <nav className="fixed bottom-0 left-0 w-full flex justify-between items-center px-8 md:px-12 py-3 bg-surface/80 backdrop-blur-md border-t border-border/5 z-40">
+        <div className="flex items-center gap-6 md:gap-8">
+          {tocEntries.length > 0 && (
+            <button
+              onClick={() => setTocOpen(!tocOpen)}
+              className="flex flex-col items-center gap-1 group"
+            >
+              <List className="h-4 w-4 text-text-muted group-hover:text-text-primary transition-colors" />
+              <span className="label-md text-[10px] font-bold tracking-wider text-text-muted">Outline</span>
+            </button>
+          )}
+        </div>
+        {/* Progress bar (desktop) */}
+        <div className="hidden md:flex items-center gap-4">
+          {wordCount > 0 && (
+            <>
+              <div className="w-48 h-1 bg-surface-overlay rounded-full overflow-hidden">
+                <div className="w-full h-full bg-accent rounded-full" />
+              </div>
+              <span className="label-md text-[10px] font-bold text-text-muted">
+                {wordCount.toLocaleString()} words
+              </span>
+            </>
+          )}
+        </div>
+        <div className="flex items-center gap-6 md:gap-8">
+          <button
+            onClick={() => window.history.back()}
+            className="flex flex-col items-center gap-1 group"
+          >
+            <ArrowLeft className="h-4 w-4 text-text-muted group-hover:text-text-primary transition-colors" />
+            <span className="label-md text-[10px] font-bold tracking-wider text-text-muted">Back</span>
+          </button>
+        </div>
+      </nav>
     </div>
   );
 }

--- a/src/components/writing-heatmap.tsx
+++ b/src/components/writing-heatmap.tsx
@@ -22,7 +22,12 @@ function intensityClass(intensity: number): string {
 const DAY_LABELS = ["S", "M", "T", "W", "T", "F", "S"];
 const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-export function WritingHeatmap() {
+interface WritingHeatmapProps {
+  /** "default" renders with glass-card wrapper; "embedded" renders just the grid */
+  variant?: "default" | "embedded";
+}
+
+export function WritingHeatmap({ variant = "default" }: WritingHeatmapProps) {
   const [days, setDays] = useState<HeatmapDay[]>([]);
   const [loading, setLoading] = useState(true);
   const [totalWords, setTotalWords] = useState(0);
@@ -71,6 +76,57 @@ export function WritingHeatmap() {
     }
   }
 
+  const gridContent = (
+    <div className="flex gap-1 overflow-x-auto pb-1">
+      {/* Day-of-week labels */}
+      <div className="flex flex-col gap-0.5 mr-1 shrink-0">
+        <div className="h-4" /> {/* spacer for month label row */}
+        {DAY_LABELS.map((label, i) => (
+          <div
+            key={i}
+            className={`h-[10px] w-4 text-[8px] text-text-muted flex items-center ${
+              i % 2 === 0 ? "opacity-0" : ""
+            }`}
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Weeks */}
+      {weeks.map((week, wi) => {
+        const monthLabel = monthLabels.find((m) => m.col === wi);
+        return (
+          <div key={wi} className="flex flex-col gap-0.5 shrink-0">
+            {/* Month label row */}
+            <div className="h-4 text-[9px] text-text-muted leading-4 w-[10px] whitespace-nowrap">
+              {monthLabel ? monthLabel.label : ""}
+            </div>
+            {week.map((day, di) => {
+              if (!day) {
+                return <div key={di} className="h-[10px] w-[10px] rounded-sm" />;
+              }
+              const intensity = getIntensity(day.wordsWritten);
+              return (
+                <div
+                  key={di}
+                  className={`h-[10px] w-[10px] rounded-sm transition-colors ${intensityClass(intensity)}`}
+                  title={`${day.date}: ${day.wordsWritten.toLocaleString()} words`}
+                />
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  // Embedded variant: just the grid, no wrapper
+  if (variant === "embedded") {
+    return gridContent;
+  }
+
+  // Default variant: glass-card wrapper with header
   return (
     <div className="glass-card p-5 mt-6">
       <div className="flex items-center justify-between mb-3">
@@ -81,48 +137,7 @@ export function WritingHeatmap() {
         </span>
       </div>
 
-      <div className="flex gap-1 overflow-x-auto pb-1">
-        {/* Day-of-week labels */}
-        <div className="flex flex-col gap-0.5 mr-1 shrink-0">
-          <div className="h-4" /> {/* spacer for month label row */}
-          {DAY_LABELS.map((label, i) => (
-            <div
-              key={i}
-              className={`h-[10px] w-4 text-[8px] text-text-muted flex items-center ${
-                i % 2 === 0 ? "opacity-0" : ""
-              }`}
-            >
-              {label}
-            </div>
-          ))}
-        </div>
-
-        {/* Weeks */}
-        {weeks.map((week, wi) => {
-          const monthLabel = monthLabels.find((m) => m.col === wi);
-          return (
-            <div key={wi} className="flex flex-col gap-0.5 shrink-0">
-              {/* Month label row */}
-              <div className="h-4 text-[9px] text-text-muted leading-4 w-[10px] whitespace-nowrap">
-                {monthLabel ? monthLabel.label : ""}
-              </div>
-              {week.map((day, di) => {
-                if (!day) {
-                  return <div key={di} className="h-[10px] w-[10px] rounded-sm" />;
-                }
-                const intensity = getIntensity(day.wordsWritten);
-                return (
-                  <div
-                    key={di}
-                    className={`h-[10px] w-[10px] rounded-sm transition-colors ${intensityClass(intensity)}`}
-                    title={`${day.date}: ${day.wordsWritten.toLocaleString()} words`}
-                  />
-                );
-              })}
-            </div>
-          );
-        })}
-      </div>
+      {gridContent}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Redesigns **reader view** (`/read/[id]`) with full-width Newsreader serif prose, generous manuscript margins, `display-lg` chapter start typography (3.5rem), translucent header with reading time estimate, surface-layered TOC drawer, and stamp chip metadata footer
- Redesigns **manuscript progress page** (`/project/[id]/progress`) with editorial typography headers, forest green accent progress bars, embedded writing heatmap with consistency legend, motivational summary panel with stats grid, keycap-style Resume Writing CTA, and stamp chip metadata tags
- Updates `WritingHeatmap` component to support an `embedded` variant (grid-only, no wrapper) for composition inside the progress page, maintaining backward compatibility with the home page's default variant
- Upgrades `reader-prose` CSS with larger font sizes (up to 1.5rem on desktop), generous paragraph spacing, and refined blockquote styling matching the Editorial Cabin manuscript feel

All changes use existing Phase 1+2 design tokens (`display-lg`, `label-md`, `stamp-chip`, `font-editorial`, accent colors, surface layers) without modifying the design system files.

Closes #217

## Test plan
- [ ] Open reader view (`/read/[id]`) and verify serif prose, chapter typography, translucent header, stamp chip footer
- [ ] Open progress page (`/project/[id]/progress`) and verify editorial headers, green progress bars, embedded heatmap, summary panel
- [ ] Verify dark mode renders correctly on both pages
- [ ] Verify mobile responsive layout on both pages
- [ ] Verify home page WritingHeatmap still renders unchanged (default variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)