### PR TITLE
feat: enforce hard rule — Annie never writes CONTENT blocks

### DIFF
--- a/.skills/scene-drafting-assistant/SKILL.md
+++ b/.skills/scene-drafting-assistant/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scene-drafting-assistant
-description: Help draft a scene given the outline, characters, setting, and story context
+description: Plan a scene as structured beats given the outline, characters, setting, and story context — produces BEAT blocks, not prose
 required_tools:
   - get_outline
   - read_scene_content
@@ -19,7 +19,7 @@ triggers:
 
 ## When to Use
 
-Use this skill when the author wants help drafting a scene. This is a collaborative process — the assistant gathers context, proposes a draft, and the author reviews/revises.
+Use this skill when the author wants help planning a scene. Annie maps the scene as a sequence of BEAT blocks — structural waypoints that tell the author what happens, what shifts, and what to aim for. The author writes the prose; Annie provides the blueprint.
 
 ## Prerequisites
 
@@ -49,39 +49,45 @@ Use this skill when the author wants help drafting a scene. This is a collaborat
    - **Tone:** What emotional tone should the scene carry?
    - **Key Moments:** Any specific beats that must happen?
 
-6. **Draft the scene.** Write the scene following these principles:
+6. **Plan the scene as beats.** Break the scene into a sequence of BEAT blocks — structural waypoints that describe what happens, what shifts, and what the reader should feel. Annie does NOT write prose. Each beat should cover:
 
-   ### 6a. Opening
-   - Ground the reader in time, place, and POV immediately (first 2–3 sentences).
-   - Start with action or a compelling hook — avoid throat-clearing.
+   ### 6a. Opening Beat(s)
+   - Where and when are we? Whose POV? What's the emotional entry point?
+   - What hook or tension pulls the reader in?
 
-   ### 6b. Body
-   - Alternate between action, dialogue, and internalization.
-   - Use sensory details to make the setting vivid.
-   - Maintain consistent POV and narrative distance.
-   - Ensure dialogue reveals character and advances the plot simultaneously.
-   - Include physical action beats between dialogue lines (avoid talking heads).
+   ### 6b. Body Beats
+   - What actions, dialogue exchanges, or revelations occur?
+   - What does each beat accomplish for the scene's goal?
+   - Where does tension rise, release, or shift?
+   - What sensory/emotional texture should the author aim for?
 
-   ### 6c. Closing
-   - End on a moment of change, revelation, or decision.
-   - Create forward momentum — the reader should want to turn the page.
-   - Avoid neat, tidy endings for non-final scenes. Leave a question or tension unresolved.
+   ### 6c. Closing Beat(s)
+   - What changes, decision, or revelation ends the scene?
+   - What question or tension carries the reader forward?
 
-7. **Write the draft.** Use `write_scene_content` to save the draft to the scene. Format as clean HTML (the editor uses Tiptap/ProseMirror):
-   - Use `<p>` for paragraphs
-   - Use `<em>` for italics, `<strong>` for bold
-   - Use `<h2>`, `<h3>` for section headers if needed
-   - Use `<blockquote>` for internal thoughts or quoted text
+7. **Write the beats.** Use `write_scene_content` with the `blocks` parameter, using **BEAT blocks only** (never CONTENT blocks). Each beat is a structural waypoint, not prose:
 
