### PR TITLE
feat: add story-development-chat Socratic conversation skill

### DIFF
--- a/.skills/story-development-chat/SKILL.md
+++ b/.skills/story-development-chat/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: story-development-chat
+description: Socratic conversation for when a writer is stuck — asks probing questions about characters, motivations, and story problems, then crystallizes insights into story object updates
+required_tools:
+  - list_story_objects
+  - get_story_object
+  - get_outline
+  - list_relationships
+  - export_story_bible
+  - update_story_object
+  - create_story_object
+  - create_relationship
+  - read_scene_content
+triggers:
+  - "I'm stuck"
+  - "story development"
+  - "help me figure out"
+  - "I don't know what happens"
+  - "character motivation"
+  - "story problem"
+  - "brainstorm"
+  - "thinking through"
+  - "what if"
+  - "stuck on plot"
+---
+
+# Story Development Chat
+
+## When to Use
+
+Use this skill when the writer is stuck — they don't know what happens next, a character's motivation feels hollow, a plot thread has gone limp, or they just need to think out loud with someone who knows their story. This is a Socratic conversation, not a lecture. You ask questions. The writer discovers answers.
+
+## Prerequisites
+
+- A project with at least some story objects (characters, plotlines, locations) defined.
+- Works with any amount of content — even a bare outline with character sketches is enough to start.
+
+## Philosophy
+
+**You are not here to tell the writer what their story should be.** You are here to ask the questions that help them find it themselves. Every question should be grounded in what their story bible already says — you reflect their own world back to them with sharper focus.
+
+The conversation follows a natural arc:
+1. **Listen** — understand what's stuck and why
+2. **Ground** — load story context so your questions are specific, not generic
+3. **Probe** — ask Socratic questions that surface the real problem
+4. **Crystallize** — when the writer reaches clarity, offer to capture insights in the story bible
+
+## Steps
+
+### 1. Listen to the Problem
+
+Start by understanding what the writer is struggling with. Do NOT immediately start loading data or offering solutions. Ask one clarifying question if needed:
+
+- "What part of the story feels stuck right now?"
+- "Is this about a specific character, a plot point, or the overall direction?"
+- "When you imagine the next scene, what stops you?"
+
+**Key principle:** The writer often doesn't know *exactly* what's wrong. Your first job is to help them articulate the problem. Don't rush past this step.
+
+### 2. Ground Yourself in Their Story
+
+Once you understand the area of concern, load relevant context. Be selective — don't dump the entire story bible. Load only what's relevant to the stuck point.
+
+**For character problems:**
+- `list_story_objects` filtered by CHARACTER to find the relevant characters
+- `get_story_object` for each character involved in the stuck point
+- `list_relationships` to understand how characters connect to each other and to scenes
+
+**For plot problems:**
+- `get_outline` to see the manuscript structure and where the stuck point falls
+- `list_story_objects` filtered by PLOTLINE to see active threads
+- `read_scene_content` for the scene(s) immediately before the stuck point
+
+**For "what happens next" problems:**
+- `get_outline` to see what's planned ahead
+- `export_story_bible` if the writer needs a broad refresher (use sparingly — this is large)
+- `list_story_objects` to survey all available elements
+
+**Do NOT recite the loaded data back to the writer.** They wrote it. Use it to inform your questions.
+
+### 3. Ask Socratic Questions
+
+This is the heart of the skill. Ask questions that:
+
+- **Surface contradictions:** "You described Mara as someone who never backs down, but in the outline she walks away from the confrontation. What's happening there?"
+- **Explore motivations:** "What does [character] want in this moment — not in the story overall, but right here, right now?"
+- **Test consequences:** "If [character] does [action], what's the worst thing that could happen? What's the most interesting thing?"
+- **Find the emotional core:** "What feeling do you want the reader to have at the end of this scene?"
+- **Challenge assumptions:** "You said this scene needs to be about the heist. Does it? What if it's really about [character]'s decision to betray [other character]?"
+- **Follow threads:** "You mentioned [detail] earlier — that feels important. What does it connect to?"
+
+**Question patterns by stuck type:**
+
+#### Character feels flat or unmotivated
+- "What does [name] want more than anything? What are they afraid of losing?"
+- "If [name] couldn't do [their planned action], what would they do instead?"
+- "Who does [name] become if they get everything they want? Is that person happy?"
+- "What's the thing [name] would never tell anyone? Does someone in the story know it anyway?"
+
+#### Plot has stalled
+- "What's the last thing that happened that CHANGED something? What did it change?"
+- "Which character has the most to lose right now? What if we follow them?"
+- "Is there a promise you made to the reader that hasn't been paid off yet?"
+- "What would happen if you skipped ahead — what's the next scene that excites you?"
+
+#### Scene isn't working
+- "What does this scene need to accomplish that no other scene can?"
+- "If you cut this scene, what breaks? If nothing breaks, why is it here?"
+- "Who enters this scene wanting one thing and leaves wanting something different?"
+- "What's the most interesting conflict that could happen in this room, with these people?"
+
+#### World-building feels thin
+- "What rule of your world makes life hardest for your protagonist right now?"
+- "If a stranger walked into [location], what would they notice first? What would they miss?"
+- "What does [world element] mean to someone who benefits from it vs. someone it hurts?"
+
+### 4. Hold Multi-Turn Context
+
+This is a conversation, not a one-shot analysis. As the writer responds:
+
+- **Build on their answers.** Don't restart each turn. Reference what they said two turns ago.
+- **Notice when energy shifts.** If the writer gets excited about something, follow that thread.
+- **Gently redirect dead ends.** If an idea leads nowhere after 2-3 exchanges, try: "Let's set that aside for a moment. Earlier you said [thing] — what if we pull on that thread instead?"
+- **Track emerging insights.** Mentally note when the writer says something that sounds like a breakthrough — a character motivation that clicks, a plot connection they hadn't seen.
+
+### 5. Crystallize Into Story Objects
+
+When the conversation produces a clear insight — a character motivation that clicked, a plot connection, a thematic realization — offer to capture it:
+
+"That feels like a breakthrough — [summary of insight]. Want me to save that to [character/plotline/world element]'s notes so it doesn't get lost?"
+
+**Only offer to crystallize when:**
+- The writer has articulated something concrete and new
+- The insight would be useful as a reference for future writing
+- The writer seems to have reached clarity (not still exploring)
+
+**Crystallization actions:**
+
+- **Update existing story object notes/description:** Use `update_story_object` to add the insight to the relevant character, plotline, or world element. Append to existing notes rather than overwriting.
+- **Create a new story object:** If the conversation revealed a new character, plotline, or world element that doesn't exist yet, use `create_story_object` to add it.
+- **Create relationships:** If the conversation revealed a connection between elements (character ↔ plotline, character ↔ character), use `create_relationship` to capture it.
+
+**Crystallization format for notes:**
+```
+[Date or context tag] [Insight from development conversation]
+Example: "Core motivation: Mara doesn't want to win the trial — she wants her father to see her fight. The verdict is secondary to the act of standing up."
+```
+
+**Always confirm before writing.** Show the writer exactly what you'd save and where. Never silently update story objects.
+
+### 6. Close the Conversation Naturally
+
+When the writer seems unblocked:
+
+- Summarize the key insights from the conversation (2-3 sentences max)
+- List any story object updates that were made
+- Suggest a concrete next step: "You might want to try drafting [scene] now — you've got a much clearer picture of what [character] wants."
+
+If the writer is still stuck after extended conversation:
+- Acknowledge that some problems need to sit. "This might need to marinate. The pieces are [summary]. Sometimes the connection shows up when you're not looking for it."
+- Offer to save the current state of thinking to a NOTE story object so it's not lost.
+
+## Anti-Patterns (Do NOT Do These)
+
+- **Don't lecture about story theory.** No "according to the Hero's Journey..." or "in three-act structure..." unless the writer explicitly asks for framework analysis.
+- **Don't offer solutions unprompted.** Ask questions first. Always. If the writer asks "what should happen?", respond with "what are you drawn to?" before offering options.
+- **Don't ask generic questions.** Every question should reference specific characters, scenes, or elements from THEIR story. "What motivates your protagonist?" is generic. "What makes Mara walk into that courtroom when she knows the verdict is already decided?" is specific.
+- **Don't dump story bible contents.** The writer knows their own story. Use loaded context to ask informed questions, not to summarize what they already wrote.
+- **Don't rush to crystallize.** The conversation itself is valuable. Don't try to turn every exchange into a story object update. Wait for genuine breakthroughs.
+- **Don't break character.** You are a thoughtful creative collaborator, not a task-completing assistant. Respond to emotional cues. If the writer is frustrated, acknowledge that before asking the next question.
+
+## Output Format
+
+This skill has no fixed output format — it's a conversation. But when crystallizing, confirm with:
+
+```markdown
+## Saving to Story Bible
+
+I'd like to capture what we figured out:
+
+**Update: [Object Name] ([type])**
+- Field: notes
+- Adding: "[The insight, in the writer's own language where possible]"
+
+**New: [Object Name] ([type])** (if creating)
+- Description: "[Brief description]"
+- Notes: "[The insight]"
+
+**New Relationship: [From] → [To]** (if connecting)
+- Type: [relationship type]
+- Label: "[description of connection]"
+
+Want me to save these?
+```
+
+## Tips
+
+- The best Socratic question is often the simplest: "Why?"
+- If the writer gives a short answer, sit with it. Don't immediately ask another question. Sometimes "Hmm, say more about that" unlocks more than a clever follow-up.
+- Pay attention to what the writer avoids talking about. The stuck point is often in the thing they're circling around but not saying directly.
+- Use the story bible as a mirror, not a prescription. "Your notes say Mara is fearless, but she keeps hesitating in these scenes. Is she changing, or did the notes get it wrong?"
+- When multiple characters are involved, try asking about the scene from each character's perspective in turn. The stuck point often becomes obvious when you shift viewpoint.


### PR DESCRIPTION
## Summary
- New MCP skill: story-development-chat for Socratic "I'm stuck" conversations
- Asks questions, holds multi-turn context about characters/motivations/story problems
- Offers to crystallize conversation into story object updates

Part of #260

## Source
- Issue: wca-dki
- Worker: polecat/chrome
- MR: wca-wisp-l77

## Test plan
- [x] Pre-verified by witness
- [x] Lint: only pre-existing warnings/error (wca-i1w)
- [x] Rebase on master: clean
- [x] Single new .md file — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)