### PR TITLE
Fix test: timeline header mismatch in mcp-export (wca-l4q)

### DIFF
--- a/src/__tests__/mcp-export.test.ts
+++ b/src/__tests__/mcp-export.test.ts
@@ -229,7 +229,7 @@ describe("MCP Export Tools", () => {
             expect(md).toContain("The main character");
             expect(md).toContain("**Tags:** main");
             expect(md).toContain("*Notes:* Very brave");
-            expect(md).toContain("**Timeline:**");
+            expect(md).toContain("**Timeline (state history):**");
             expect(md).toContain("**Birth**: Born in a village");
         });
 

--- a/src/mcp/tools/export.ts
+++ b/src/mcp/tools/export.ts
@@ -473,7 +473,7 @@ export async function exportUniverse(universeId: string): Promise<string> {
             if (obj.notes) lines.push(`*Notes:* ${obj.notes}\n`);
 
             if (obj.timeline.length > 0) {
-                lines.push(`\n**Timeline:**\n`);
+                lines.push(`\n**Timeline (state history):**\n`);
                 for (const entry of obj.timeline) {
                     lines.push(`- **${entry.label}**: ${entry.description}`);
                 }


### PR DESCRIPTION
## Summary

Automated merge from polecat branch.

- **Issue**: wca-l4q
- **Polecat**: rust
- **Branch**: polecat/rust/wca-l4q@mngrh9d1
- **Tests**: Passed (verified by refinery)

Fixes test failure from wca-75r timeline header rename.

---
*Created by Gas Town Refinery*