### PR TITLE
feat: add per-user API rate limiting (wca-sob)

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -19,11 +19,13 @@ vi.mock("@/lib/auth", () => ({
 import { isAuthEnabled, deriveSessionToken, verifySessionToken } from "@/lib/auth";
 
 function createRequest(path: string, options?: {
+    method?: string;
     headers?: Record<string, string>;
     cookies?: Record<string, string>;
 }): NextRequest {
     const url = `http://localhost:3000${path}`;
     const req = new NextRequest(url, {
+        method: options?.method ?? "GET",
         headers: options?.headers,
     });
     if (options?.cookies) {
@@ -151,6 +153,7 @@ describe("middleware", () => {
             // Send 30 requests (the chat limit)
             for (let i = 0; i < 30; i++) {
                 const req = createRequest("/api/chat", {
+                    method: "POST",
                     cookies: { annie_session: "valid-jwt" },
                 });
                 const res = await middleware(req);
@@ -159,6 +162,7 @@ describe("middleware", () => {
 
             // 31st should be rate limited
             const req = createRequest("/api/chat", {
+                method: "POST",
                 cookies: { annie_session: "valid-jwt" },
             });
             const res = await middleware(req);
@@ -174,6 +178,7 @@ describe("middleware", () => {
 
             for (let i = 0; i < 30; i++) {
                 const req = createRequest("/api/chat", {
+                    method: "POST",
                     headers: { authorization: "Bearer test-token" },
                 });
                 const res = await middleware(req);
@@ -181,22 +186,23 @@ describe("middleware", () => {
             }
 
             const req = createRequest("/api/chat", {
+                method: "POST",
                 headers: { authorization: "Bearer test-token" },
             });
             const res = await middleware(req);
             expect(res.status).toBe(429);
         });
 
-        it("allows non-chat API requests up to 100/min", async () => {
+        it("allows read API requests up to 120/min", async () => {
             vi.mocked(isAuthEnabled).mockReturnValue(true);
             vi.mocked(verifySessionToken).mockResolvedValue({
-                userId: "api-test-user",
+                userId: "read-test-user",
                 email: "test@example.com",
                 name: "Test",
             });
 
-            // 100 requests should all pass
-            for (let i = 0; i < 100; i++) {
+            // 120 GET requests should all pass
+            for (let i = 0; i < 120; i++) {
                 const req = createRequest("/api/projects", {
                     cookies: { annie_session: "valid-jwt" },
                 });
@@ -204,25 +210,108 @@ describe("middleware", () => {
                 expect(res.status).toBe(200);
             }
 
-            // 101st should fail
+            // 121st should fail
             const req = createRequest("/api/projects", {
                 cookies: { annie_session: "valid-jwt" },
             });
             const res = await middleware(req);
             expect(res.status).toBe(429);
+            expect(res.headers.get("X-RateLimit-Limit")).toBe("120");
+        });
+
+        it("allows write API requests up to 60/min", async () => {
+            vi.mocked(isAuthEnabled).mockReturnValue(true);
+            vi.mocked(verifySessionToken).mockResolvedValue({
+                userId: "write-test-user",
+                email: "test@example.com",
+                name: "Test",
+            });
+
+            // 60 PATCH requests should all pass
+            for (let i = 0; i < 60; i++) {
+                const req = createRequest("/api/nodes/123", {
+                    method: "PATCH",
+                    cookies: { annie_session: "valid-jwt" },
+                });
+                const res = await middleware(req);
+                expect(res.status).toBe(200);
+            }
+
+            // 61st should fail
+            const req = createRequest("/api/nodes/123", {
+                method: "PATCH",
+                cookies: { annie_session: "valid-jwt" },
+            });
+            const res = await middleware(req);
+            expect(res.status).toBe(429);
+            expect(res.headers.get("X-RateLimit-Limit")).toBe("60");
+        });
+
+        it("returns 429 when project creation limit exceeded (10/hour)", async () => {
+            vi.mocked(isAuthEnabled).mockReturnValue(true);
+            vi.mocked(verifySessionToken).mockResolvedValue({
+                userId: "project-create-user",
+                email: "test@example.com",
+                name: "Test",
+            });
+
+            // 10 project creates should pass
+            for (let i = 0; i < 10; i++) {
+                const req = createRequest("/api/projects", {
+                    method: "POST",
+                    cookies: { annie_session: "valid-jwt" },
+                });
+                const res = await middleware(req);
+                expect(res.status).toBe(200);
+            }
+
+            // 11th should be rate limited
+            const req = createRequest("/api/projects", {
+                method: "POST",
+                cookies: { annie_session: "valid-jwt" },
+            });
+            const res = await middleware(req);
+            expect(res.status).toBe(429);
+            expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+        });
+
+        it("project create limit does not affect other POST routes", async () => {
+            vi.mocked(isAuthEnabled).mockReturnValue(true);
+            vi.mocked(verifySessionToken).mockResolvedValue({
+                userId: "project-create-separate",
+                email: "test@example.com",
+                name: "Test",
+            });
+
+            // Max out project creates
+            for (let i = 0; i < 10; i++) {
+                const req = createRequest("/api/projects", {
+                    method: "POST",
+                    cookies: { annie_session: "valid-jwt" },
+                });
+                await middleware(req);
+            }
+
+            // POST to another endpoint should still work (uses write limit)
+            const req = createRequest("/api/nodes/123", {
+                method: "POST",
+                cookies: { annie_session: "valid-jwt" },
+            });
+            const res = await middleware(req);
+            expect(res.status).toBe(200);
         });
 
         it("does not rate limit when auth is disabled", async () => {
             vi.mocked(isAuthEnabled).mockReturnValue(false);
             // Should always pass through without rate limiting
             for (let i = 0; i < 50; i++) {
-                const req = createRequest("/api/chat");
+                const req = createRequest("/api/chat", { method: "POST" });
                 const res = await middleware(req);
                 expect(res.status).toBe(200);
             }
         });
 
-        it("tracks chat and API limits separately", async () => {
+        it("tracks chat and read/write limits separately", async () => {
             vi.mocked(isAuthEnabled).mockReturnValue(true);
             vi.mocked(verifySessionToken).mockResolvedValue({
                 userId: "separate-test",
@@ -233,6 +322,7 @@ describe("middleware", () => {
             // Max out chat limit
             for (let i = 0; i < 30; i++) {
                 const req = createRequest("/api/chat", {
+                    method: "POST",
                     cookies: { annie_session: "valid-jwt" },
                 });
                 await middleware(req);
@@ -240,15 +330,47 @@ describe("middleware", () => {
 
             // Chat should be blocked
             const chatReq = createRequest("/api/chat", {
+                method: "POST",
                 cookies: { annie_session: "valid-jwt" },
             });
             expect((await middleware(chatReq)).status).toBe(429);
 
-            // But API should still work
+            // But read API should still work
             const apiReq = createRequest("/api/projects", {
                 cookies: { annie_session: "valid-jwt" },
             });
             expect((await middleware(apiReq)).status).toBe(200);
+        });
+
+        it("tracks read and write limits separately", async () => {
+            vi.mocked(isAuthEnabled).mockReturnValue(true);
+            vi.mocked(verifySessionToken).mockResolvedValue({
+                userId: "rw-separate-test",
+                email: "test@example.com",
+                name: "Test",
+            });
+
+            // Max out write limit (60)
+            for (let i = 0; i < 60; i++) {
+                const req = createRequest(`/api/nodes/${i}`, {
+                    method: "PATCH",
+                    cookies: { annie_session: "valid-jwt" },
+                });
+                await middleware(req);
+            }
+
+            // Write should be blocked
+            const writeReq = createRequest("/api/nodes/999", {
+                method: "PATCH",
+                cookies: { annie_session: "valid-jwt" },
+            });
+            expect((await middleware(writeReq)).status).toBe(429);
+
+            // But read should still work
+            const readReq = createRequest("/api/projects", {
+                cookies: { annie_session: "valid-jwt" },
+            });
+            expect((await middleware(readReq)).status).toBe(200);
         });
     });
 });

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -54,8 +54,12 @@ describe("rate-limit", () => {
     it("has correct default configs", () => {
         expect(RATE_LIMITS.chat.limit).toBe(30);
         expect(RATE_LIMITS.chat.windowMs).toBe(60_000);
-        expect(RATE_LIMITS.api.limit).toBe(100);
-        expect(RATE_LIMITS.api.windowMs).toBe(60_000);
+        expect(RATE_LIMITS.read.limit).toBe(120);
+        expect(RATE_LIMITS.read.windowMs).toBe(60_000);
+        expect(RATE_LIMITS.write.limit).toBe(60);
+        expect(RATE_LIMITS.write.windowMs).toBe(60_000);
+        expect(RATE_LIMITS.projectCreate.limit).toBe(10);
+        expect(RATE_LIMITS.projectCreate.windowMs).toBe(3_600_000);
     });
 
     it("provides retryAfterMs on rejection", () => {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -85,8 +85,12 @@ export function checkRateLimit(
 export const RATE_LIMITS = {
     /** AI chat endpoint: 30 requests per minute per user */
     chat: { limit: 30, windowMs: 60_000 } satisfies RateLimitConfig,
-    /** General API: 100 requests per minute per user */
-    api: { limit: 100, windowMs: 60_000 } satisfies RateLimitConfig,
+    /** Read operations (GET): 120 requests per minute per user */
+    read: { limit: 120, windowMs: 60_000 } satisfies RateLimitConfig,
+    /** Write operations (POST/PATCH/DELETE): 60 requests per minute per user */
+    write: { limit: 60, windowMs: 60_000 } satisfies RateLimitConfig,
+    /** Project creation (POST /api/projects): 10 per hour per user */
+    projectCreate: { limit: 10, windowMs: 3_600_000 } satisfies RateLimitConfig,
 };
 
 /** Clear all entries (for testing) */

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,38 +30,85 @@ function isPublicPath(pathname: string): boolean {
     );
 }
 
+function makeRateLimitResponse(
+    config: { limit: number; windowMs: number },
+    retryAfterMs: number,
+    resetMs: number
+): NextResponse {
+    const retryAfterSec = Math.ceil((retryAfterMs ?? 1000) / 1000);
+    return NextResponse.json(
+        { error: "Too many requests. Please try again later." },
+        {
+            status: 429,
+            headers: {
+                "Retry-After": String(retryAfterSec),
+                "X-RateLimit-Limit": String(config.limit),
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": String(Math.ceil(resetMs / 1000)),
+            },
+        }
+    );
+}
+
 /**
  * Apply per-user rate limiting on API routes.
- * Chat endpoint: 30 req/min. Other API routes: 100 req/min.
- * Returns a 429 response if the limit is exceeded, or null if allowed.
+ * - Chat: 30 req/min
+ * - Read (GET): 120 req/min
+ * - Write (POST/PATCH/DELETE): 60 req/min
+ * - Project creation (POST /api/projects): 10/hour
+ * Returns a 429 response if any limit is exceeded, or null if allowed.
  */
 function applyRateLimit(
-    pathname: string,
+    request: NextRequest,
     userKey: string
 ): NextResponse | null {
+    const pathname = request.nextUrl.pathname;
     if (!pathname.startsWith("/api/")) return null;
 
+    const method = request.method;
+
+    // Chat endpoint has its own dedicated limit
     const isChatRoute =
         pathname === "/api/chat" || pathname.startsWith("/api/chat/");
-    const config = isChatRoute ? RATE_LIMITS.chat : RATE_LIMITS.api;
-    const prefix = isChatRoute ? "chat" : "api";
+    if (isChatRoute) {
+        const result = checkRateLimit(`chat:${userKey}`, RATE_LIMITS.chat);
+        if (!result.allowed) {
+            return makeRateLimitResponse(
+                RATE_LIMITS.chat,
+                result.retryAfterMs!,
+                result.resetMs
+            );
+        }
+        return null;
+    }
+
+    // Project creation: POST /api/projects (not /api/projects/:id subpaths)
+    const isProjectCreate = method === "POST" && pathname === "/api/projects";
+    if (isProjectCreate) {
+        const result = checkRateLimit(
+            `projectCreate:${userKey}`,
+            RATE_LIMITS.projectCreate
+        );
+        if (!result.allowed) {
+            return makeRateLimitResponse(
+                RATE_LIMITS.projectCreate,
+                result.retryAfterMs!,
+                result.resetMs
+            );
+        }
+    }
+
+    // Read vs write rate limit
+    const isRead = method === "GET" || method === "HEAD";
+    const config = isRead ? RATE_LIMITS.read : RATE_LIMITS.write;
+    const prefix = isRead ? "read" : "write";
     const result = checkRateLimit(`${prefix}:${userKey}`, config);
 
     if (!result.allowed) {
-        const retryAfterSec = Math.ceil((result.retryAfterMs ?? 1000) / 1000);
-        return NextResponse.json(
-            { error: "Too many requests. Please try again later." },
-            {
-                status: 429,
-                headers: {
-                    "Retry-After": String(retryAfterSec),
-                    "X-RateLimit-Limit": String(config.limit),
-                    "X-RateLimit-Remaining": "0",
-                    "X-RateLimit-Reset": String(
-                        Math.ceil(result.resetMs / 1000)
-                    ),
-                },
-            }
+        return makeRateLimitResponse(
+            config,
+            result.retryAfterMs!,
+            result.resetMs
         );
     }
 
@@ -91,7 +138,7 @@ export async function middleware(request: NextRequest) {
 
         // 1. Check static API_TOKEN
         if (token && apiToken && token === apiToken) {
-            const rateLimited = applyRateLimit(pathname, "apitoken");
+            const rateLimited = applyRateLimit(request, "apitoken");
             if (rateLimited) return rateLimited;
             return NextResponse.next();
         }
@@ -100,7 +147,7 @@ export async function middleware(request: NextRequest) {
         if (token) {
             const mcpSession = await verifyMcpToken(token, "mcp_access");
             if (mcpSession) {
-                const rateLimited = applyRateLimit(pathname, mcpSession.userId);
+                const rateLimited = applyRateLimit(request, mcpSession.userId);
                 if (rateLimited) return rateLimited;
 
                 Sentry.setUser({
@@ -133,7 +180,7 @@ export async function middleware(request: NextRequest) {
         const session = await verifySessionToken(sessionCookie);
         if (session) {
             // Rate limit by authenticated user ID
-            const rateLimited = applyRateLimit(pathname, session.userId);
+            const rateLimited = applyRateLimit(request, session.userId);
             if (rateLimited) return rateLimited;
 
             // Set Sentry user context for error attribution
@@ -156,7 +203,7 @@ export async function middleware(request: NextRequest) {
             const expected = await deriveSessionToken(apiToken);
             if (sessionCookie === expected) {
                 // Rate limit legacy sessions by token
-                const rateLimited = applyRateLimit(pathname, "apitoken");
+                const rateLimited = applyRateLimit(request, "apitoken");
                 if (rateLimited) return rateLimited;
                 return NextResponse.next();
             }


### PR DESCRIPTION
## Summary

- Adds rate limit middleware: 60 req/min writes, 120 reads, 10 project creates/hour
- Returns 429 with Retry-After header
- Required for open registration security

Part of #311

---
*Created by Gas Town Refinery*