### PR TITLE
feat: MCP-first coaching — move all AI intelligence into tools and prompts (wca-wmi)

### DIFF
--- a/src/app/api/ai-manuscript/route.ts
+++ b/src/app/api/ai-manuscript/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
 import { getAiConfig } from "@/lib/ai/settings";
 import { getCurrentUserId } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
+import { getManuscriptContext } from "@/mcp/tools/coaching";
 import OpenAI from "openai";
 
 export type ManuscriptAnalysisType =
@@ -10,81 +10,7 @@ export type ManuscriptAnalysisType =
   | "character-arcs"
   | "consistency-check";
 
-async function buildManuscriptContext(projectId: string) {
-  const [project, nodes, storyObjects, relationships] = await Promise.all([
-    prisma.project.findUnique({ where: { id: projectId } }),
-    prisma.structureNode.findMany({
-      where: { projectId },
-      orderBy: { orderIndex: "asc" },
-      include: {
-        contentVersions: {
-          orderBy: { createdAt: "desc" },
-          take: 1,
-          select: { content: true, wordCount: true },
-        },
-      },
-    }),
-    prisma.storyObject.findMany({
-      where: { projectId },
-      select: { id: true, type: true, name: true, description: true, role: true },
-    }),
-    prisma.relationship.findMany({
-      where: {
-        OR: [
-          { fromObject: { projectId } },
-          { toObject: { projectId } },
-        ],
-      },
-      include: {
-        fromObject: { select: { name: true, type: true } },
-        toObject: { select: { name: true, type: true } },
-      },
-      take: 30,
-    }),
-  ]);
-
-  if (!project) throw new Error("Project not found");
-
-  const chapters = nodes.filter((n) => n.type === "CHAPTER");
-  const scenes = nodes.filter((n) => n.type === "SCENE");
-
-  const outlineWithContent = chapters
-    .map((ch) => {
-      const chScenes = scenes
-        .filter((s) => s.parentId === ch.id)
-        .map((s) => {
-          const content = s.contentVersions[0]?.content || "";
-          const preview = content
-            .replace(/<[^>]+>/g, " ")
-            .replace(/\s+/g, " ")
-            .trim()
-            .slice(0, 300);
-          return `    Scene: ${s.title} [${s.status}]${s.synopsis ? ` — ${s.synopsis}` : ""}${preview ? `\n      Content preview: ${preview}...` : ""}`;
-        })
-        .join("\n");
-      return `Chapter: ${ch.title}${ch.synopsis ? ` — ${ch.synopsis}` : ""}\n${chScenes}`;
-    })
-    .join("\n\n");
-
-  const characters = storyObjects
-    .filter((o) => o.type === "CHARACTER")
-    .map((o) => `${o.name}${o.role ? ` (${o.role})` : ""}${o.description ? `: ${o.description.slice(0, 200)}` : ""}`)
-    .join("\n");
-
-  const plotlines = storyObjects
-    .filter((o) => o.type === "PLOTLINE")
-    .map((o) => `${o.name}${o.description ? `: ${o.description.slice(0, 200)}` : ""}`)
-    .join("\n");
-
-  const relationshipsText = relationships
-    .filter((r) => r.fromObject && r.toObject)
-    .map((r) => `${r.fromObject!.name} → ${r.toObject!.name}: ${r.type}`)
-    .join("\n");
-
-  return { project, outlineWithContent, characters, plotlines, relationships: relationshipsText };
-}
-
-const ANALYSIS_PROMPTS: Record<ManuscriptAnalysisType, (ctx: Awaited<ReturnType<typeof buildManuscriptContext>>) => string> = {
+const ANALYSIS_PROMPTS: Record<ManuscriptAnalysisType, (ctx: Awaited<ReturnType<typeof getManuscriptContext>>) => string> = {
   "plot-threads": ({ project, outlineWithContent, plotlines }) => `Analyze the plot threads in "${project.title}". Based on the manuscript structure below, identify:
 1. **Active threads** — which plot lines are introduced and developed
 2. **Dormant threads** — threads introduced but not recently advanced
@@ -129,7 +55,11 @@ ${outlineWithContent || "(No scenes yet)"}
 Format as a structured report. List specific potential issues with scene references where possible. If no issues are found in a category, say so briefly. Be honest but constructive.`,
 };
 
-// POST /api/ai-manuscript — run manuscript-level analysis
+/**
+ * POST /api/ai-manuscript — run manuscript-level analysis
+ *
+ * Uses shared manuscript context from MCP coaching module.
+ */
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
@@ -159,7 +89,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unknown analysis type" }, { status: 400 });
     }
 
