### PR TITLE
feat: add bidirectional relationship display on world objects (wca-64t)

### DIFF
--- a/src/app/api/story-objects/[id]/route.ts
+++ b/src/app/api/story-objects/[id]/route.ts
@@ -18,12 +18,14 @@ export async function GET(
           include: {
             toNode: { select: { id: true, title: true, type: true } },
             toObject: { select: { id: true, name: true, type: true } },
+            toWorldObject: { select: { id: true, name: true, type: true } },
           },
         },
         relatedBy: {
           include: {
             fromNode: { select: { id: true, title: true, type: true } },
             fromObject: { select: { id: true, name: true, type: true } },
+            fromWorldObject: { select: { id: true, name: true, type: true } },
           },
         },
       },

--- a/src/components/story-object-panel.tsx
+++ b/src/components/story-object-panel.tsx
@@ -118,8 +118,10 @@ export function StoryObjectPanel({ objectId, source = "project", onClose, onDele
             label: string;
             toNode?: { id: string; title: string; type: string } | null;
             toObject?: { id: string; name: string; type: string } | null;
+            toWorldObject?: { id: string; name: string; type: string } | null;
             fromNode?: { id: string; title: string; type: string } | null;
             fromObject?: { id: string; name: string; type: string } | null;
+            fromWorldObject?: { id: string; name: string; type: string } | null;
         }
         if (Array.isArray(data.relationships)) {
             for (const r of data.relationships as RawRelationship[]) {
@@ -127,7 +129,9 @@ export function StoryObjectPanel({ objectId, source = "project", onClose, onDele
                     ? { id: r.toNode.id, name: r.toNode.title, entityType: r.toNode.type }
                     : r.toObject
                         ? { id: r.toObject.id, name: r.toObject.name, entityType: r.toObject.type }
-                        : null;
+                        : r.toWorldObject
+                            ? { id: r.toWorldObject.id, name: r.toWorldObject.name, entityType: r.toWorldObject.type }
+                            : null;
                 rels.push({ relationshipId: r.id, type: r.type, label: r.label, direction: "outgoing", target });
             }
         }
@@ -137,7 +141,9 @@ export function StoryObjectPanel({ objectId, source = "project", onClose, onDele
                     ? { id: r.fromNode.id, name: r.fromNode.title, entityType: r.fromNode.type }
                     : r.fromObject
                         ? { id: r.fromObject.id, name: r.fromObject.name, entityType: r.fromObject.type }
-                        : null;
+                        : r.fromWorldObject
+                            ? { id: r.fromWorldObject.id, name: r.fromWorldObject.name, entityType: r.fromWorldObject.type }
+                            : null;
                 rels.push({ relationshipId: r.id, type: r.type, label: r.label, direction: "incoming", target });
             }
         }

--- a/src/components/world-object-panel.tsx
+++ b/src/components/world-object-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { X, Save, Trash2, Plus, Clock, MoveUp, MoveDown } from "lucide-react";
+import { X, Save, Trash2, Plus, Clock, MoveUp, MoveDown, Link } from "lucide-react";
 import { offlineFetch } from "@/lib/offline/sync-queue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -16,7 +16,59 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import type { WorldObject, WorldObjectTimelineEntry } from "@/lib/types";
+import type { WorldObject, WorldObjectTimelineEntry, Relationship } from "@/lib/types";
+
+const RELATIONSHIP_TYPE_LABELS: Record<string, string> = {
+    APPEARS_IN: "Appears in",
+    LOCATED_AT: "Located at",
+    PART_OF_PLOTLINE: "Part of plotline",
+    RELATED_TO: "Related to",
+    INTERACTS_WITH: "Interacts with",
+    CONTAINS: "Contains",
+    PRECEDES: "Precedes",
+    FOLLOWS: "Follows",
+};
+
+interface NormalizedRelationship {
+    relationshipId: string;
+    type: string;
+    label: string;
+    direction: "outgoing" | "incoming";
+    target: {
+        id: string;
+        name: string;
+        entityType: string;
+    } | null;
+}
+
+function normalizeRelationships(data: WorldObject): NormalizedRelationship[] {
+    const rels: NormalizedRelationship[] = [];
+    if (Array.isArray(data.relationships)) {
+        for (const r of data.relationships as Relationship[]) {
+            const target = r.toNode
+                ? { id: r.toNode.id, name: (r.toNode as unknown as { title: string }).title, entityType: r.toNode.type as string }
+                : r.toObject
+                    ? { id: r.toObject.id, name: r.toObject.name, entityType: r.toObject.type }
+                    : r.toWorldObject
+                        ? { id: r.toWorldObject.id, name: r.toWorldObject.name, entityType: r.toWorldObject.type }
+                        : null;
+            rels.push({ relationshipId: r.id, type: r.type, label: r.label, direction: "outgoing", target });
+        }
+    }
+    if (Array.isArray(data.relatedBy)) {
+        for (const r of data.relatedBy as Relationship[]) {
+            const target = r.fromNode
+                ? { id: r.fromNode.id, name: (r.fromNode as unknown as { title: string }).title, entityType: r.fromNode.type as string }
+                : r.fromObject
+                    ? { id: r.fromObject.id, name: r.fromObject.name, entityType: r.fromObject.type }
+                    : r.fromWorldObject
+                        ? { id: r.fromWorldObject.id, name: r.fromWorldObject.name, entityType: r.fromWorldObject.type }
+                        : null;
+            rels.push({ relationshipId: r.id, type: r.type, label: r.label, direction: "incoming", target });
+        }
+    }
+    return rels;
+}
 
 interface WorldObjectPanelProps {
     objectId: string;
@@ -41,6 +93,7 @@ export function WorldObjectPanel({ objectId, onClose, onDeleted, onUpdated }: Wo
     const [newEntryOpen, setNewEntryOpen] = useState(false);
     const [newEntryLabel, setNewEntryLabel] = useState("");
     const [newEntryDesc, setNewEntryDesc] = useState("");
+    const [relationships, setRelationships] = useState<NormalizedRelationship[]>([]);
 
     const fetchWo = async () => {
         const res = await fetch(`/api/world-objects/${objectId}`);
@@ -53,6 +106,7 @@ export function WorldObjectPanel({ objectId, onClose, onDeleted, onUpdated }: Wo
             setType(data.type || "");
             setTags(data.tags || "");
             setTimeline(data.timeline || []);
+            setRelationships(normalizeRelationships(data));
         }
     };
 
@@ -244,6 +298,40 @@ export function WorldObjectPanel({ objectId, onClose, onDeleted, onUpdated }: Wo
                         ))}
                     </div>
                 </div>
+
+                {/* Relationships Section */}
+                {relationships.length > 0 && (
+                    <div className="space-y-4 border-t border-border pt-6">
+                        <div className="flex items-center gap-2">
+                            <Link className="h-4 w-4 text-accent" />
+                            <h3 className="text-sm font-semibold text-text-primary tracking-tight">Relationships</h3>
+                        </div>
+                        <div className="space-y-1.5">
+                            {relationships.map((rel) => (
+                                <div
+                                    key={rel.relationshipId}
+                                    className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-surface-overlay/50 hover:bg-surface-overlay transition-colors"
+                                >
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-1.5 text-xs">
+                                            <span className="tag-pill text-[10px] px-1.5 py-0.5 bg-accent/10 text-accent/80">
+                                                {rel.direction === "incoming" ? "\u2190" : "\u2192"} {RELATIONSHIP_TYPE_LABELS[rel.type] || rel.type}
+                                            </span>
+                                            {rel.target && (
+                                                <span className="truncate font-medium text-text-primary">
+                                                    {rel.target.name}
+                                                </span>
+                                            )}
+                                        </div>
+                                        {rel.label && (
+                                            <p className="text-[11px] text-text-muted mt-0.5 truncate">{rel.label}</p>
+                                        )}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
 
                 {/* Tags */}
                 <div className="border-t border-border pt-6">

--- a/src/lib/controllers/universes.ts
+++ b/src/lib/controllers/universes.ts
@@ -119,6 +119,20 @@ export class UniversesController {
                 timeline: {
                     orderBy: { orderIndex: "asc" },
                 },
+                relationships: {
+                    include: {
+                        toNode: { select: { id: true, title: true, type: true } },
+                        toObject: { select: { id: true, name: true, type: true } },
+                        toWorldObject: { select: { id: true, name: true, type: true } },
+                    },
+                },
+                relatedBy: {
+                    include: {
+                        fromNode: { select: { id: true, title: true, type: true } },
+                        fromObject: { select: { id: true, name: true, type: true } },
+                        fromWorldObject: { select: { id: true, name: true, type: true } },
+                    },
+                },
             },
         });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,8 @@ export interface WorldObject {
   createdAt: string;
   updatedAt: string;
   timeline?: WorldObjectTimelineEntry[];
+  relationships?: Relationship[];
+  relatedBy?: Relationship[];
 }
 
 export interface WorldObjectTimelineEntry {
@@ -105,13 +107,17 @@ export interface Relationship {
   label: string;
   fromNodeId: string | null;
   fromObjectId: string | null;
+  fromWorldObjectId: string | null;
   toNodeId: string | null;
   toObjectId: string | null;
+  toWorldObjectId: string | null;
   createdAt: string;
   fromNode?: StructureNode;
   fromObject?: StoryObject;
+  fromWorldObject?: WorldObject;
   toNode?: StructureNode;
   toObject?: StoryObject;
+  toWorldObject?: WorldObject;
 }
 
 export interface ContentVersion {


### PR DESCRIPTION
## Summary

- Adds bidirectional relationship display on world objects
- Updates story-object and world-object panels to show related objects
- Part of #301

**Issue**: wca-64t
**Polecat**: chrome
**Branch**: polecat/chrome/wca-64t@mnhfo2wi

---
*Created by Gas Town Refinery*