### PR TITLE
feat: story bible cross-referencing with confirmation flow

### DIFF
--- a/.skills/consistency-check/SKILL.md
+++ b/.skills/consistency-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consistency-check
-description: Cross-reference world elements, characters, and settings for contradictions across the manuscript
+description: Cross-reference world elements, characters, and settings for contradictions across the manuscript — including story bible cross-referencing with confirmation flow
 required_tools:
   - get_outline
   - read_scene_content
@@ -8,18 +8,23 @@ required_tools:
   - get_story_object
   - list_relationships
   - export_story_bible
+  - cross_reference_story_bible
+  - update_story_object
+  - add_annotation
 triggers:
   - "consistency check"
   - "continuity check"
   - "find contradictions"
   - "world consistency"
+  - "story bible check"
+  - "canon check"
 ---
 
 # Consistency Check
 
 ## When to Use
 
-Use this skill when the author wants to verify that their manuscript is internally consistent — no contradictions in character details, timeline, setting descriptions, or world-building rules.
+Use this skill when the author wants to verify that their manuscript is internally consistent — no contradictions in character details, timeline, setting descriptions, or world-building rules. This includes cross-referencing the actual prose against story object definitions to catch drift between what the story bible says and what the manuscript says.
 
 ## Prerequisites
 
@@ -27,6 +32,8 @@ Use this skill when the author wants to verify that their manuscript is internal
 - Works best when characters, locations, and world elements have descriptions and relationships set up.
 
 ## Steps
+
+### Phase 1: Gather Reference Data
 
 1. **Export the story bible.** Use `export_story_bible` to get a complete reference of all characters, locations, plotlines, and world elements in one view.
 
@@ -36,37 +43,73 @@ Use this skill when the author wants to verify that their manuscript is internal
 
 4. **Load detailed story objects.** For each key character and location, use `get_story_object` to get full descriptions and notes.
 
-5. **Read scenes sequentially.** Working through the outline in order, use `read_scene_content` for each scene. While reading, track:
+### Phase 2: Cross-Reference Prose Against Story Bible
 
-   ### 5a. Character Consistency
+5. **Run story bible cross-reference.** Use `cross_reference_story_bible` to load all story objects alongside scene content with relationship mappings. This provides structured data optimized for finding mismatches between the story bible and the actual prose.
+
+6. **Identify mismatches.** For each story object, compare its defined attributes against how it appears in the prose. Track:
+
+   - **Character attributes**: Does the prose describe a character differently than the story object? (hair color, eye color, age, height, scars, distinguishing features)
+   - **Character behaviour**: Does a character act inconsistently with their defined personality, knowledge, or abilities?
+   - **Location details**: Are location descriptions in the prose consistent with the story object definition?
+   - **Timeline events**: Do events in the prose match timeline entries on world objects?
+   - **World-building rules**: Does the prose follow the rules established in world element definitions?
+
+### Phase 3: Scene-by-Scene Consistency
+
+7. **Read scenes sequentially.** Working through the outline in order, use `read_scene_content` for each scene. While reading, track:
+
+   #### 7a. Character Consistency
    - Physical descriptions (hair color, height, scars, distinguishing features)
    - Personality traits and behavioral patterns
    - Knowledge — does a character reference something they shouldn't know yet?
    - Abilities — do character skills stay consistent?
    - Names and titles — are they spelled and used consistently?
 
-   ### 5b. Timeline Consistency
+   #### 7b. Timeline Consistency
    - Do events happen in a logical order?
    - Are time references consistent? (e.g., "three days later" followed by "yesterday" — does the math work?)
    - Are character ages consistent with the timeline?
    - Are seasonal/weather references consistent with the stated time period?
 
-   ### 5c. Setting Consistency
+   #### 7c. Setting Consistency
    - Are location descriptions consistent between scenes? (e.g., a tavern described as "dimly lit" in one scene and "sun-drenched" in another — is this explained by time of day?)
    - Are distances and travel times plausible?
    - Are geographical relationships consistent? (North of the river in one scene, south in another?)
 