-    const ctx = await buildManuscriptContext(projectId);
+    const ctx = await getManuscriptContext(projectId);
     const prompt = promptFn(ctx);
 
     const client = new OpenAI({

--- a/src/app/api/focus/[sceneId]/route.ts
+++ b/src/app/api/focus/[sceneId]/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { FocusController } from "@/lib/controllers/focus";
 import { getCurrentUserId, verifyProjectAccessByNode } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
+import { getSceneFocus } from "@/mcp/tools/coaching";
 
+/**
+ * GET /api/focus/[sceneId]
+ *
+ * Returns scene context, related elements, and annotations.
+ * Thin wrapper around MCP tool implementation.
+ */
 export async function GET(
     request: NextRequest,
     { params }: { params: Promise<{ sceneId: string }> }
@@ -15,13 +21,30 @@ export async function GET(
         const access = await verifyProjectAccessByNode(sceneId, userId);
         if (!access.authorized) return access.response;
 
-        const context = await FocusController.getSceneContext(sceneId);
-        const related = await FocusController.getRelatedElements(sceneId);
-        const annotations = await FocusController.getAnnotations(sceneId);
+        const result = await getSceneFocus(sceneId);
 
-        return NextResponse.json({ context, related, annotations });
+        // Reshape to match the original API contract
+        return NextResponse.json({
+            context: result.scene,
+            related: groupByType(result.relatedElements),
+            annotations: result.annotations,
+        });
     } catch (error) {
         logger.error("Focus API error", error);
         return new NextResponse("Internal Server Error", { status: 500 });
     }
+}
+
+function groupByType(elements: { type: string }[]): Record<string, typeof elements> {
+    const grouped: Record<string, typeof elements> = {
+        CHARACTER: [],
+        LOCATION: [],
+        PLOTLINE: [],
+        WORLD_ELEMENT: [],
+        NOTE: [],
+    };
+    for (const el of elements) {
+        if (grouped[el.type]) grouped[el.type].push(el);
+    }
+    return grouped;
 }

--- a/src/app/api/projects/[id]/consistency-check/route.ts
+++ b/src/app/api/projects/[id]/consistency-check/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
 import { getAiConfig } from "@/lib/ai/settings";
+import { getConsistencyContext } from "@/mcp/tools/coaching";
 import OpenAI from "openai";
 
 export interface ConsistencyAlert {
@@ -10,13 +10,10 @@ export interface ConsistencyAlert {
   type: "CHARACTER_ATTRIBUTE" | "PLOT_CONTRADICTION" | "TIMELINE" | "OTHER";
   severity: "high" | "medium" | "low";
   description: string;
-  /** Scene where contradiction was found */
   sceneId: string;
   sceneTitle: string;
-  /** Scene where the original (conflicting) information lives */
   sourceSceneId?: string;
   sourceSceneTitle?: string;
-  /** The object (character, location, etc.) involved */
   objectName?: string;
   dismissed?: boolean;
 }
@@ -25,8 +22,7 @@ export interface ConsistencyAlert {
  * POST /api/projects/[id]/consistency-check
  *
  * Runs an AI consistency analysis on the project.
- * Body: { sceneId?: string }  — if provided, focus on that scene
- * Returns: { alerts: ConsistencyAlert[] }
+ * Uses shared context from MCP coaching module.
  */
 export async function POST(
   request: NextRequest,
@@ -46,66 +42,9 @@ export async function POST(
   }
 
   try {
-    // Load project data for analysis
-    const project = await prisma.project.findUnique({
-      where: { id: projectId },
-      select: { title: true },
-    });
-    if (!project) {
-      return NextResponse.json({ error: "Project not found" }, { status: 404 });
-    }
+    const ctx = await getConsistencyContext(projectId, focusSceneId);
 
-    // Load characters with their descriptions
-    const characters = await prisma.storyObject.findMany({
-      where: { projectId, type: "CHARACTER" },
-      select: { id: true, name: true, description: true, notes: true, role: true },
-    });
-
-    if (characters.length === 0) {
-      return NextResponse.json({ alerts: [] });
-    }
-
-    // Load scenes with content (limited for token efficiency)
-    const sceneQuery: Parameters<typeof prisma.structureNode.findMany>[0] = {
-      where: { projectId, type: "SCENE" },
-      orderBy: { orderIndex: "asc" },
-      select: { id: true, title: true, parentId: true },
-    };
-    const scenes = await prisma.structureNode.findMany(sceneQuery);
-
-    // Load latest content for each relevant scene
-    const scenesWithContent: { id: string; title: string; content: string }[] = [];
-
-    const targetSceneIds = focusSceneId
-      ? [focusSceneId]
-      : scenes.slice(0, 20).map((s) => s.id); // limit to 20 scenes
-
-    for (const sceneId of targetSceneIds) {
-      const version = await prisma.contentVersion.findFirst({
-        where: { nodeId: sceneId },
-        orderBy: { createdAt: "desc" },
-        select: { content: true },
-      });
-      const scene = scenes.find((s) => s.id === sceneId);
-      if (scene && version?.content) {
-        // Strip HTML and beat comments for analysis
-        const textContent = version.content
-          .replace(/<!--[\s\S]*?-->/g, "")
-          .replace(/<[^>]*>/g, " ")
-          .replace(/\s+/g, " ")
-          .trim()
-          .slice(0, 800); // limit per scene
-        if (textContent.length > 50) {
-          scenesWithContent.push({
-            id: sceneId,
-            title: scene.title,
-            content: textContent,
-          });
-        }
-      }
-    }
-
-    if (scenesWithContent.length === 0) {
+    if (ctx.characters.length === 0 || ctx.scenes.length === 0) {
       return NextResponse.json({ alerts: [] });
     }
 
@@ -114,21 +53,20 @@ export async function POST(
       return NextResponse.json({ alerts: [], warning: "AI not configured" });
     }
 
-    // Build prompt for consistency analysis
-    const characterSummary = characters
+    const characterSummary = ctx.characters
       .map((c) => {
         const parts = [`${c.name}${c.role ? ` (${c.role})` : ""}`];
-        if (c.description) parts.push(`Description: ${c.description.slice(0, 300)}`);
-        if (c.notes) parts.push(`Notes: ${c.notes.slice(0, 200)}`);
+        if (c.description) parts.push(`Description: ${c.description}`);
+        if (c.notes) parts.push(`Notes: ${c.notes}`);
         return parts.join(". ");
       })
       .join("\n");
 
-    const scenesSummary = scenesWithContent
+    const scenesSummary = ctx.scenes
       .map((s) => `SCENE "${s.title}" (id:${s.id}):\n${s.content}`)
       .join("\n\n---\n\n");
 
-    const prompt = `You are a manuscript consistency checker for the story "${project.title}".
+    const prompt = `You are a manuscript consistency checker for the story "${ctx.project.title}".
 
 CHARACTER PROFILES:
 ${characterSummary}
@@ -187,8 +125,7 @@ Only report clear, specific contradictions. Do not report vague impressions.`;
       parsed = [];
     }
 
-    // Map parsed results to alerts, resolving scene IDs
-    const sceneByTitle = new Map(scenesWithContent.map((s) => [s.title, s.id]));
+    const sceneByTitle = new Map(ctx.scenes.map((s) => [s.title, s.id]));
 
     const alerts: ConsistencyAlert[] = parsed.slice(0, 20).map((item, idx) => ({
       id: `alert-${Date.now()}-${idx}`,
@@ -199,7 +136,7 @@ Only report clear, specific contradictions. Do not report vague impressions.`;
         ? item.severity
         : "medium") as ConsistencyAlert["severity"],
       description: String(item.description ?? "").slice(0, 500),
-      sceneId: sceneByTitle.get(item.sceneTitle) ?? scenesWithContent[0]?.id ?? "",
+      sceneId: sceneByTitle.get(item.sceneTitle) ?? ctx.scenes[0]?.id ?? "",
       sceneTitle: String(item.sceneTitle ?? ""),
       sourceSceneId: item.sourceSceneTitle ? sceneByTitle.get(item.sourceSceneTitle) : undefined,
       sourceSceneTitle: item.sourceSceneTitle ? String(item.sourceSceneTitle) : undefined,

--- a/src/app/api/projects/[id]/plot-thread-status/route.ts
+++ b/src/app/api/projects/[id]/plot-thread-status/route.ts
@@ -1,30 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
+import { getPlotThreadStatus } from "@/mcp/tools/coaching";
 
-export type PlotlineStatus = "advancing" | "mentioned" | "dormant";
-
-export interface PlotlineIndicator {
-  id: string;
-  name: string;
-  status: PlotlineStatus;
-  lastSeenTitle?: string;
-}
-
-export interface ScenePlotThreadStatus {
-  sceneId: string;
-  indicators: PlotlineIndicator[];
-}
+// Re-export types for consumers
+export type { PlotlineStatus, PlotlineIndicator, ScenePlotThreadStatus } from "@/mcp/tools/coaching";
 
 /**
  * GET /api/projects/[id]/plot-thread-status
  *
  * Returns plotline status indicators for each scene in story order.
- * - advancing: plotline linked to this scene AND appeared in a prior scene
- * - mentioned: plotline linked to this scene for the first time (introduced here)
- * - dormant: plotline appeared in a prior scene but is absent from this scene
- *   (only included for plotlines that have been seen at least once)
+ * Thin wrapper around MCP tool implementation.
  */
 export async function GET(
   request: NextRequest,
@@ -36,104 +22,7 @@ export async function GET(
   if (!access.authorized) return access.response;
 
   try {
-    // Load all scenes in story order (part → chapter → scene hierarchy)
-    const allNodes = await prisma.structureNode.findMany({
-      where: { projectId },
-      orderBy: { orderIndex: "asc" },
-      select: { id: true, type: true, title: true, parentId: true, orderIndex: true },
-    });
-
-    // Load all plotlines for this project
-    const plotlines = await prisma.storyObject.findMany({
-      where: { projectId, type: "PLOTLINE" },
-      select: { id: true, name: true },
-    });
-
-    if (plotlines.length === 0) {
-      return NextResponse.json([]);
-    }
-
-    const plotlineIds = plotlines.map((p) => p.id);
-    const sceneIds = allNodes.filter((n) => n.type === "SCENE").map((n) => n.id);
-
-    if (sceneIds.length === 0) {
-      return NextResponse.json([]);
-    }
-
-    // Load all relationships between plotlines and scenes
-    const relationships = await prisma.relationship.findMany({
-      where: {
-        OR: [
-          { fromObjectId: { in: plotlineIds }, toNodeId: { in: sceneIds } },
-          { fromNodeId: { in: sceneIds }, toObjectId: { in: plotlineIds } },
-        ],
-      },
-      select: {
-        fromObjectId: true,
-        fromNodeId: true,
-        toObjectId: true,
-        toNodeId: true,
-      },
-    });
-
-    // Build a map: sceneId → Set<plotlineId>
-    const sceneToPlotlines = new Map<string, Set<string>>();
-    for (const rel of relationships) {
-      const sceneId = rel.fromNodeId ?? rel.toNodeId;
-      const plotlineId = rel.fromObjectId ?? rel.toObjectId;
-      if (!sceneId || !plotlineId) continue;
-      if (!sceneToPlotlines.has(sceneId)) {
-        sceneToPlotlines.set(sceneId, new Set());
-      }
-      sceneToPlotlines.get(sceneId)!.add(plotlineId);
-    }
-
-    // Build an ordered list of scenes (respecting hierarchy)
-    const orderedScenes = buildOrderedScenes(allNodes);
-
-    // For each scene, compute indicators
-    // Track which plotlines have been seen so far
-    const plotlineLastSeenTitle = new Map<string, string>(); // plotlineId → last scene title
-    const plotlineMap = new Map(plotlines.map((p) => [p.id, p.name]));
-
-    const result: ScenePlotThreadStatus[] = [];
-
-    for (const scene of orderedScenes) {
-      const activePlotlineIds = sceneToPlotlines.get(scene.id) ?? new Set<string>();
-      const indicators: PlotlineIndicator[] = [];
-
-      // Active plotlines in this scene
-      for (const plotlineId of activePlotlineIds) {
-        const name = plotlineMap.get(plotlineId) ?? "Unknown";
-        const wasSeenBefore = plotlineLastSeenTitle.has(plotlineId);
-        indicators.push({
-          id: plotlineId,
-          name,
-          status: wasSeenBefore ? "advancing" : "mentioned",
-        });
-      }
-
-      // Dormant plotlines: seen before but absent from this scene
-      for (const [plotlineId, lastTitle] of plotlineLastSeenTitle.entries()) {
-        if (!activePlotlineIds.has(plotlineId)) {
-          const name = plotlineMap.get(plotlineId) ?? "Unknown";
-          indicators.push({
-            id: plotlineId,
-            name,
-            status: "dormant",
-            lastSeenTitle: lastTitle,
-          });
-        }
-      }
-
-      result.push({ sceneId: scene.id, indicators });
-
-      // Update last seen for active plotlines
-      for (const plotlineId of activePlotlineIds) {
-        plotlineLastSeenTitle.set(plotlineId, scene.title);
-      }
-    }
-
+    const result = await getPlotThreadStatus(projectId);
     return NextResponse.json(result);
   } catch (error) {
     logger.error("GET /api/projects/[id]/plot-thread-status error", error);
@@ -142,42 +31,4 @@ export async function GET(
       { status: 500 }
     );
   }
-}
-
-interface NodeInfo {
-  id: string;
-  type: string;
-  title: string;
-  parentId: string | null;
-  orderIndex: number;
-}
-
-function buildOrderedScenes(nodes: NodeInfo[]): NodeInfo[] {
-  const childrenMap = new Map<string | null, NodeInfo[]>();
-
-  for (const node of nodes) {
-    const key = node.parentId ?? null;
-    if (!childrenMap.has(key)) childrenMap.set(key, []);
-    childrenMap.get(key)!.push(node);
-  }
-
-  // Sort children at each level by orderIndex
-  for (const children of childrenMap.values()) {
-    children.sort((a, b) => a.orderIndex - b.orderIndex);
-  }
-
-  const scenes: NodeInfo[] = [];
-  function traverse(parentId: string | null) {
-    const children = childrenMap.get(parentId) ?? [];
-    for (const child of children) {
-      if (child.type === "SCENE") {
-        scenes.push(child);
-      } else {
-        traverse(child.id);
-      }
-    }
-  }
-
-  traverse(null);
-  return scenes;
 }

--- a/src/app/api/projects/[id]/voice-check/route.ts
+++ b/src/app/api/projects/[id]/voice-check/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
 import { getAiConfig } from "@/lib/ai/settings";
+import { getVoiceContext } from "@/mcp/tools/coaching";
 import OpenAI from "openai";
 
 interface VoiceProfile {
@@ -24,11 +24,7 @@ interface VoiceFeedback {
  * POST /api/projects/[id]/voice-check
  *
  * Analyzes character voice consistency in a scene.
- * Body: { sceneId: string, selectedText?: string }
- * Returns: { profiles: VoiceProfile[], feedback: VoiceFeedback[] }
- *
- * profiles: established voice traits for each character linked to this scene
- * feedback: voice consistency issues found (only when selectedText is provided or scene has dialogue)
+ * Uses shared context from MCP coaching module.
  */
 export async function POST(
   request: NextRequest,
@@ -54,71 +50,34 @@ export async function POST(
   }
 
   try {
-    // Find characters linked to this scene via relationships
-    const sceneRelationships = await prisma.relationship.findMany({
-      where: {
-        OR: [
-          { fromNodeId: sceneId },
-          { toNodeId: sceneId },
-        ],
-      },
-      select: {
-        fromObjectId: true,
-        toObjectId: true,
-      },
-    });
+    const ctx = await getVoiceContext(projectId, sceneId);
 
-    const linkedObjectIds = new Set<string>();
-    for (const rel of sceneRelationships) {
-      if (rel.fromObjectId) linkedObjectIds.add(rel.fromObjectId);
-      if (rel.toObjectId) linkedObjectIds.add(rel.toObjectId);
-    }
-
-    if (linkedObjectIds.size === 0) {
-      return NextResponse.json({ profiles: [], feedback: [] });
-    }
-
-    // Load characters from linked objects
-    const characters = await prisma.storyObject.findMany({
-      where: {
-        id: { in: Array.from(linkedObjectIds) },
-        type: "CHARACTER",
-        projectId,
-      },
-      select: { id: true, name: true, description: true, notes: true, role: true },
-    });
-
-    if (characters.length === 0) {
+    if (ctx.characters.length === 0) {
       return NextResponse.json({ profiles: [], feedback: [] });
     }
 
     const aiConfig = await getAiConfig(userId);
     if (!aiConfig.apiKey) {
       // Return basic profiles without AI feedback
-      const profiles: VoiceProfile[] = characters.map((c) => ({
+      const profiles: VoiceProfile[] = ctx.characters.map((c) => ({
         characterId: c.id,
         characterName: c.name,
-        traits: extractTraits(c.description + " " + c.notes),
-        summary: c.description.slice(0, 200) || "No description available.",
+        traits: extractTraits((c.description || "") + " " + (c.notes || "")),
+        summary: c.description?.slice(0, 200) || "No description available.",
       }));
       return NextResponse.json({ profiles, feedback: [] });
     }
 
-    const client = new OpenAI({
-      apiKey: aiConfig.apiKey,
-      baseURL: aiConfig.baseUrl || undefined,
-    });
-
-    const characterSummary = characters
+    const characterSummary = ctx.characters
       .map((c) => {
         const parts = [`${c.name}${c.role ? ` (${c.role})` : ""}`];
-        if (c.description) parts.push(`Description: ${c.description.slice(0, 400)}`);
-        if (c.notes) parts.push(`Notes: ${c.notes.slice(0, 200)}`);
+        if (c.description) parts.push(`Description: ${c.description}`);
+        if (c.notes) parts.push(`Notes: ${c.notes}`);
         return parts.join(". ");
       })
       .join("\n\n");
 
-    const textToAnalyze = selectedText || await getSceneText(sceneId);
+    const textToAnalyze = selectedText || ctx.sceneText;
 
     const prompt = `You are a character voice coach for a fiction writer.
 
@@ -155,6 +114,11 @@ Return ONLY valid JSON with this structure:
 }
 
 The "feedback" array should be empty if the text is not dialogue or no voice issues are found.`;
+
+    const client = new OpenAI({
+      apiKey: aiConfig.apiKey,
+      baseURL: aiConfig.baseUrl || undefined,
+    });
 
     const response = await client.chat.completions.create({
       model: aiConfig.model,
@@ -195,21 +159,6 @@ The "feedback" array should be empty if the text is not dialogue or no voice iss
       { status: 500 }
     );
   }
-}
-
-async function getSceneText(sceneId: string): Promise<string> {
-  const version = await prisma.contentVersion.findFirst({
-    where: { nodeId: sceneId },
-    orderBy: { createdAt: "desc" },
-    select: { content: true },
-  });
-  if (!version?.content) return "";
-  return version.content
-    .replace(/<!--[\s\S]*?-->/g, "")
-    .replace(/<[^>]*>/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 1500);
 }
 
 function extractTraits(text: string): string[] {

--- a/src/lib/ai/adk-tools.ts
+++ b/src/lib/ai/adk-tools.ts
@@ -107,6 +107,48 @@ const tools: ToolDefinition[] = [
         category: "core",
         parameters: z.object({}),
     },
+    {
+        name: "get_plot_thread_status",
+        description: "Track plotline engagement across scenes. Shows which plot threads are advancing, newly mentioned, or dormant in each scene.",
+        category: "core",
+        parameters: z.object({
+            projectId: z.string().describe("The project ID"),
+        }),
+    },
+    {
+        name: "get_scene_focus",
+        description: "Get complete context for coaching on a single scene: metadata, status, word count, adjacent scenes, linked characters/locations/plotlines, and open annotations.",
+        category: "core",
+        parameters: z.object({
+            sceneId: z.string().describe("The scene node ID"),
+        }),
+    },
+    {
+        name: "get_manuscript_context",
+        description: "Get the full manuscript context for analysis: outline with scene previews, character profiles, plotline summaries, and relationships.",
+        category: "core",
+        parameters: z.object({
+            projectId: z.string().describe("The project ID"),
+        }),
+    },
+    {
+        name: "get_consistency_context",
+        description: "Gather character profiles and scene text for consistency analysis. Optionally focus on a single scene.",
+        category: "core",
+        parameters: z.object({
+            projectId: z.string().describe("The project ID"),
+            sceneId: z.string().optional().describe("Focus on a specific scene"),
+        }),
+    },
+    {
+        name: "get_voice_context",
+        description: "Gather character profiles and scene dialogue for voice consistency analysis.",
+        category: "core",
+        parameters: z.object({
+            projectId: z.string().describe("The project ID"),
+            sceneId: z.string().describe("The scene to analyze"),
+        }),
+    },
 
     // ─── Structure ──────────────────────────────────────────────────────────
     {
@@ -634,6 +676,13 @@ import {
   unlinkProjectFromUniverse,
 } from "@/mcp/tools/universes";
 import { listSkills } from "@/mcp/skills";
+import {
+  getPlotThreadStatus,
+  getSceneFocus,
+  getManuscriptContext,
+  getConsistencyContext,
+  getVoiceContext,
+} from "@/mcp/tools/coaching";
 import { GoogleAuthController } from "@/lib/controllers/google-auth";
 import { GoogleDocsExporter } from "@/lib/export/google-docs-exporter";
 
@@ -652,6 +701,11 @@ const toolExecutors: Record<string, (args: Args) => Promise<unknown>> = {
   get_project_summary: async (a) => getProjectSummary(a.projectId as string),
   get_open_annotations: async (a) => getOpenAnnotations(a.projectId as string | undefined),
   list_skills: async () => listSkills(),
+  get_plot_thread_status: async (a) => getPlotThreadStatus(a.projectId as string),
+  get_scene_focus: async (a) => getSceneFocus(a.sceneId as string),
+  get_manuscript_context: async (a) => getManuscriptContext(a.projectId as string),
+  get_consistency_context: async (a) => getConsistencyContext(a.projectId as string, a.sceneId as string | undefined),
+  get_voice_context: async (a) => getVoiceContext(a.projectId as string, a.sceneId as string),
 
   // Structure
   create_node: async (a) => createNode(a as Parameters<typeof createNode>[0]),

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -71,6 +71,13 @@ import {
     linkProjectToUniverse,
     unlinkProjectFromUniverse,
 } from "./tools/universes";
+import {
+    getPlotThreadStatus,
+    getSceneFocus,
+    getManuscriptContext,
+    getConsistencyContext,
+    getVoiceContext,
+} from "./tools/coaching";
 import { GoogleAuthController } from "../lib/controllers/google-auth";
 import { GoogleDocsExporter } from "../lib/export/google-docs-exporter";
 
@@ -1021,6 +1028,232 @@ server.tool(
         } catch (e) {
             return { content: [{ type: "text", text: `Export failed: ${e}` }], isError: true };
         }
+    }
+);
+
+// ─── Coaching & Analysis Tools ───────────────────────────────────────────────
+
+server.tool(
+    "get_plot_thread_status",
+    "Track plotline engagement across scenes. Shows which plot threads are advancing, newly mentioned, or dormant in each scene — essential for spotting dropped threads.",
+    {
+        projectId: z.string().describe("The project ID"),
+    },
+    async ({ projectId }) => {
+        const result = await getPlotThreadStatus(projectId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "get_scene_focus",
+    "Get complete context for coaching on a single scene: scene metadata, status, word count, adjacent scenes, linked characters/locations/plotlines, and open annotations.",
+    {
+        sceneId: z.string().describe("The scene node ID"),
+    },
+    async ({ sceneId }) => {
+        const result = await getSceneFocus(sceneId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "get_manuscript_context",
+    "Get the full manuscript context for analysis: outline with scene previews, character profiles, plotline summaries, and relationships. Use this before running manuscript-level analysis.",
+    {
+        projectId: z.string().describe("The project ID"),
+    },
+    async ({ projectId }) => {
+        const result = await getManuscriptContext(projectId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "get_consistency_context",
+    "Gather character profiles and scene text for consistency analysis. Optionally focus on a single scene. Returns structured data ready for identifying contradictions.",
+    {
+        projectId: z.string().describe("The project ID"),
+        sceneId: z.string().optional().describe("Focus on a specific scene (if omitted, checks up to 20 scenes)"),
+    },
+    async ({ projectId, sceneId }) => {
+        const result = await getConsistencyContext(projectId, sceneId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "get_voice_context",
+    "Gather character profiles and scene dialogue for voice consistency analysis. Returns characters linked to the scene with their descriptions and the scene text.",
+    {
+        projectId: z.string().describe("The project ID"),
+        sceneId: z.string().describe("The scene to analyze"),
+    },
+    async ({ projectId, sceneId }) => {
+        const result = await getVoiceContext(projectId, sceneId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+// ─── Coaching Prompts ───────────────────────────────────────────────────────
+
+server.prompt(
+    "scene-coaching",
+    "Status-aware coaching for a scene. Adapts review approach based on whether the scene is OUTLINE, DRAFT, REVISED, or FINAL — each stage gets different coaching focus.",
+    {
+        sceneId: z.string().describe("The scene node ID to coach on"),
+        projectId: z.string().optional().describe("The project ID (for broader context)"),
+    },
+    async (args) => {
+        let contextNote = "";
+        if (args.projectId) contextNote += `Project ID: ${args.projectId}\n`;
+        if (args.sceneId) contextNote += `Scene ID: ${args.sceneId}\n`;
+
+        return {
+            messages: [{
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `${contextNote ? `## Context\n${contextNote}\n---\n\n` : ""}## Scene Coaching (Status-Aware)
+
+You are Annie, a writing coach. Your job is to coach the writer on this scene.
+
+**Step 1: Load scene context**
+Use the \`get_scene_focus\` tool with the scene ID to get the scene's status, synopsis, linked characters, locations, plotlines, and open annotations.
+
+**Step 2: Adapt your coaching to the scene's status**
+
+### If status is OUTLINE:
+- Focus on **story structure and planning**: Does the synopsis convey a clear scene goal? What's the conflict? What changes by the end?
+- Suggest beat-by-beat structure. Identify which characters should appear and what each wants.
+- Ask: "What is the ONE thing this scene must accomplish for the story?"
+- Do NOT critique prose (there is none yet).
+
+### If status is DRAFT:
+- Focus on **big-picture feedback**: Does the scene deliver on its synopsis? Is the conflict clear? Do characters behave consistently?
+- Check pacing: Is the opening too slow? Does the ending land?
+- Flag missing elements: Are all linked characters present? Is the setting grounded?
+- Light prose notes only if something actively confuses the reader.
+
+### If status is REVISED:
+- Focus on **craft-level polish**: Prose rhythm, word choice, voice consistency, dialogue authenticity.
+- Use \`get_voice_context\` to check character voice if dialogue is present.
+- Check for: filler words, passive voice overuse, telling vs showing, cliché.
+- Verify continuity with adjacent scenes (prev/next from focus data).
+
+### If status is FINAL:
+- Focus on **proofreading and consistency**: Typos, grammar, formatting, factual consistency.
+- Use \`get_consistency_context\` to cross-check character details and timeline.
+- Flag only concrete errors. This is not the time for subjective style feedback.
+- If the scene is genuinely polished, say so — don't manufacture issues.
+
+**Step 3: Check annotations**
+Review any open annotations on the scene. Address them in your feedback if relevant.
+
+**Step 4: Deliver coaching**
+Structure your response as:
+1. **Scene snapshot** — one-sentence summary of what the scene does
+2. **Status-appropriate feedback** — 3-5 specific, actionable points
+3. **Annotation responses** — if any open annotations relate to your feedback
+4. **Next step** — one concrete suggestion for the writer's next action`,
+                },
+            }],
+        };
+    }
+);
+
+server.prompt(
+    "inline-edit",
+    "Inline text editing operations: rewrite tighter, more vivid, simpler; continue writing; expand; voice check; or custom prompt on selected text.",
+    {
+        action: z.enum(["rewrite-tighter", "rewrite-vivid", "rewrite-simpler", "continue", "expand", "voice-check", "ask"]).describe("The editing action to perform"),
+        selectedText: z.string().describe("The text to edit or analyze"),
+        sceneContext: z.string().optional().describe("Surrounding text for context (a few paragraphs around the selection)"),
+        askPrompt: z.string().optional().describe("Custom prompt (required when action is 'ask')"),
+    },
+    async (args) => {
+        const actionInstructions: Record<string, string> = {
+            "rewrite-tighter": "Rewrite this passage to be tighter and more concise — cut any filler words, redundant phrases, or unnecessary detail. Keep the same meaning and voice.",
+            "rewrite-vivid": "Rewrite this passage to be more vivid and evocative — stronger verbs, sensory detail, concrete imagery. Keep the same meaning and approximate length.",
+            "rewrite-simpler": "Rewrite this passage in simpler, clearer language. Replace complex words with everyday ones, shorten sentences, keep it direct.",
+            "continue": "Continue the story naturally from where this passage ends. Match the existing voice, pacing, and style. Write 1-3 short paragraphs.",
+            "expand": "Expand this passage with more detail, texture, and depth. Add sensory details, internality, or action beats where appropriate. Stay true to the voice.",
+            "voice-check": "Analyze this passage for voice consistency and effectiveness. Comment on: sentence rhythm, word choice, point of view consistency, and any jarring shifts. Be specific and brief (2-4 sentences).",
+            "ask": args.askPrompt || "What do you think about this passage?",
+        };
+
+        const instruction = actionInstructions[args.action] || actionInstructions["ask"];
+        const contextBlock = args.sceneContext ? `\nContext (surrounding text):\n${args.sceneContext}\n` : "";
+        const textLabel = args.action === "continue" ? "End of passage (continue from here)" : args.action === "voice-check" ? "Passage to review" : "Selected text";
+
+        return {
+            messages: [{
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `${instruction}${contextBlock}\n${textLabel}:\n${args.selectedText}\n\n${args.action !== "voice-check" && args.action !== "ask" ? "Return ONLY the rewritten/new text, no explanation." : ""}`,
+                },
+            }],
+        };
+    }
+);
+
+server.prompt(
+    "manuscript-analysis",
+    "Deep manuscript-level analysis: plot thread tracking, character arc evaluation, or consistency checking across the full project.",
+    {
+        projectId: z.string().describe("The project ID to analyze"),
+        analysisType: z.enum(["plot-threads", "character-arcs", "consistency-check"]).describe("Type of analysis to perform"),
+    },
+    async (args) => {
+        const instructions: Record<string, string> = {
+            "plot-threads": `## Plot Thread Analysis
+
+Use the \`get_manuscript_context\` tool to load the project outline, characters, and plotlines.
+Then use \`get_plot_thread_status\` to see which threads are active, dormant, or newly introduced in each scene.
+
+Analyze:
+1. **Active threads** — which plot lines are being developed consistently
+2. **Dormant threads** — threads introduced but not recently advanced (risk of being dropped)
+3. **Unresolved threads** — threads that need payoff before the story ends
+4. **Suggested connections** — opportunities to weave threads together for richer storytelling
+
+Be specific about which scenes/chapters contain each thread. Keep it concise and actionable.`,
+
+            "character-arcs": `## Character Arc Analysis
+
+Use the \`get_manuscript_context\` tool to load the project outline, characters, and relationships.
+
+For each major character, analyze:
+1. **Arc type** — transformation, revelation, flat/steadfast, or fallen
+2. **Current position** — where they are in their arc based on the manuscript
+3. **Missing beats** — what arc beats are absent or underdeveloped
+4. **Key relationships** — how relationships drive or reflect the arc
+
+Be specific about which scenes show arc development. Format as one section per major character.`,
+
+            "consistency-check": `## Consistency Check
+
+Use the \`get_consistency_context\` tool to load character profiles and scene content.
+
+Look for specific contradictions:
+1. **Character details** — appearance, backstory, traits mentioned differently across scenes
+2. **Timeline** — events out of chronological order, impossible timing
+3. **World/setting** — location descriptions that contradict each other
+4. **Plot logic** — cause-effect gaps, character motivations that don't hold
+
+Only report clear, specific contradictions with scene references. Do not report vague impressions. If no issues found in a category, say so briefly.`,
+        };
+
+        return {
+            messages: [{
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Project ID: ${args.projectId}\n\n${instructions[args.analysisType]}`,
+                },
+            }],
+        };
     }
 );
 

--- a/src/mcp/tools/coaching.ts
+++ b/src/mcp/tools/coaching.ts
@@ -1,0 +1,429 @@
+import { prisma } from "@/lib/db";
+
+// ─── Plot Thread Status ─────────────────────────────────────────────────────
+
+export type PlotlineStatus = "advancing" | "mentioned" | "dormant";
+
+export interface PlotlineIndicator {
+  id: string;
+  name: string;
+  status: PlotlineStatus;
+  lastSeenTitle?: string;
+}
+
+export interface ScenePlotThreadStatus {
+  sceneId: string;
+  sceneTitle: string;
+  indicators: PlotlineIndicator[];
+}
+
+export async function getPlotThreadStatus(projectId: string): Promise<ScenePlotThreadStatus[]> {
+  const allNodes = await prisma.structureNode.findMany({
+    where: { projectId },
+    orderBy: { orderIndex: "asc" },
+    select: { id: true, type: true, title: true, parentId: true, orderIndex: true },
+  });
+
+  const plotlines = await prisma.storyObject.findMany({
+    where: { projectId, type: "PLOTLINE" },
+    select: { id: true, name: true },
+  });
+
+  if (plotlines.length === 0) return [];
+
+  const plotlineIds = plotlines.map((p) => p.id);
+  const sceneIds = allNodes.filter((n) => n.type === "SCENE").map((n) => n.id);
+  if (sceneIds.length === 0) return [];
+
+  const relationships = await prisma.relationship.findMany({
+    where: {
+      OR: [
+        { fromObjectId: { in: plotlineIds }, toNodeId: { in: sceneIds } },
+        { fromNodeId: { in: sceneIds }, toObjectId: { in: plotlineIds } },
+      ],
+    },
+    select: {
+      fromObjectId: true,
+      fromNodeId: true,
+      toObjectId: true,
+      toNodeId: true,
+    },
+  });
+
+  const sceneToPlotlines = new Map<string, Set<string>>();
+  for (const rel of relationships) {
+    const sceneId = rel.fromNodeId ?? rel.toNodeId;
+    const plotlineId = rel.fromObjectId ?? rel.toObjectId;
+    if (!sceneId || !plotlineId) continue;
+    if (!sceneToPlotlines.has(sceneId)) sceneToPlotlines.set(sceneId, new Set());
+    sceneToPlotlines.get(sceneId)!.add(plotlineId);
+  }
+
+  const orderedScenes = buildOrderedScenes(allNodes);
+  const plotlineLastSeenTitle = new Map<string, string>();
+  const plotlineMap = new Map(plotlines.map((p) => [p.id, p.name]));
+
+  const result: ScenePlotThreadStatus[] = [];
+
+  for (const scene of orderedScenes) {
+    const activePlotlineIds = sceneToPlotlines.get(scene.id) ?? new Set<string>();
+    const indicators: PlotlineIndicator[] = [];
+
+    for (const plotlineId of activePlotlineIds) {
+      const name = plotlineMap.get(plotlineId) ?? "Unknown";
+      const wasSeenBefore = plotlineLastSeenTitle.has(plotlineId);
+      indicators.push({
+        id: plotlineId,
+        name,
+        status: wasSeenBefore ? "advancing" : "mentioned",
+      });
+    }
+
+    for (const [plotlineId, lastTitle] of plotlineLastSeenTitle.entries()) {
+      if (!activePlotlineIds.has(plotlineId)) {
+        indicators.push({
+          id: plotlineId,
+          name: plotlineMap.get(plotlineId) ?? "Unknown",
+          status: "dormant",
+          lastSeenTitle: lastTitle,
+        });
+      }
+    }
+
+    result.push({ sceneId: scene.id, sceneTitle: scene.title, indicators });
+
+    for (const plotlineId of activePlotlineIds) {
+      plotlineLastSeenTitle.set(plotlineId, scene.title);
+    }
+  }
+
+  return result;
+}
+
+// ─── Scene Focus ─────────────────────────────────────────────────────────────
+
+export async function getSceneFocus(sceneId: string) {
+  const scene = await prisma.structureNode.findUnique({
+    where: { id: sceneId },
+    include: { project: { select: { title: true, id: true } } },
+  });
+  if (!scene) throw new Error(`Scene not found: ${sceneId}`);
+
+  const siblings = await prisma.structureNode.findMany({
+    where: { projectId: scene.projectId, type: "SCENE" },
+    orderBy: [{ parent: { orderIndex: "asc" } }, { orderIndex: "asc" }],
+    select: { id: true, title: true, orderIndex: true },
+  });
+
+  const currentIndex = siblings.findIndex((s) => s.id === sceneId);
+  const prevScene = currentIndex > 0 ? siblings[currentIndex - 1] : null;
+  const nextScene = currentIndex < siblings.length - 1 ? siblings[currentIndex + 1] : null;
+
+  const version = await prisma.contentVersion.findFirst({
+    where: { nodeId: sceneId },
+    orderBy: { createdAt: "desc" },
+    select: { wordCount: true },
+  });
+
+  let chapterTitle = null;
+  if (scene.parentId) {
+    const parent = await prisma.structureNode.findUnique({
+      where: { id: scene.parentId },
+      select: { title: true },
+    });
+    chapterTitle = parent?.title || null;
+  }
+
+  // Related elements
+  const relationships = await prisma.relationship.findMany({
+    where: { OR: [{ fromNodeId: sceneId }, { toNodeId: sceneId }] },
+    include: {
+      fromObject: true,
+      toObject: true,
+      fromWorldObject: true,
+      toWorldObject: true,
+    },
+  });
+
+  const relatedObjects: { id: string; type: string; name: string; description: string | null; role: string | null; source: "project" | "universe" }[] = [];
+  const seenIds = new Set<string>();
+
+  for (const rel of relationships) {
+    const storyObj = rel.fromObject || rel.toObject;
+    if (storyObj && !seenIds.has(storyObj.id)) {
+      relatedObjects.push({
+        id: storyObj.id,
+        type: storyObj.type,
+        name: storyObj.name,
+        description: storyObj.description,
+        role: storyObj.role,
+        source: "project",
+      });
+      seenIds.add(storyObj.id);
+    }
+    const worldObj = rel.fromWorldObject || rel.toWorldObject;
+    if (worldObj && !seenIds.has(worldObj.id)) {
+      relatedObjects.push({
+        id: worldObj.id,
+        type: worldObj.type,
+        name: worldObj.name,
+        description: worldObj.description,
+        role: null,
+        source: "universe",
+      });
+      seenIds.add(worldObj.id);
+    }
+  }
+
+  // Annotations
+  const annotations = await prisma.annotation.findMany({
+    where: { nodeId: sceneId },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return {
+    scene: {
+      id: scene.id,
+      title: scene.title,
+      synopsis: scene.synopsis,
+      status: scene.status,
+      projectId: scene.projectId,
+      projectTitle: scene.project.title,
+      chapterTitle,
+      wordCount: version?.wordCount || 0,
+      prevScene: prevScene ? { id: prevScene.id, title: prevScene.title } : null,
+      nextScene: nextScene ? { id: nextScene.id, title: nextScene.title } : null,
+    },
+    relatedElements: relatedObjects,
+    annotations: annotations.map((a) => ({
+      id: a.id,
+      content: a.content,
+      resolved: a.resolved,
+      selectedText: a.selectedText,
+    })),
+  };
+}
+
+// ─── Manuscript Context ──────────────────────────────────────────────────────
+
+export async function getManuscriptContext(projectId: string) {
+  const [project, nodes, storyObjects, relationships] = await Promise.all([
+    prisma.project.findUnique({ where: { id: projectId } }),
+    prisma.structureNode.findMany({
+      where: { projectId },
+      orderBy: { orderIndex: "asc" },
+      include: {
+        contentVersions: {
+          orderBy: { createdAt: "desc" },
+          take: 1,
+          select: { content: true, wordCount: true },
+        },
+      },
+    }),
+    prisma.storyObject.findMany({
+      where: { projectId },
+      select: { id: true, type: true, name: true, description: true, role: true },
+    }),
+    prisma.relationship.findMany({
+      where: {
+        OR: [
+          { fromObject: { projectId } },
+          { toObject: { projectId } },
+        ],
+      },
+      include: {
+        fromObject: { select: { name: true, type: true } },
+        toObject: { select: { name: true, type: true } },
+      },
+      take: 30,
+    }),
+  ]);
+
+  if (!project) throw new Error("Project not found");
+
+  const chapters = nodes.filter((n) => n.type === "CHAPTER");
+  const scenes = nodes.filter((n) => n.type === "SCENE");
+
+  const outlineWithContent = chapters
+    .map((ch) => {
+      const chScenes = scenes
+        .filter((s) => s.parentId === ch.id)
+        .map((s) => {
+          const content = s.contentVersions[0]?.content || "";
+          const preview = content
+            .replace(/<[^>]+>/g, " ")
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, 300);
+          return `    Scene: ${s.title} [${s.status}]${s.synopsis ? ` — ${s.synopsis}` : ""}${preview ? `\n      Content preview: ${preview}...` : ""}`;
+        })
+        .join("\n");
+      return `Chapter: ${ch.title}${ch.synopsis ? ` — ${ch.synopsis}` : ""}\n${chScenes}`;
+    })
+    .join("\n\n");
+
+  const characters = storyObjects
+    .filter((o) => o.type === "CHARACTER")
+    .map((o) => `${o.name}${o.role ? ` (${o.role})` : ""}${o.description ? `: ${o.description.slice(0, 200)}` : ""}`)
+    .join("\n");
+
+  const plotlines = storyObjects
+    .filter((o) => o.type === "PLOTLINE")
+    .map((o) => `${o.name}${o.description ? `: ${o.description.slice(0, 200)}` : ""}`)
+    .join("\n");
+
+  const relationshipsText = relationships
+    .filter((r) => r.fromObject && r.toObject)
+    .map((r) => `${r.fromObject!.name} → ${r.toObject!.name}: ${r.type}`)
+    .join("\n");
+
+  return {
+    project: { id: project.id, title: project.title, genre: project.genre },
+    outlineWithContent,
+    characters,
+    plotlines,
+    relationships: relationshipsText,
+  };
+}
+
+// ─── Consistency Context ─────────────────────────────────────────────────────
+
+export async function getConsistencyContext(projectId: string, focusSceneId?: string) {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { title: true },
+  });
+  if (!project) throw new Error("Project not found");
+
+  const characters = await prisma.storyObject.findMany({
+    where: { projectId, type: "CHARACTER" },
+    select: { id: true, name: true, description: true, notes: true, role: true },
+  });
+
+  if (characters.length === 0) return { project, characters: [], scenes: [] };
+
+  const scenes = await prisma.structureNode.findMany({
+    where: { projectId, type: "SCENE" },
+    orderBy: { orderIndex: "asc" },
+    select: { id: true, title: true },
+  });
+
+  const targetSceneIds = focusSceneId
+    ? [focusSceneId]
+    : scenes.slice(0, 20).map((s) => s.id);
+
+  const scenesWithContent: { id: string; title: string; content: string }[] = [];
+
+  for (const sceneId of targetSceneIds) {
+    const version = await prisma.contentVersion.findFirst({
+      where: { nodeId: sceneId },
+      orderBy: { createdAt: "desc" },
+      select: { content: true },
+    });
+    const scene = scenes.find((s) => s.id === sceneId);
+    if (scene && version?.content) {
+      const textContent = version.content
+        .replace(/<!--[\s\S]*?-->/g, "")
+        .replace(/<[^>]*>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 800);
+      if (textContent.length > 50) {
+        scenesWithContent.push({ id: sceneId, title: scene.title, content: textContent });
+      }
+    }
+  }
+
+  return {
+    project,
+    characters: characters.map((c) => ({
+      id: c.id,
+      name: c.name,
+      role: c.role,
+      description: c.description?.slice(0, 300) || null,
+      notes: c.notes?.slice(0, 200) || null,
+    })),
+    scenes: scenesWithContent,
+  };
+}
+
+// ─── Voice Context ───────────────────────────────────────────────────────────
+
+export async function getVoiceContext(projectId: string, sceneId: string) {
+  const sceneRelationships = await prisma.relationship.findMany({
+    where: { OR: [{ fromNodeId: sceneId }, { toNodeId: sceneId }] },
+    select: { fromObjectId: true, toObjectId: true },
+  });
+
+  const linkedObjectIds = new Set<string>();
+  for (const rel of sceneRelationships) {
+    if (rel.fromObjectId) linkedObjectIds.add(rel.fromObjectId);
+    if (rel.toObjectId) linkedObjectIds.add(rel.toObjectId);
+  }
+
+  const characters = linkedObjectIds.size > 0
+    ? await prisma.storyObject.findMany({
+        where: { id: { in: Array.from(linkedObjectIds) }, type: "CHARACTER", projectId },
+        select: { id: true, name: true, description: true, notes: true, role: true },
+      })
+    : [];
+
+  // Get scene text
+  const version = await prisma.contentVersion.findFirst({
+    where: { nodeId: sceneId },
+    orderBy: { createdAt: "desc" },
+    select: { content: true },
+  });
+  const sceneText = version?.content
+    ? version.content
+        .replace(/<!--[\s\S]*?-->/g, "")
+        .replace(/<[^>]*>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 1500)
+    : "";
+
+  return {
+    characters: characters.map((c) => ({
+      id: c.id,
+      name: c.name,
+      role: c.role,
+      description: c.description?.slice(0, 400) || null,
+      notes: c.notes?.slice(0, 200) || null,
+    })),
+    sceneText,
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface NodeInfo {
+  id: string;
+  type: string;
+  title: string;
+  parentId: string | null;
+  orderIndex: number;
+}
+
+function buildOrderedScenes(nodes: NodeInfo[]): NodeInfo[] {
+  const childrenMap = new Map<string | null, NodeInfo[]>();
+  for (const node of nodes) {
+    const key = node.parentId ?? null;
+    if (!childrenMap.has(key)) childrenMap.set(key, []);
+    childrenMap.get(key)!.push(node);
+  }
+  for (const children of childrenMap.values()) {
+    children.sort((a, b) => a.orderIndex - b.orderIndex);
+  }
+
+  const scenes: NodeInfo[] = [];
+  function traverse(parentId: string | null) {
+    const children = childrenMap.get(parentId) ?? [];
+    for (const child of children) {
+      if (child.type === "SCENE") scenes.push(child);
+      else traverse(child.id);
+    }
+  }
+  traverse(null);
+  return scenes;
+}


### PR DESCRIPTION
## Summary

- Move coaching AI intelligence (consistency check, voice check, plot thread status, manuscript analysis) from inline API route logic into dedicated MCP tools in `src/mcp/tools/coaching.ts`
- Add `getSceneFocus` coaching tool for scene-level context with related elements and annotations
- Register coaching tools as ADK tools for chat agent integration
- Simplify API routes to thin wrappers that call through to the MCP tools

**Issue**: wca-wmi — MCP-first: ensure all Annie intelligence lives in tools and prompts

## Test plan

- [x] TypeScript typecheck passes
- [x] 573 tests pass (57 test files)
- [ ] CI status checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)