### PR TITLE
feat: add privacy policy and terms of service pages (wca-1kk)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { UpdateBanner } from "@/components/update-banner";
 import { SwLifecycle } from "@/components/sw-lifecycle";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ToastProvider } from "@/components/ui/toast";
+import { SiteFooter } from "@/components/site-footer";
 
 export const metadata: Metadata = {
   title: {
@@ -65,6 +66,7 @@ export default function RootLayout({
             {children}
             <SyncToast />
           </ToastProvider>
+          <SiteFooter />
           <OfflineIndicator />
           <SwLifecycle />
         </ThemeProvider>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -122,6 +122,15 @@ export default function LoginPage() {
                 <Suspense>
                     <LoginForm />
                 </Suspense>
+                <div className="text-center text-xs text-muted-foreground pt-2">
+                    <a href="/privacy" className="hover:text-foreground transition-colors">
+                        Privacy
+                    </a>
+                    {" · "}
+                    <a href="/terms" className="hover:text-foreground transition-colors">
+                        Terms
+                    </a>
+                </div>
             </div>
         </div>
     );

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,138 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "Word Coach Annie Privacy Policy",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main id="main-content" className="min-h-screen">
+      <div className="h-1 accent-gradient" />
+
+      <div className="max-w-2xl mx-auto px-6 py-10">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-text-muted hover:text-text-primary mb-10"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Link>
+
+        <h1 className="text-2xl font-bold tracking-tight text-text-primary mb-2">
+          Privacy Policy
+        </h1>
+        <p className="text-sm text-text-muted mb-8">
+          Last updated: April 2026
+        </p>
+
+        <div className="space-y-8 text-sm text-text-secondary leading-relaxed">
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Your manuscripts are yours
+            </h2>
+            <p>
+              Word Coach Annie is a writing tool. Everything you write — manuscripts,
+              scenes, notes, character sheets, world-building documents — belongs
+              entirely to you. We do not claim any rights to your creative work.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              What we store
+            </h2>
+            <p>
+              Your data is stored in a private SQLite database on the server that
+              hosts your instance. This includes:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>Your account information (email address, display name)</li>
+              <li>Projects, scenes, and all manuscript content you create</li>
+              <li>Universes, characters, locations, and world-building entries</li>
+              <li>Version history of your writing (for the undo/version feature)</li>
+            </ul>
+            <p>
+              We do not store passwords. Authentication is handled through Google
+              OAuth or admin-issued access tokens.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              No AI training on your work
+            </h2>
+            <p>
+              Your manuscripts and creative content are never used to train AI
+              models. If you use Annie&apos;s optional AI-assisted features (such as
+              brainstorming prompts), your content is sent to the AI provider only
+              for that specific request and is not retained for training purposes.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Data sharing
+            </h2>
+            <p>
+              We do not sell, share, or distribute your personal data or creative
+              work to third parties. The only external services that may receive
+              data are:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>
+                <strong>Google OAuth</strong> — your email address, solely for
+                authentication
+              </li>
+              <li>
+                <strong>Sentry</strong> — anonymous error reports to help us fix
+                bugs (no manuscript content is included)
+              </li>
+            </ul>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Your right to delete
+            </h2>
+            <p>
+              You can delete any project, scene, or universe entry at any time from
+              within the app. Deleted items are removed from the database.
+            </p>
+            <p>
+              To delete your entire account and all associated data, contact the
+              instance administrator. We will remove all your data promptly upon
+              request.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Cookies
+            </h2>
+            <p>
+              We use a single session cookie to keep you signed in. We do not use
+              tracking cookies or third-party analytics.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Changes to this policy
+            </h2>
+            <p>
+              If we make material changes to this privacy policy, we will update
+              this page and the &ldquo;last updated&rdquo; date above.
+            </p>
+          </section>
+        </div>
+
+        <div className="mt-12 pt-6 border-t border-border text-xs text-text-muted">
+          Questions? Contact the instance administrator.
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,125 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description: "Word Coach Annie Terms of Service",
+};
+
+export default function TermsPage() {
+  return (
+    <main id="main-content" className="min-h-screen">
+      <div className="h-1 accent-gradient" />
+
+      <div className="max-w-2xl mx-auto px-6 py-10">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-text-muted hover:text-text-primary mb-10"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Link>
+
+        <h1 className="text-2xl font-bold tracking-tight text-text-primary mb-2">
+          Terms of Service
+        </h1>
+        <p className="text-sm text-text-muted mb-8">
+          Last updated: April 2026
+        </p>
+
+        <div className="space-y-8 text-sm text-text-secondary leading-relaxed">
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              What Word Coach Annie is
+            </h2>
+            <p>
+              Word Coach Annie is a fiction writing and book management tool. It
+              helps you organize manuscripts, track characters and worlds, and
+              manage your creative projects.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Your content
+            </h2>
+            <p>
+              You retain full ownership of everything you create in Word Coach
+              Annie. We do not claim any intellectual property rights over your
+              manuscripts, characters, world-building, or any other content you
+              produce using the tool.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Acceptable use
+            </h2>
+            <p>
+              You agree to use Word Coach Annie for its intended purpose as a
+              writing tool. You may not:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>Attempt to gain unauthorized access to other users&apos; accounts or data</li>
+              <li>Use automated tools to scrape or overload the service</li>
+              <li>Upload malicious content or code</li>
+            </ul>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Service availability
+            </h2>
+            <p>
+              Word Coach Annie is provided as-is. While we strive to keep the
+              service available and your data safe (with regular backups), we
+              cannot guarantee uninterrupted access. We recommend keeping local
+              copies of important work.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Data and privacy
+            </h2>
+            <p>
+              Your use of Word Coach Annie is also governed by our{" "}
+              <Link href="/privacy" className="text-accent hover:underline">
+                Privacy Policy
+              </Link>
+              , which describes how we handle your data, including our commitment
+              to never use your creative work for AI training.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Account termination
+            </h2>
+            <p>
+              You may request deletion of your account and data at any time by
+              contacting the instance administrator. We reserve the right to
+              suspend accounts that violate these terms.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Changes to these terms
+            </h2>
+            <p>
+              If we make material changes to these terms, we will update this page
+              and the &ldquo;last updated&rdquo; date above. Continued use of the
+              service after changes constitutes acceptance.
+            </p>
+          </section>
+        </div>
+
+        <div className="mt-12 pt-6 border-t border-border text-xs text-text-muted">
+          Questions? Contact the instance administrator.
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-border bg-surface py-6 text-center text-xs text-text-muted">
+      <div className="max-w-7xl mx-auto px-6 flex items-center justify-center gap-3">
+        <Link href="/privacy" className="hover:text-text-primary transition-colors">
+          Privacy
+        </Link>
+        <span aria-hidden="true">&middot;</span>
+        <Link href="/terms" className="hover:text-text-primary transition-colors">
+          Terms
+        </Link>
+      </div>
+    </footer>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,6 +18,8 @@ const PUBLIC_PATHS = [
     "/api/auth/google",
     "/api/auth/me",
     "/login",
+    "/privacy",
+    "/terms",
     "/.well-known/oauth-authorization-server",
     "/oauth/register",
     "/oauth/token",


### PR DESCRIPTION
## Summary

- Adds static /privacy and /terms pages
- Links from login and footer
- Covers manuscript privacy, data storage, no AI training, right to delete

Part of #313

---
*Created by Gas Town Refinery*