-   ### 5d. World-Building Consistency
+   #### 7d. World-Building Consistency
    - Do magic systems / technology / rules of the world stay consistent?
    - Are cultural practices described consistently?
    - Do organizations and power structures remain coherent?
 
-   ### 5e. Plot Consistency
+   #### 7e. Plot Consistency
    - Are plot threads picked up and resolved?
    - Are character motivations consistent with their actions?
    - Are cause-and-effect chains logical?
 
-6. **Compile findings** into a structured consistency report.
+### Phase 4: Compile and Present Findings
+
+8. **Compile findings** into a structured consistency report (see Output Format below).
+
+### Phase 5: Confirmation Flow for Story Object Sync
+
+9. **Present each mismatch** between the story bible and the prose to the author. For each mismatch, show:
+   - What the story bible says
+   - What the prose says
+   - Which scene contains the discrepancy
+
+10. **Ask the author which is the source of truth.** Never silently overwrite. For each mismatch, offer three options:
+
+    - **Option A: Update the story bible** — "The prose is correct. Update the story object to match."
+      → Use `update_story_object` to sync the story bible entry with what the prose says.
+
+    - **Option B: Flag the scene for revision** — "The story bible is correct. The prose needs editing."
+      → Use `add_annotation` on the scene to mark the specific passage for the author to revise, noting what the correct value should be.
+
+    - **Option C: Keep both versions** — "This difference is intentional."
+      → The author confirms the discrepancy is deliberate (e.g., unreliable narrator, character growth, regional dialect differences). No changes needed.
+
+11. **Wait for author confirmation before making any changes.** Present all mismatches first, let the author decide on each one, then execute the chosen actions.
 
 ## Output Format
 
@@ -75,6 +118,20 @@ Use this skill when the author wants to verify that their manuscript is internal
 
 ## Summary
 [Overview of consistency status — How many issues found, severity breakdown]
+
+## Story Bible vs Prose Mismatches
+[Discrepancies between story object definitions and the actual manuscript text]
+
+### Mismatch 1: [Object Name] — [Brief title]
+- **Object:** [Name] ([Type], ID: [id])
+- **Story Bible says:** [value from story object]
+- **Prose says:** [value from scene text]
+- **Scene:** [Scene title] (ID: [id])
+- **Severity:** CRITICAL / MAJOR / MINOR
+- **Resolution options:**
+  - A) Update story object to match prose
+  - B) Flag scene for revision (story bible is correct)
+  - C) Keep both (intentional difference)
 
 ## Critical Issues (Must Fix)
 [Contradictions that would confuse or frustrate readers]
@@ -114,3 +171,5 @@ Use this skill when the author wants to verify that their manuscript is internal
 - Some apparent inconsistencies are intentional (unreliable narrator, character lying). Note these as "ambiguous" rather than flagging as errors.
 - Focus on reader-facing issues. Internal notes and outlines don't need the same consistency rigor.
 - Prioritize by severity: a character changing eye color mid-book is more critical than a minor timeline ambiguity.
+- **Never silently change story objects or prose.** Always present the mismatch and let the author choose.
+- When updating story objects after confirmation, include a note in the story object's notes field about what was changed and why (e.g., "Updated eye color to match Ch. 3 description per author confirmation").

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -77,6 +77,7 @@ import {
     getManuscriptContext,
     getConsistencyContext,
     getVoiceContext,
+    getStoryBibleCrossReference,
 } from "./tools/coaching";
 import { GoogleAuthController } from "../lib/controllers/google-auth";
 import { GoogleDocsExporter } from "../lib/export/google-docs-exporter";
