### PR TITLE
fix: update project.updatedAt on content and structure changes (wca-03j)

### DIFF
--- a/src/__tests__/beats.test.ts
+++ b/src/__tests__/beats.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/db", () => ({
         },
         project: {
             findUnique: vi.fn(),
+            update: vi.fn(),
         },
     },
 }));
@@ -28,7 +29,7 @@ describe("Scene Beats", () => {
     });
 
     describe("Validation (StructureController.writeSceneContent)", () => {
-        const mockNode = { id: "scene-1", type: "SCENE", title: "Scene 1" };
+        const mockNode = { id: "scene-1", type: "SCENE", title: "Scene 1", projectId: "proj-1" };
 
         it("should accept content with valid beats", async () => {
             (prisma.structureNode.findUnique as any).mockResolvedValue(mockNode);

--- a/src/lib/controllers/structure.ts
+++ b/src/lib/controllers/structure.ts
@@ -201,11 +201,20 @@ export class StructureController {
             },
         });
 
+        const createPromises: Promise<unknown>[] = [
+            prisma.project.update({
+                where: { id: projectId },
+                data: { updatedAt: new Date() },
+            }),
+        ];
         if (type === "SCENE") {
-            await prisma.contentVersion.create({
-                data: { nodeId: node.id, content: "", wordCount: 0 },
-            });
+            createPromises.push(
+                prisma.contentVersion.create({
+                    data: { nodeId: node.id, content: "", wordCount: 0 },
+                })
+            );
         }
+        await Promise.all(createPromises);
 
         return {
             id: node.id,
@@ -255,10 +264,16 @@ export class StructureController {
             throw new Error("No fields to update");
         }
 
-        const node = await prisma.structureNode.update({
-            where: { id: nodeId },
-            data: updateData,
-        });
+        const [node] = await Promise.all([
+            prisma.structureNode.update({
+                where: { id: nodeId },
+                data: updateData,
+            }),
+            prisma.project.update({
+                where: { id: existing.projectId },
+                data: { updatedAt: new Date() },
+            }),
+        ]);
 
         return {
             id: node.id,
@@ -286,7 +301,13 @@ export class StructureController {
             logger.warn("Snapshot failed or not available", e);
         }
 
-        await prisma.structureNode.delete({ where: { id: nodeId } });
+        await Promise.all([
+            prisma.structureNode.delete({ where: { id: nodeId } }),
+            prisma.project.update({
+                where: { id: node.projectId },
+                data: { updatedAt: new Date() },
+            }),
+        ]);
 
         const siblings = await prisma.structureNode.findMany({
             where: { projectId: node.projectId, parentId: node.parentId },
@@ -362,7 +383,7 @@ export class StructureController {
     static async writeSceneContent(nodeId: string, content: string) {
         const node = await prisma.structureNode.findUnique({
             where: { id: nodeId },
-            select: { id: true, type: true, title: true },
+            select: { id: true, type: true, title: true, projectId: true },
         });
         if (!node) throw new Error(`Node not found: ${nodeId}`);
         if (node.type !== "SCENE") throw new Error("Content can only be written to SCENE nodes");
@@ -379,9 +400,15 @@ export class StructureController {
         const prose = stripped.replace(/<[^>]*>/g, " ").replace(/&nbsp;/gi, " ").replace(/\s+/g, " ").trim();
         const wordCount = prose === "" ? 0 : prose.split(/\s+/).length;
 
-        const version = await prisma.contentVersion.create({
-            data: { nodeId, content, wordCount },
-        });
+        const [version] = await Promise.all([
+            prisma.contentVersion.create({
+                data: { nodeId, content, wordCount },
+            }),
+            prisma.project.update({
+                where: { id: node.projectId },
+                data: { updatedAt: new Date() },
+            }),
+        ]);
 
         // Prune old versions (keep latest 50)
         const allVersions = await prisma.contentVersion.findMany({
@@ -439,7 +466,7 @@ export class StructureController {
     static async restoreSceneVersion(nodeId: string, versionId: string) {
         const node = await prisma.structureNode.findUnique({
             where: { id: nodeId },
-            select: { id: true, title: true },
+            select: { id: true, title: true, projectId: true },
         });
         if (!node) throw new Error(`Node not found: ${nodeId}`);
 
@@ -448,13 +475,19 @@ export class StructureController {
         });
         if (!oldVersion) throw new Error(`Version not found: ${versionId}`);
 
-        const newVersion = await prisma.contentVersion.create({
-            data: {
-                nodeId,
-                content: oldVersion.content,
-                wordCount: oldVersion.wordCount,
-            },
-        });
+        const [newVersion] = await Promise.all([
+            prisma.contentVersion.create({
+                data: {
+                    nodeId,
+                    content: oldVersion.content,
+                    wordCount: oldVersion.wordCount,
+                },
+            }),
+            prisma.project.update({
+                where: { id: node.projectId },
+                data: { updatedAt: new Date() },
+            }),
+        ]);
 
         return {
             nodeId,


### PR DESCRIPTION
## Summary
- Updates `project.updatedAt` timestamp when content or structure changes occur
- Adds missing `prisma.project.update` mock to beats tests
- Ensures top project sorting reflects most recently edited

Part of https://github.com/alexsiri7/word-coach-annie/issues?q=wca-03j

## Test plan
- [x] Lint passes (warnings only, pre-existing)
- [ ] CI checks pass
- [ ] Verify project timestamps update on content/structure changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)