### PR TITLE
chore: rename default branch from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   lint-and-typecheck:

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -217,7 +217,7 @@ jobs:
               `### Manual rollback steps`,
               `1. Go to [Railway Dashboard](https://railway.app) > Annie project > Deployments`,
               `2. Find the last known-good deployment and click "Rollback"`,
-              `3. Or revert the commit: \`git revert ${shortSha} && git push origin master\``,
+              `3. Or revert the commit: \`git revert ${shortSha} && git push origin main\``,
               ``,
               `### Investigation`,
               `- Check [production health](https://annie.interstellarai.net/api/health)`,

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -117,7 +117,7 @@ No component tests or e2e tests yet (Playwright visual tests in progress).
 ### Code Quality
 - **ESLint**: Modern flat config (eslint.config.mjs)
 - **TypeScript**: Strict mode enabled
-- **Branch protection**: master requires Quality Gates check
+- **Branch protection**: main requires Quality Gates check
 
 ### Networking
 - **Cloudflare Tunnel** — Public access via tunnel token in docker-compose


### PR DESCRIPTION
## Summary
- Updated CI workflow (`ci.yml`) branch triggers from `master` to `main`
- Updated staging pipeline (`staging-smoke.yml`) branch trigger and rollback instructions from `master` to `main`
- Updated `docs/TECH_STACK.md` branch protection reference from `master` to `main`

The GitHub branch rename (`master` -> `main`) and default branch update were done prior to this PR via the GitHub API. Branch protection rules transferred automatically.

### Not changed (intentional)
- `docs/UX_STRATEGY.md` — uses "master list" (English word, not branch name)
- `package-lock.json` — third-party URL referencing bezierjs repo's master branch

## Railway config notes
No `railway.json` or `railway.toml` exists in the repo. Deploys are triggered via GitHub Actions (Railway GraphQL API), not Railway's auto-deploy from a branch. No Railway config changes needed.

## Test plan
- [ ] Verify CI triggers on pushes/PRs to `main`
- [ ] Verify staging pipeline triggers after CI completes on `main`
- [ ] Verify Railway deploys still work via the GraphQL API trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)