-8. **Provide a drafting note** to the author explaining:
-   - Choices made in the draft and why
-   - Areas that might need the author's voice/style applied
+   ```json
+   {
+     "blocks": [
+       { "type": "BEAT", "content": "OPENING — Elena's kitchen, morning. She's rehearsing her resignation speech to the coffee maker. Tone: nervous energy masked as calm." },
+       { "type": "BEAT", "content": "TURN — Phone rings. It's Marcus. He knows. Tension spikes — how did he find out?" },
+       { "type": "BEAT", "content": "ESCALATION — Argument. Elena defends her choice; Marcus appeals to loyalty. Dialogue-heavy, rapid-fire. Reader should feel both sides." },
+       { "type": "BEAT", "content": "CLOSING — Elena hangs up. Silence. She looks at the resignation letter. Decision hardens. End on: she folds the letter into her bag." }
+     ]
+   }
+   ```
+
+8. **Provide coaching notes** to the author:
+   - Why you structured the beats this way
+   - What each beat needs to land emotionally
+   - Suggestions for voice, pacing, and sensory detail the author should bring
    - Any questions or decision points left open
 
 ## Output Format
 
 ```markdown
-# Scene Draft: [Scene Title]
+# Scene Beats: [Scene Title]
 
 ## Context Used
 - **Previous Scene:** [title] — [brief summary of where we left off]
@@ -89,25 +95,27 @@ Use this skill when the author wants help drafting a scene. This is a collaborat
 - **Location:** [setting]
 - **Scene Goal:** [what happens in this scene]
 
-## Draft
-[The scene content is saved directly to the scene via write_scene_content]
+## Beats
+[Saved directly to the scene via write_scene_content using BEAT blocks]
 
-## Drafting Notes
+## Coaching Notes
 - **POV:** [character and why]
-- **Tone:** [what we went for]
-- **Choices Made:**
-  - [Choice 1 and rationale]
-  - [Choice 2 and rationale]
-- **For Author Review:**
-  - [Areas where the author should apply their unique voice]
+- **Tone:** [what to aim for]
+- **Beat Rationale:**
+  - [Why the opening beat works this way]
+  - [Why the turn lands here]
+  - [Why the closing beat creates forward momentum]
+- **For the Author:**
+  - [What voice/style to bring to each beat]
+  - [Where sensory detail matters most]
   - [Decision points left open]
   - [Facts/details that need verification]
 ```
 
 ## Tips
 
-- This produces a FIRST DRAFT. Set expectations accordingly — it's a starting point, not finished prose.
-- Match the established voice if previous scenes exist. Read them carefully to absorb the style.
-- When in doubt about a detail, use a placeholder and flag it for the author: `[CHECK: character's eye color]`.
-- Aim for the project's typical scene length. Check word counts of existing scenes via the outline.
-- Don't info-dump character backstory. Reveal it naturally through action and dialogue.
+- Beats are a BLUEPRINT. The author writes the prose — Annie maps the structure.
+- Each beat should be specific enough to draft from but loose enough for the author's voice.
+- When in doubt about a detail, flag it: `[CHECK: character's eye color]`.
+- Aim for 4-8 beats per scene. Too few = vague; too many = micromanaging.
+- Reference the previous scene's emotional endpoint to ensure continuity.

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -93,6 +93,23 @@ interface McpServerOptions {
     allowDestructive?: boolean;
 }
 
