### PR TITLE
feat: Medium publish dialog and export button (#344)

### DIFF
--- a/prisma/migrations/20260402_add_medium_integration/migration.sql
+++ b/prisma/migrations/20260402_add_medium_integration/migration.sql
@@ -1,0 +1,38 @@
+-- CreateTable: MediumCredential
+CREATE TABLE "MediumCredential" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT,
+    "integrationToken" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "username" TEXT NOT NULL DEFAULT '',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MediumCredential_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MediumCredential_userId_key" ON "MediumCredential"("userId");
+
+-- CreateTable: MediumExport
+CREATE TABLE "MediumExport" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "nodeId" TEXT,
+    "mediumPostId" TEXT NOT NULL,
+    "mediumPostUrl" TEXT NOT NULL,
+    "publishStatus" TEXT NOT NULL,
+    "lastSyncedAt" TIMESTAMP(3) NOT NULL,
+    "credentialId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MediumExport_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MediumExport_projectId_nodeId_credentialId_key" ON "MediumExport"("projectId", "nodeId", "credentialId");
+
+-- AddForeignKey: MediumExport -> Project
+ALTER TABLE "MediumExport" ADD CONSTRAINT "MediumExport_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey: MediumExport -> MediumCredential
+ALTER TABLE "MediumExport" ADD CONSTRAINT "MediumExport_credentialId_fkey" FOREIGN KEY ("credentialId") REFERENCES "MediumCredential"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,9 +64,9 @@ model Project {
   isSample       Boolean         @default(false)
   chatMessages   ChatMessage[]
   googleDocExports GoogleDocExport[]
+  mediumExports  MediumExport[]
   writingSessions WritingSession[]
   shares         ProjectShare[]
-  mediumExports  MediumExport[]
 
   @@index([userId])
 }
@@ -312,4 +312,5 @@ model MediumExport {
   credential    MediumCredential @relation(fields: [credentialId], references: [id], onDelete: Cascade)
 
   @@unique([projectId, nodeId, credentialId])
+  @@index([projectId])
 }

--- a/scripts/run-migrations.ts
+++ b/scripts/run-migrations.ts
@@ -10,7 +10,7 @@
 
 import { PrismaClient } from '@prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
-import { readFileSync, readdirSync } from 'fs'
+import { readFileSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
 
 const connectionString = process.env.DATABASE_URL
@@ -33,26 +33,40 @@ async function runMigrations() {
   )
   const applied = new Set(rows.map((r) => r.name))
 
-  // Collect migration files sorted alphabetically
+  // Collect migration files sorted alphabetically.
+  // Supports both flat .sql files and subdirectory/migration.sql layouts.
   const migrationsDir = join(__dirname, '..', 'prisma', 'migrations')
-  const files = readdirSync(migrationsDir)
-    .filter((f) => f.endsWith('.sql'))
-    .sort()
+  const entries = readdirSync(migrationsDir).sort()
+  const migrationFiles: Array<{ name: string; path: string }> = []
+  for (const entry of entries) {
+    const entryPath = join(migrationsDir, entry)
+    if (entry.endsWith('.sql') && statSync(entryPath).isFile()) {
+      migrationFiles.push({ name: entry, path: entryPath })
+    } else if (statSync(entryPath).isDirectory()) {
+      const sqlPath = join(entryPath, 'migration.sql')
+      try {
+        statSync(sqlPath)
+        migrationFiles.push({ name: entry, path: sqlPath })
+      } catch {
+        // No migration.sql in this directory, skip
+      }
+    }
+  }
 
-  if (files.length === 0) {
+  if (migrationFiles.length === 0) {
     console.log('No migration files found.')
     return
   }
 
   let applied_count = 0
-  for (const file of files) {
+  for (const { name: file, path: filePath } of migrationFiles) {
     if (applied.has(file)) {
       console.log(`  skip  ${file} (already applied)`)
       continue
     }
 
     console.log(`  apply ${file}`)
-    const sql = readFileSync(join(migrationsDir, file), 'utf-8')
+    const sql = readFileSync(filePath, 'utf-8')
 
     // Split into individual statements, stripping line comments
     const statements = sql

--- a/src/app/api/projects/[id]/publish-to-medium/route.ts
+++ b/src/app/api/projects/[id]/publish-to-medium/route.ts
@@ -1,0 +1,173 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
+import { decrypt } from "@/lib/crypto";
+import { exportMedium } from "@/mcp/tools/export";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/projects/[id]/publish-to-medium
+ * Body: {
+ *   title: string,
+ *   publishStatus: "draft" | "public" | "unlisted",
+ *   tags?: string[],
+ *   canonicalUrl?: string,
+ *   nodeId?: string,  // for single article/chapter export
+ * }
+ */
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    try {
+        const { id: projectId } = await params;
+        const userId = getCurrentUserId(request);
+
+        const access = await verifyProjectAccess(projectId, userId);
+        if (!access.authorized) return access.response;
+
+        // Get Medium credential
+        const cred = await prisma.mediumCredential.findFirst({
+            where: userId ? { userId } : {},
+        });
+        if (!cred) {
+            return NextResponse.json(
+                { error: "Medium is not connected. Go to Settings to connect your account." },
+                { status: 400 }
+            );
+        }
+
+        const body = await request.json();
+        const {
+            title,
+            publishStatus = "draft",
+            tags = [],
+            canonicalUrl,
+            nodeId,
+        } = body;
+
+        if (!title || typeof title !== "string") {
+            return NextResponse.json({ error: "title is required" }, { status: 400 });
+        }
+        if (!["draft", "public", "unlisted"].includes(publishStatus)) {
+            return NextResponse.json({ error: "Invalid publishStatus" }, { status: 400 });
+        }
+        if (Array.isArray(tags) && tags.length > 3) {
+            return NextResponse.json({ error: "Maximum 3 tags allowed" }, { status: 400 });
+        }
+
+        // Generate content
+        const content = await exportMedium(projectId, nodeId);
+        if (!content) {
+            return NextResponse.json({ error: "No content to publish" }, { status: 400 });
+        }
+
+        const token = decrypt(cred.integrationToken);
+
+        // Publish to Medium
+        const postRes = await fetch(
+            `https://api.medium.com/v1/users/${cred.authorId}/posts`,
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                    Accept: "application/json",
+                },
+                body: JSON.stringify({
+                    title,
+                    contentFormat: "markdown",
+                    content,
+                    publishStatus,
+                    tags: tags.slice(0, 3),
+                    ...(canonicalUrl ? { canonicalUrl } : {}),
+                }),
+            }
+        );
+
+        if (!postRes.ok) {
+            const errorText = await postRes.text();
+            logger.error("Medium publish failed", { status: postRes.status, body: errorText });
+            return NextResponse.json(
+                { error: `Medium API error: ${postRes.status}` },
+                { status: 502 }
+            );
+        }
+
+        const postData = await postRes.json();
+        const mediumPostId: string = postData.data?.id;
+        const mediumPostUrl: string = postData.data?.url;
+
+        if (!mediumPostId || !mediumPostUrl) {
+            return NextResponse.json({ error: "Unexpected response from Medium" }, { status: 502 });
+        }
+
+        // Track the export (upsert to handle republish)
+        await prisma.mediumExport.upsert({
+            where: {
+                projectId_nodeId_credentialId: {
+                    projectId,
+                    nodeId: nodeId ?? null,
+                    credentialId: cred.id,
+                },
+            },
+            update: {
+                mediumPostId,
+                mediumPostUrl,
+                publishStatus,
+                lastSyncedAt: new Date(),
+            },
+            create: {
+                projectId,
+                nodeId: nodeId ?? null,
+                mediumPostId,
+                mediumPostUrl,
+                publishStatus,
+                lastSyncedAt: new Date(),
+                credentialId: cred.id,
+            },
+        });
+
+        return NextResponse.json(
+            { mediumPostId, mediumPostUrl },
+            { status: 201 }
+        );
+    } catch (error) {
+        logger.error("POST /api/projects/[id]/publish-to-medium error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}
+
+/**
+ * GET /api/projects/[id]/publish-to-medium
+ * Returns existing Medium exports for the project.
+ */
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    try {
+        const { id: projectId } = await params;
+        const userId = getCurrentUserId(request);
+
+        const access = await verifyProjectAccess(projectId, userId);
+        if (!access.authorized) return access.response;
+
+        const cred = await prisma.mediumCredential.findFirst({
+            where: userId ? { userId } : {},
+        });
+        if (!cred) {
+            return NextResponse.json({ exports: [] });
+        }
+
+        const exports = await prisma.mediumExport.findMany({
+            where: { projectId, credentialId: cred.id },
+            orderBy: { lastSyncedAt: "desc" },
+        });
+
+        return NextResponse.json({ exports });
+    } catch (error) {
+        logger.error("GET /api/projects/[id]/publish-to-medium error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/project/[id]/settings/page.tsx
+++ b/src/app/project/[id]/settings/page.tsx
@@ -7,6 +7,7 @@ import { offlineFetch } from "@/lib/offline/sync-queue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { MediumPublishDialog } from "@/components/medium-publish-dialog";
 
 interface ProjectSettings {
   id: string;
@@ -47,6 +48,17 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
   const [includeSceneBreaks, setIncludeSceneBreaks] = useState(true);
   const [chapterNumbering, setChapterNumbering] = useState(true);
   const [exporting, setExporting] = useState<string | null>(null);
+
+  // Medium integration
+  const [mediumConnected, setMediumConnected] = useState(false);
+  const [mediumDialogOpen, setMediumDialogOpen] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/integrations/medium")
+      .then((r) => r.json())
+      .then((d) => setMediumConnected(d.connected ?? false))
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     fetch(`/api/projects/${projectId}`)
@@ -420,7 +432,50 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
               <span className="text-xs">Export All Projects (ZIP)</span>
             </Button>
           </div>
+
+          {mediumConnected && (
+            <>
+              <p className="text-xs font-medium text-text-muted uppercase tracking-wider mt-5 mb-2">Publish</p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Button
+                  variant="outline"
+                  onClick={() => setMediumDialogOpen(true)}
+                  className="gap-1.5 h-auto py-3 flex-col"
+                >
+                  <svg
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-4 w-4 fill-current"
+                    aria-hidden="true"
+                  >
+                    <path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z" />
+                  </svg>
+                  <span className="text-xs">Publish to Medium</span>
+                </Button>
+              </div>
+            </>
+          )}
+
+          {!mediumConnected && (
+            <p className="text-xs text-text-muted mt-4">
+              Connect Medium in{" "}
+              <a href="/settings" className="text-accent hover:underline">
+                Settings
+              </a>{" "}
+              to publish directly to Medium.
+            </p>
+          )}
         </div>
+
+        {project && (
+          <MediumPublishDialog
+            projectId={projectId}
+            projectTitle={title || project.title}
+            open={mediumDialogOpen}
+            onOpenChange={setMediumDialogOpen}
+          />
+        )}
 
         {/* Archive & Danger Zone */}
         <div className="glass-card p-6 mt-6">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Save, Check, Eye, EyeOff, Settings, Sparkles, MessageSquare } from "lucide-react";
+import { ArrowLeft, Save, Check, Eye, EyeOff, Settings, Sparkles, MessageSquare, Link2, Link2Off, Loader2 } from "lucide-react";
 import { offlineFetch } from "@/lib/offline/sync-queue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -38,6 +38,56 @@ export default function SettingsPage() {
   const [customInstructions, setCustomInstructions] = useState("");
   const [coachingStyle, setCoachingStyle] = useState("balanced");
   const [responseLength, setResponseLength] = useState("moderate");
+
+  // Medium integration
+  const [mediumConnected, setMediumConnected] = useState(false);
+  const [mediumUsername, setMediumUsername] = useState("");
+  const [mediumToken, setMediumToken] = useState("");
+  const [mediumConnecting, setMediumConnecting] = useState(false);
+  const [mediumError, setMediumError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/integrations/medium")
+      .then((r) => r.json())
+      .then((d) => {
+        setMediumConnected(d.connected ?? false);
+        setMediumUsername(d.username ?? "");
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleMediumConnect = async () => {
+    setMediumConnecting(true);
+    setMediumError("");
+    try {
+      const res = await fetch("/api/integrations/medium", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: mediumToken.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setMediumError(data.error || "Connection failed");
+        return;
+      }
+      setMediumConnected(true);
+      setMediumUsername(data.username || "");
+      setMediumToken("");
+    } finally {
+      setMediumConnecting(false);
+    }
+  };
+
+  const handleMediumDisconnect = async () => {
+    setMediumConnecting(true);
+    try {
+      await fetch("/api/integrations/medium", { method: "DELETE" });
+      setMediumConnected(false);
+      setMediumUsername("");
+    } finally {
+      setMediumConnecting(false);
+    }
+  };
 
   useEffect(() => {
     fetch("/api/ai-settings")
@@ -271,6 +321,94 @@ export default function SettingsPage() {
               )}
               {saving ? "Saving..." : saved ? "Saved!" : "Save"}
             </Button>
+          </div>
+        )}
+
+        {/* Medium Integration */}
+        {!loading && (
+          <div className="glass-card p-6 mt-6">
+            <div className="flex items-center gap-2 mb-1">
+              <svg
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4 fill-current text-accent"
+                aria-hidden="true"
+              >
+                <path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z" />
+              </svg>
+              <h2 className="text-lg font-semibold text-text-primary">Medium</h2>
+            </div>
+            <p className="text-sm text-text-secondary mb-4">
+              Publish your stories directly to Medium. Uses a self-issued integration token from your{" "}
+              <a
+                href="https://medium.com/me/settings/security"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:underline"
+              >
+                Medium security settings
+              </a>
+              .
+            </p>
+
+            {mediumConnected ? (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm">
+                  <Link2 className="h-4 w-4 text-green-500" />
+                  <span className="text-text-secondary">
+                    Connected{mediumUsername ? ` as @${mediumUsername}` : ""}
+                  </span>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleMediumDisconnect}
+                  disabled={mediumConnecting}
+                  className="gap-1.5"
+                >
+                  {mediumConnecting ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Link2Off className="h-4 w-4" />
+                  )}
+                  Disconnect
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div>
+                  <label className="block text-sm font-medium text-text-secondary mb-1.5">
+                    Integration Token
+                  </label>
+                  <Input
+                    type="password"
+                    value={mediumToken}
+                    onChange={(e) => setMediumToken(e.target.value)}
+                    placeholder="Paste your Medium integration token"
+                  />
+                  <p className="text-xs text-text-muted mt-1">
+                    Get it from medium.com/me/settings/security → Integration tokens
+                  </p>
+                </div>
+                {mediumError && <p className="text-sm text-danger">{mediumError}</p>}
+                <Button
+                  onClick={handleMediumConnect}
+                  disabled={mediumConnecting || !mediumToken.trim()}
+                  className="gap-1.5"
+                >
+                  {mediumConnecting ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Link2 className="h-4 w-4" />
+                  )}
+                  Connect Medium
+                </Button>
+                <p className="text-xs text-text-muted">
+                  Note: The Medium API is deprecated as of Jan 2025 but continues to work for existing integration tokens.
+                </p>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/components/medium-publish-dialog.tsx
+++ b/src/components/medium-publish-dialog.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { ExternalLink, Loader2, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface MediumPublishDialogProps {
+  projectId: string;
+  projectTitle: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** If set, publish a single node (chapter/article) instead of the full project */
+  nodeId?: string;
+}
+
+interface MediumExport {
+  mediumPostId: string;
+  mediumPostUrl: string;
+  publishStatus: string;
+  nodeId: string | null;
+  lastSyncedAt: string;
+}
+
+export function MediumPublishDialog({
+  projectId,
+  projectTitle,
+  open,
+  onOpenChange,
+  nodeId,
+}: MediumPublishDialogProps) {
+  const [title, setTitle] = useState(projectTitle);
+  const [publishStatus, setPublishStatus] = useState<"draft" | "public" | "unlisted">("draft");
+  const [tagsInput, setTagsInput] = useState("");
+  const [canonicalUrl, setCanonicalUrl] = useState("");
+  const [publishing, setPublishing] = useState(false);
+  const [result, setResult] = useState<{ url: string } | null>(null);
+  const [error, setError] = useState("");
+  const [existingExport, setExistingExport] = useState<MediumExport | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setTitle(projectTitle);
+    setPublishStatus("draft");
+    setTagsInput("");
+    setCanonicalUrl("");
+    setError("");
+    setResult(null);
+
+    // Check for existing exports
+    fetch(`/api/projects/${projectId}/publish-to-medium`)
+      .then((r) => r.json())
+      .then((data) => {
+        const exports: MediumExport[] = data.exports || [];
+        const match = exports.find((e) =>
+          nodeId ? e.nodeId === nodeId : e.nodeId === null
+        );
+        setExistingExport(match ?? null);
+      })
+      .catch(() => {});
+  }, [open, projectId, projectTitle, nodeId]);
+
+  const parsedTags = tagsInput
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .slice(0, 3);
+
+  const tagValidationError =
+    parsedTags.some((t) => t.length > 25)
+      ? "Each tag must be 25 characters or fewer"
+      : parsedTags.length > 3
+      ? "Maximum 3 tags"
+      : "";
+
+  const titleTooLong = title.length > 100;
+
+  const handlePublish = async () => {
+    setPublishing(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/projects/${projectId}/publish-to-medium`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title,
+          publishStatus,
+          tags: parsedTags,
+          ...(canonicalUrl.trim() ? { canonicalUrl: canonicalUrl.trim() } : {}),
+          ...(nodeId ? { nodeId } : {}),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Publish failed");
+        return;
+      }
+      setResult({ url: data.mediumPostUrl });
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Publish to Medium</DialogTitle>
+          <DialogDescription>
+            Send your story to Medium as a post. You can edit it on Medium before making it public.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result ? (
+          <div className="space-y-4 pt-2">
+            <p className="text-sm text-text-secondary">
+              {existingExport ? "Republished successfully!" : "Published successfully!"}
+            </p>
+            <a
+              href={result.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-sm text-accent hover:underline"
+            >
+              <ExternalLink className="h-4 w-4 shrink-0" />
+              Open in Medium
+            </a>
+            <Button variant="outline" onClick={() => onOpenChange(false)} className="w-full">
+              Done
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4 pt-2">
+            {existingExport && (
+              <div className="rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-3 text-sm">
+                <p className="font-medium text-amber-800 dark:text-amber-300 mb-1">
+                  Already published
+                </p>
+                <p className="text-amber-700 dark:text-amber-400 text-xs">
+                  This will create a new Medium post — Medium does not support updating existing posts.
+                </p>
+                <a
+                  href={existingExport.mediumPostUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 mt-1.5 text-xs text-accent hover:underline"
+                >
+                  <ExternalLink className="h-3 w-3" />
+                  View existing post
+                </a>
+              </div>
+            )}
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-text-secondary">Title</label>
+              <Input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Post title"
+                maxLength={120}
+              />
+              {titleTooLong && (
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                  Title exceeds 100 characters — Medium may truncate it.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-text-secondary">Publish status</label>
+              <Select value={publishStatus} onValueChange={(v) => setPublishStatus(v as typeof publishStatus)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="draft">Draft (recommended)</SelectItem>
+                  <SelectItem value="public">Public</SelectItem>
+                  <SelectItem value="unlisted">Unlisted</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-text-secondary">
+                Tags <span className="text-text-muted font-normal">(optional, max 3)</span>
+              </label>
+              <Input
+                value={tagsInput}
+                onChange={(e) => setTagsInput(e.target.value)}
+                placeholder="fiction, short story, fantasy"
+              />
+              {tagValidationError ? (
+                <p className="text-xs text-danger">{tagValidationError}</p>
+              ) : parsedTags.length > 0 ? (
+                <p className="text-xs text-text-muted">
+                  {parsedTags.map((t) => `"${t}"`).join(", ")}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-text-secondary">
+                Canonical URL <span className="text-text-muted font-normal">(optional)</span>
+              </label>
+              <Input
+                value={canonicalUrl}
+                onChange={(e) => setCanonicalUrl(e.target.value)}
+                placeholder="https://yourblog.com/original-post"
+                type="url"
+              />
+            </div>
+
+            {error && <p className="text-sm text-danger">{error}</p>}
+
+            <div className="flex gap-2 pt-1">
+              <Button
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={publishing}
+                className="flex-1"
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handlePublish}
+                disabled={
+                  publishing ||
+                  !title.trim() ||
+                  !!tagValidationError
+                }
+                className="flex-1 gap-1.5"
+              >
+                {publishing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+                {publishing
+                  ? "Publishing..."
+                  : existingExport
+                  ? "Republish"
+                  : "Publish"}
+              </Button>
+            </div>
+
+            <p className="text-xs text-text-muted">
+              Note: The Medium API is deprecated (Jan 2025) but continues to work for existing integration tokens.
+            </p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
Add "Publish to Medium" button and dialog to project export section with title, status selector, tags, and canonical URL.

Closes #344

Completes the Medium integration feature (#339):
- #348 DB models + connect/disconnect API
- #349 Publish endpoint  
- #351 Settings UI
- This PR: Publish dialog

🤖 Generated with Gas City (claude-sonnet polecat)