### PR TITLE
fix: add missing migration for Project.archivedAt and isSample

### DIFF
--- a/prisma/migrations/20260403_add_project_archive_and_sample/migration.sql
+++ b/prisma/migrations/20260403_add_project_archive_and_sample/migration.sql
@@ -1,0 +1,5 @@
+-- Add archivedAt column to Project (nullable timestamp for soft-delete)
+ALTER TABLE "Project" ADD COLUMN "archivedAt" TIMESTAMP(3);
+
+-- Add isSample column to Project (boolean flag for sample/demo projects)
+ALTER TABLE "Project" ADD COLUMN "isSample" BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary

Staging is returning 500 on all project API calls:
- `The column 'Project.archivedAt' does not exist in the current database`
- `The column 'isSample of relation Project' does not exist in the current database`

The Prisma schema has these fields but no migration was ever created for them.

## Fix

Adds `20260403_add_project_archive_and_sample` migration with two ALTER TABLE statements.

## Impact

Unblocks staging deploy → production pipeline.