### PR TITLE
fix: CRITICAL — prevent tests from running against production database

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "db:migrate": "prisma migrate dev",
-    "db:push": "prisma db push",
     "db:studio": "prisma studio",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",

--- a/src/__tests__/globalSetup.ts
+++ b/src/__tests__/globalSetup.ts
@@ -2,13 +2,27 @@ import { execSync } from "child_process";
 
 /**
  * Vitest global setup: ensure the test database schema exists.
- * Safe for test DBs only — production uses hand-written migrations.
+ * SAFETY: Only uses TEST_DATABASE_URL — never falls back to DATABASE_URL
+ * to prevent accidentally running db push against production.
  */
 export function setup() {
-  const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL;
+  const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL;
   if (!TEST_DATABASE_URL) {
-    throw new Error("TEST_DATABASE_URL or DATABASE_URL must be set for tests");
+    throw new Error(
+      "TEST_DATABASE_URL must be set for tests. " +
+      "This intentionally does NOT fall back to DATABASE_URL to prevent destroying production data. " +
+      "Set TEST_DATABASE_URL to a local/test PostgreSQL instance."
+    );
   }
+
+  // Refuse to run against anything that looks like a production database
+  if (TEST_DATABASE_URL.includes("supabase.com") || TEST_DATABASE_URL.includes("pooler.supabase.com")) {
+    throw new Error(
+      "TEST_DATABASE_URL points to Supabase — refusing to run tests against a production-like database. " +
+      "Use a local PostgreSQL instance for tests."
+    );
+  }
+
   execSync("npx prisma db push --accept-data-loss --url " + JSON.stringify(TEST_DATABASE_URL), {
     env: { ...process.env, DATABASE_URL: TEST_DATABASE_URL, DIRECT_DATABASE_URL: TEST_DATABASE_URL },
     stdio: "inherit",

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -13,10 +13,19 @@ vi.mock("@sentry/nextjs", () => ({
   captureRequestError: vi.fn(),
 }));
 
-// Use a separate test database — set TEST_DATABASE_URL to override.
-const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL;
+// SAFETY: Only use TEST_DATABASE_URL — never fall back to DATABASE_URL.
+// Falling back to DATABASE_URL destroyed production data when agents ran tests
+// in worktrees that had .env.local with the production connection string.
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL;
 if (!TEST_DATABASE_URL) {
-  throw new Error("TEST_DATABASE_URL or DATABASE_URL must be set for tests");
+  throw new Error(
+    "TEST_DATABASE_URL must be set for tests. " +
+    "This intentionally does NOT fall back to DATABASE_URL to prevent destroying production data."
+  );
+}
+
+if (TEST_DATABASE_URL.includes("supabase.com") || TEST_DATABASE_URL.includes("pooler.supabase.com")) {
+  throw new Error("TEST_DATABASE_URL points to Supabase — refusing to run tests against production.");
 }
 
 process.env.DATABASE_URL = TEST_DATABASE_URL;


### PR DESCRIPTION
## Summary
- **Remove DATABASE_URL fallback** in test setup files — `TEST_DATABASE_URL` is now required, never falls back to production
- **Reject Supabase URLs** in both `globalSetup.ts` and `setup.ts` — refuses to run tests against anything that looks like production
- **Remove dangerous npm scripts** (`db:push`, `db:migrate`) from package.json that could accidentally hit production

## Root Cause
Agents running tests in worktrees with `.env.local` containing the production `DATABASE_URL` caused `prisma db push --accept-data-loss` to execute against the live Supabase database, **destroying all production data twice**.

## Test plan
- [ ] CI passes (tests require TEST_DATABASE_URL, CI provides it via postgres service)
- [ ] Verify `npm run test` fails without TEST_DATABASE_URL set
- [ ] Verify test setup rejects Supabase URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)