### PR TITLE
fix: data integrity monitoring + migration safety guard

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -6,15 +6,36 @@ on:
   workflow_dispatch: # Manual trigger
 
 jobs:
-  check:
-    name: Health Check
+  check-production:
+    name: Production Health Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check health + data integrity
+        run: |
+          BODY=$(curl -s --max-time 10 https://annie.interstellarai.net/api/health)
+          STATUS=$(echo "$BODY" | jq -r '.status // "unknown"')
+          echo "Response: $BODY"
+          if [ "$STATUS" = "error" ]; then
+            echo "::error::Production health check failed — DB unreachable"
+            exit 1
+          fi
+          if [ "$STATUS" = "degraded" ]; then
+            echo "::error::Production database appears empty — possible data loss!"
+            exit 1
+          fi
+          echo "Production health check passed (status: $STATUS)"
+
+  check-staging:
+    name: Staging Health Check
     runs-on: ubuntu-latest
     steps:
       - name: Check health endpoint
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://annie.interstellarai.net/api/health)
-          if [ "$STATUS" != "200" ]; then
-            echo "::error::Health check failed with status $STATUS"
+          BODY=$(curl -s --max-time 10 https://amusing-blessing-staging.up.railway.app/api/health)
+          STATUS=$(echo "$BODY" | jq -r '.status // "unknown"')
+          echo "Response: $BODY"
+          if [ "$STATUS" = "error" ]; then
+            echo "::error::Staging health check failed — DB unreachable"
             exit 1
           fi
-          echo "Health check passed (HTTP $STATUS)"
+          echo "Staging health check passed (status: $STATUS)"

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -72,6 +72,21 @@ async function migrate() {
     const sql = readFileSync(sqlPath, 'utf-8');
     const checksum = createHash('sha256').update(sql).digest('hex');
 
+    // Safety check: refuse to run migrations that contain destructive DDL
+    // if the database already has data. This prevents accidental data loss
+    // from re-applying the init migration against a populated database.
+    const destructivePatterns = /\b(DROP\s+TABLE|TRUNCATE|DROP\s+SCHEMA)\b/i;
+    if (destructivePatterns.test(sql)) {
+      const [{ count }] = await prisma.$queryRawUnsafe(
+        `SELECT COALESCE(SUM(n_tup_ins - n_tup_del), 0)::bigint AS count FROM pg_stat_user_tables WHERE schemaname = 'public'`
+      );
+      if (count > 0) {
+        console.error(`  ABORT ${dir} — contains destructive DDL (DROP/TRUNCATE) and database has ${count} live rows`);
+        console.error(`  Refusing to run. If this is intentional, apply manually.`);
+        process.exit(1);
+      }
+    }
+
     console.log(`  apply ${dir}`);
 
     // Split into individual statements for Prisma's $executeRawUnsafe

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,26 @@
 import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
 
 export async function GET() {
-    return NextResponse.json({ status: "ok" });
+    // Quick data integrity check — ensure core tables have data.
+    // If all rows disappeared, something catastrophic happened (bad migration, etc.).
+    try {
+        const [projects, users] = await Promise.all([
+            prisma.project.count(),
+            prisma.user.count(),
+        ]);
+
+        const dataOk = projects > 0 || users > 0;
+
+        return NextResponse.json({
+            status: dataOk ? "ok" : "degraded",
+            db: { projects, users },
+            ...(!dataOk && { warning: "Database appears empty — possible data loss" }),
+        });
+    } catch (e) {
+        return NextResponse.json(
+            { status: "error", error: e instanceof Error ? e.message : "DB unreachable" },
+            { status: 503 }
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Post-mortem from the data loss incident on 2026-03-29.

### Changes
- **Health endpoint** (`/api/health`) now queries `Project` and `User` counts. Returns `"degraded"` if DB is empty, `"error"` if DB is unreachable
- **Uptime monitor** checks response body for degraded/error status on both production and staging — alerts on data loss, not just downtime
- **Migration runner** refuses to apply migrations containing `DROP TABLE` or `TRUNCATE` when the database has live rows — prevents accidental wipes

### What this would have caught
- The empty database would have triggered "degraded" status within 5 minutes
- If the init migration was re-applied with a DROP, the safety guard would have aborted

## Test plan
- [ ] Health endpoint returns `{"status":"ok","db":{"projects":5,"users":1}}`
- [ ] Uptime monitor runs for both prod and staging
- [ ] Migration runner with destructive DDL against populated DB → aborts

🤖 Generated with [Claude Code](https://claude.com/claude-code)