### PR TITLE
ci: add E2E integration tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,77 @@ jobs:
       - name: Test
         run: ./scripts/gates.sh test
 
+  e2e:
+    name: E2E Integration Tests
+    runs-on: ubuntu-latest
+    needs: [test]
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: annie_test
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/annie_test
+      API_TOKEN: e2e-ci-token
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
+      - name: Push database schema
+        run: npx prisma db push --accept-data-loss
+
+      - name: Build Next.js
+        run: npm run build
+
+      - name: Start server and run E2E tests
+        run: |
+          npm start &
+          # Wait for server to be ready
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:3000/api/health && break
+            sleep 2
+          done
+          npx playwright test e2e/integration.spec.ts --project=integration
+        env:
+          BASE_URL: http://localhost:3000
+          PORT: 3000
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `e2e` job to `.github/workflows/ci.yml` that runs after unit tests pass
- Spins up PostgreSQL 16, pushes Prisma schema, builds Next.js, starts the server on port 3000, then runs `e2e/integration.spec.ts` with the `integration` Playwright project
- Uses `API_TOKEN` auth (no user record needed -- API_TOKEN mode bypasses user scoping)
- Sets `BASE_URL` so Playwright's `webServer` block is skipped (avoids double server)
- Uploads Playwright report as artifact on failure

Part of #251

## Test plan
- [ ] CI runs the new `e2e` job on this PR
- [ ] Health check, project CRUD, content authoring, story objects, and dashboard tests all pass against localhost
- [ ] Existing lint, typecheck, test, and build jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)