@@ -1083,6 +1084,19 @@ server.tool(
 );
 
 server.tool(
+    "cross_reference_story_bible",
+    "Cross-reference prose content against story object definitions. Returns all story objects (characters, locations, world elements, plotlines) with full details alongside scene text and relationship mappings. Use this to find attribute mismatches, behavioural inconsistencies, and timeline contradictions between what the story bible defines and what the prose actually says. Includes instructions for presenting mismatches and confirmation flow.",
+    {
+        projectId: z.string().describe("The project ID"),
+        sceneId: z.string().optional().describe("Focus on a specific scene (if omitted, checks up to 15 scenes)"),
+    },
+    async ({ projectId, sceneId }) => {
+        const result = await getStoryBibleCrossReference(projectId, sceneId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
     "get_voice_context",
     "Gather character profiles and scene dialogue for voice consistency analysis. Returns characters linked to the scene with their descriptions and the scene text.",
     {
@@ -1234,6 +1248,12 @@ Be specific about which scenes show arc development. Format as one section per m
 
             "consistency-check": `## Consistency Check
 
+**Step 1: Cross-reference story bible against prose.**
+Use the \`cross_reference_story_bible\` tool to load all story objects alongside scene content.
+Compare each story object's defined attributes against how they appear in the prose.
+Follow the instructions included in the tool response for structuring mismatches.
+
+**Step 2: Check for scene-to-scene contradictions.**
 Use the \`get_consistency_context\` tool to load character profiles and scene content.
 
 Look for specific contradictions:
@@ -1242,7 +1262,14 @@ Look for specific contradictions:
 3. **World/setting** — location descriptions that contradict each other
 4. **Plot logic** — cause-effect gaps, character motivations that don't hold
 
-Only report clear, specific contradictions with scene references. Do not report vague impressions. If no issues found in a category, say so briefly.`,
+**Step 3: Present findings with confirmation flow.**
+For each story bible vs prose mismatch, present both versions and ask which is the source of truth:
+- **A) Update story object** → use \`update_story_object\` to sync bible to prose
+- **B) Flag scene** → use \`add_annotation\` to mark prose for revision
+- **C) Keep both** → intentional difference, no action needed
+
+IMPORTANT: Never silently overwrite. Always ask before making changes.
+Only report clear, specific contradictions with scene references. Do not report vague impressions.`,
         };
 
         return {

--- a/src/mcp/tools/coaching.ts
+++ b/src/mcp/tools/coaching.ts
@@ -347,6 +347,144 @@ export async function getConsistencyContext(projectId: string, focusSceneId?: st
   };
 }
 
+// ─── Story Bible Cross-Reference ────────────────────────────────────────────
+
+export interface StoryBibleEntry {
+  id: string;
+  type: string;
+  name: string;
+  description: string | null;
+  notes: string | null;
+  role: string | null;
+  tags: string[];
+  linkedSceneIds: string[];
+}
+
+export interface CrossReferenceScene {
+  id: string;
+  title: string;
+  content: string;
+  linkedObjectIds: string[];
+}
+
+export async function getStoryBibleCrossReference(projectId: string, sceneId?: string) {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { title: true },
+  });
+  if (!project) throw new Error("Project not found");
+
+  // Fetch ALL story object types — not just characters
+  const storyObjects = await prisma.storyObject.findMany({
+    where: { projectId },
+    select: { id: true, type: true, name: true, description: true, notes: true, role: true, tags: true },
+  });
+
+  if (storyObjects.length === 0) return { project, storyObjects: [], scenes: [], instructions: "" };
+
+  const scenes = await prisma.structureNode.findMany({
+    where: { projectId, type: "SCENE" },
+    orderBy: { orderIndex: "asc" },
+    select: { id: true, title: true },
+  });
+
+  const targetSceneIds = sceneId
+    ? [sceneId]
+    : scenes.slice(0, 15).map((s) => s.id);
+
+  // Fetch relationships to map objects ↔ scenes
+  const objectIds = storyObjects.map((o) => o.id);
+  const relationships = await prisma.relationship.findMany({
+    where: {
+      OR: [
+        { fromObjectId: { in: objectIds }, toNodeId: { in: targetSceneIds } },
+        { fromNodeId: { in: targetSceneIds }, toObjectId: { in: objectIds } },
+      ],
+    },
+    select: { fromObjectId: true, fromNodeId: true, toObjectId: true, toNodeId: true },
+  });
+
+  // Build bidirectional maps
+  const objectToScenes = new Map<string, Set<string>>();
+  const sceneToObjects = new Map<string, Set<string>>();
+
+  for (const rel of relationships) {
+    const objId = rel.fromObjectId ?? rel.toObjectId;
+    const nodeId = rel.fromNodeId ?? rel.toNodeId;
+    if (!objId || !nodeId) continue;
+
+    if (!objectToScenes.has(objId)) objectToScenes.set(objId, new Set());
+    objectToScenes.get(objId)!.add(nodeId);
+
+    if (!sceneToObjects.has(nodeId)) sceneToObjects.set(nodeId, new Set());
+    sceneToObjects.get(nodeId)!.add(objId);
+  }
+
+  // Fetch scene content with larger windows for cross-referencing
+  const scenesWithContent: CrossReferenceScene[] = [];
+
+  for (const sid of targetSceneIds) {
+    const version = await prisma.contentVersion.findFirst({
+      where: { nodeId: sid },
+      orderBy: { createdAt: "desc" },
+      select: { content: true },
+    });
+    const scene = scenes.find((s) => s.id === sid);
+    if (scene && version?.content) {
+      const textContent = version.content
+        .replace(/<!--[\s\S]*?-->/g, "")
+        .replace(/<[^>]*>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 2000);
+      if (textContent.length > 50) {
+        scenesWithContent.push({
+          id: sid,
+          title: scene.title,
+          content: textContent,
+          linkedObjectIds: Array.from(sceneToObjects.get(sid) ?? []),
+        });
+      }
+    }
+  }
+
+  const storyBibleEntries: StoryBibleEntry[] = storyObjects.map((o) => ({
+    id: o.id,
+    type: o.type,
+    name: o.name,
+    description: o.description?.slice(0, 600) || null,
+    notes: o.notes?.slice(0, 400) || null,
+    role: o.role,
+    tags: o.tags ? (typeof o.tags === "string" ? (o.tags as string).split(",").map((t: string) => t.trim()) : o.tags as string[]) : [],
+    linkedSceneIds: Array.from(objectToScenes.get(o.id) ?? []),
+  }));
+
+  const instructions = `## Cross-Reference Instructions
+
+Compare each story object's defined attributes against how they appear in the prose.
+For each mismatch found, report:
+- **Object**: which story object (name, type, ID)
+- **Attribute**: what differs (e.g. hair color, location description, timeline event)
+- **Story Bible says**: the value from the story object definition
+- **Prose says**: what the scene text states
+- **Scene**: which scene contains the discrepancy (title, ID)
+- **Severity**: CRITICAL (reader-facing contradiction), MAJOR (notable inconsistency), MINOR (trivial difference)
+
+IMPORTANT: Do NOT decide which version is correct. Present both versions and ask the author which is the source of truth. Never silently overwrite either the prose or the story object.
+
+After presenting mismatches, offer these resolution options for each:
+1. **Update story object** → use \`update_story_object\` to sync the bible to match the prose
+2. **Flag scene for revision** → use \`add_annotation\` on the scene to mark the prose for editing
+3. **Keep both** → the difference is intentional (e.g. unreliable narrator, character growth)`;
+
+  return {
+    project,
+    storyObjects: storyBibleEntries,
+    scenes: scenesWithContent,
+    instructions,
+  };
+}
+
 // ─── Voice Context ───────────────────────────────────────────────────────────
 
 export async function getVoiceContext(projectId: string, sceneId: string) {


### PR DESCRIPTION
## Summary
- Extend consistency-check skill to cross-reference prose against story objects
- Surface attribute mismatches, behavioral inconsistencies, timeline contradictions
- Always ask which is source of truth — never silently overwrite
- Add confirmation flow for story object sync

Part of #261

## Source
- Issue: wca-6p3
- Worker: polecat/chrome
- MR: wca-wisp-ckk

## Test plan
- [x] Pre-verified by witness (base SHA matches master)
- [x] Lint: only pre-existing warnings/error (wca-i1w)
- [x] Rebase on master: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)