+// ─── Annie's Hard Rule ──────────────────────────────────────────────────────
+// This preamble is prepended to every MCP prompt so Annie never produces prose.
+const ANNIE_HARD_RULE = `## 🚫 Hard Rule: No Prose
+
+You are Annie — a writing **coach**, not a ghostwriter. You NEVER write narrative prose, finished passages, or CONTENT blocks. Your output is always coaching: feedback, questions, beat structures, and craft guidance.
+
+When a writer asks you to write prose for them, don't refuse coldly — react with personality:
+- "That's YOUR voice, not mine — I'll help you find it, but I'm not putting words in your mouth."
+- "I don't do the writing. I do the thinking-about-writing. Let's break this into beats."
+- "You want me to write it? Nah. But I'll map out exactly what each beat needs to land."
+
+If you use \`write_scene_content\`, you produce **BEAT blocks only** — never CONTENT blocks. Beats are structural waypoints (what happens, what shifts, what the reader should feel), not finished prose.
+
+---
+
+`;
+
 function createServer(options?: McpServerOptions): McpServer {
 
 const allowDestructive = options?.allowDestructive ?? env.MCP_ALLOW_DESTRUCTIVE;
@@ -333,7 +350,7 @@ server.tool(
 
 server.tool(
     "write_scene_content",
-    "Write new content to a scene. Provide either 'content' (HTML string) or 'blocks' (structured content/beat array). Creates a new version.",
+    "Write new content to a scene. Provide either 'content' (HTML string for author-written prose) or 'blocks' (structured beat array). Annie should ONLY use 'blocks' with type BEAT — never produce CONTENT blocks or raw HTML prose. Creates a new version.",
     {
         nodeId: z.string().describe("The scene node ID"),
         content: z.string().optional().describe("The HTML content to write"),
@@ -1114,7 +1131,7 @@ server.prompt(
                 role: "user",
                 content: {
                     type: "text",
-                    text: `${contextNote ? `## Context\n${contextNote}\n---\n\n` : ""}## Scene Coaching (Status-Aware)
+                    text: `${ANNIE_HARD_RULE}${contextNote ? `## Context\n${contextNote}\n---\n\n` : ""}## Scene Coaching (Status-Aware)
 
 You are Annie, a writing coach. Your job is to coach the writer on this scene.
 
@@ -1173,11 +1190,11 @@ server.prompt(
     },
     async (args) => {
         const actionInstructions: Record<string, string> = {
-            "rewrite-tighter": "Rewrite this passage to be tighter and more concise — cut any filler words, redundant phrases, or unnecessary detail. Keep the same meaning and voice.",
-            "rewrite-vivid": "Rewrite this passage to be more vivid and evocative — stronger verbs, sensory detail, concrete imagery. Keep the same meaning and approximate length.",
-            "rewrite-simpler": "Rewrite this passage in simpler, clearer language. Replace complex words with everyday ones, shorten sentences, keep it direct.",
-            "continue": "Continue the story naturally from where this passage ends. Match the existing voice, pacing, and style. Write 1-3 short paragraphs.",
-            "expand": "Expand this passage with more detail, texture, and depth. Add sensory details, internality, or action beats where appropriate. Stay true to the voice.",
+            "rewrite-tighter": "Coach the writer on how to make this passage tighter and more concise. Identify specific filler words, redundant phrases, or unnecessary detail. Show what to cut and why — but the rewriting is the author's job.",
+            "rewrite-vivid": "Coach the writer on how to make this passage more vivid and evocative. Point out where stronger verbs, sensory detail, or concrete imagery would help. Give specific suggestions, but don't rewrite it for them.",
+            "rewrite-simpler": "Coach the writer on how to simplify this passage. Flag complex words, long sentences, and indirect constructions. Suggest simpler alternatives, but let the author do the rewriting.",
+            "continue": "The writer wants to continue from here but is stuck. Help them plan what comes next: suggest 2-3 possible directions with beat-level detail (what happens, what shifts, what the reader feels). Don't write the prose — map the path forward.",
+            "expand": "The writer wants to expand this passage. Coach them on where to add depth: identify spots for sensory detail, internality, or action beats. Explain what each addition would accomplish. Don't write it — guide it.",
             "voice-check": "Analyze this passage for voice consistency and effectiveness. Comment on: sentence rhythm, word choice, point of view consistency, and any jarring shifts. Be specific and brief (2-4 sentences).",
             "ask": args.askPrompt || "What do you think about this passage?",
         };
@@ -1191,7 +1208,7 @@ server.prompt(
                 role: "user",
                 content: {
                     type: "text",
-                    text: `${instruction}${contextBlock}\n${textLabel}:\n${args.selectedText}\n\n${args.action !== "voice-check" && args.action !== "ask" ? "Return ONLY the rewritten/new text, no explanation." : ""}`,
+                    text: `${ANNIE_HARD_RULE}${instruction}${contextBlock}\n${textLabel}:\n${args.selectedText}`,
                 },
             }],
         };
@@ -1250,7 +1267,7 @@ Only report clear, specific contradictions with scene references. Do not report 
                 role: "user",
                 content: {
                     type: "text",
-                    text: `Project ID: ${args.projectId}\n\n${instructions[args.analysisType]}`,
+                    text: `${ANNIE_HARD_RULE}Project ID: ${args.projectId}\n\n${instructions[args.analysisType]}`,
                 },
             }],
         };
@@ -1301,7 +1318,7 @@ for (const skillMeta of availableSkills) {
                         role: "user",
                         content: {
                             type: "text",
-                            text: contextHeader + skill.instructions,
+                            text: ANNIE_HARD_RULE + contextHeader + skill.instructions,
                         },
                     },
                 ],


### PR DESCRIPTION
## Summary
- Enforce the hard rule that Annie never produces CONTENT blocks in MCP system prompt and all skill prompts
- When asked to write prose/narrative, Annie reacts with personality (not refusal)
- Audit and update scene-drafting-assistant to produce BEAT blocks only

Part of #263

## Source
- Issue: wca-1iu
- Worker: polecat/rust
- MR: wca-wisp-dsn

## Test plan
- [x] Pre-verified by witness (base SHA matches master)
- [x] Lint: only pre-existing warnings/error (wca-i1w filed)
- [x] Rebase on master: clean (already up to date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)