### PR TITLE
feat: Google Docs bidirectional sync - pull comments as annotations

### DIFF
--- a/prisma/migrations/20260403_google_docs_comment_sync/migration.sql
+++ b/prisma/migrations/20260403_google_docs_comment_sync/migration.sql
@@ -1,0 +1,6 @@
+-- Add externalId to Annotation for tracking imported Google Docs comment IDs
+ALTER TABLE "Annotation" ADD COLUMN "externalId" TEXT;
+CREATE UNIQUE INDEX "Annotation_externalId_key" ON "Annotation"("externalId") WHERE "externalId" IS NOT NULL;
+
+-- Add lastCommentSyncAt to GoogleDocExport for tracking last comment sync time
+ALTER TABLE "GoogleDocExport" ADD COLUMN "lastCommentSyncAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,7 @@ model Annotation {
   resolved      Boolean       @default(false)
   range         String        @default("")
   selectedText  String?
+  externalId    String?       @unique // Google Docs comment ID for imported annotations
   createdAt     DateTime      @default(now())
   updatedAt     DateTime      @updatedAt
   node          StructureNode @relation(fields: [nodeId], references: [id], onDelete: Cascade)
@@ -243,16 +244,17 @@ model UserAiSettings {
 }
 
 model GoogleDocExport {
-  id           String   @id @default(cuid())
-  projectId    String?
-  universeId   String?
-  exportMode   String   // UNIVERSE, STORY_INTERNAL, STORY_READER
-  googleDocId  String
-  googleDocUrl String
-  lastSyncedAt DateTime
-  createdAt    DateTime @default(now())
-  project      Project?  @relation(fields: [projectId], references: [id], onDelete: SetNull)
-  universe     Universe? @relation(fields: [universeId], references: [id], onDelete: SetNull)
+  id                  String    @id @default(cuid())
+  projectId           String?
+  universeId          String?
+  exportMode          String    // UNIVERSE, STORY_INTERNAL, STORY_READER
+  googleDocId         String
+  googleDocUrl        String
+  lastSyncedAt        DateTime
+  lastCommentSyncAt   DateTime? // Last time comments were pulled from Google Docs
+  createdAt           DateTime  @default(now())
+  project             Project?  @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  universe            Universe? @relation(fields: [universeId], references: [id], onDelete: SetNull)
 
   @@unique([projectId, universeId, exportMode])
   @@index([projectId])

--- a/src/__tests__/google-docs-comment-sync.test.ts
+++ b/src/__tests__/google-docs-comment-sync.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock GoogleDocsApi
+vi.mock("@/lib/google-api", () => ({
+    GoogleDocsApi: {
+        fetchComments: vi.fn(),
+    },
+}));
+
+import { GoogleDocsCommentSync } from "@/lib/export/google-docs-comment-sync";
+import { GoogleDocsApi } from "@/lib/google-api";
+import { ProjectsController } from "@/lib/controllers/projects";
+import { StructureController } from "@/lib/controllers/structure";
+import { prisma } from "@/lib/db";
+
+describe("GoogleDocsCommentSync", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("syncComments", () => {
+        it("throws when no Google Doc export exists for project", async () => {
+            const project = await ProjectsController.createProject({ title: "No Export" });
+            await expect(
+                GoogleDocsCommentSync.syncComments(project.id)
+            ).rejects.toThrow("No Google Doc export found");
+        });
+
+        it("imports new comment as annotation on the matching scene", async () => {
+            const project = await ProjectsController.createProject({ title: "Comment Test" });
+            const chapter = await StructureController.createNode({
+                projectId: project.id,
+                type: "CHAPTER",
+                title: "Chapter 1",
+            });
+            const scene = await StructureController.createNode({
+                projectId: project.id,
+                type: "SCENE",
+                title: "Scene 1",
+                parentId: chapter.id,
+            });
+            // Save scene content
+            await prisma.contentVersion.create({
+                data: {
+                    nodeId: scene.id,
+                    content: "Once upon a time, a hero was born.",
+                    wordCount: 8,
+                },
+            });
+
+            // Create a GoogleDocExport for this project
+            const exportRecord = await prisma.googleDocExport.create({
+                data: {
+                    projectId: project.id,
+                    exportMode: "STORY_READER",
+                    googleDocId: "doc-abc",
+                    googleDocUrl: "https://docs.google.com/document/d/doc-abc/edit",
+                    lastSyncedAt: new Date(),
+                },
+            });
+
+            vi.mocked(GoogleDocsApi.fetchComments).mockResolvedValue([
+                {
+                    id: "comment-1",
+                    content: "Great opening!",
+                    quotedFileContent: { value: "a hero was born" },
+                    author: { displayName: "Reviewer" },
+                    resolved: false,
+                    replies: [],
+                },
+            ]);
+
+            const result = await GoogleDocsCommentSync.syncComments(project.id);
+
+            expect(result.imported).toBe(1);
+            expect(result.skipped).toBe(0);
+            expect(result.unresolvable).toBe(0);
+            expect(GoogleDocsApi.fetchComments).toHaveBeenCalledWith("doc-abc");
+
+            // Verify annotation was created
+            const annotations = await prisma.annotation.findMany({
+                where: { nodeId: scene.id },
+            });
+            expect(annotations).toHaveLength(1);
+            expect(annotations[0].content).toContain("Reviewer");
+            expect(annotations[0].content).toContain("Great opening!");
+            expect(annotations[0].externalId).toBe(`gdoc:doc-abc:comment-1`);
+            expect(annotations[0].selectedText).toBe("a hero was born");
+            expect(annotations[0].resolved).toBe(false);
+
+            // Verify lastCommentSyncAt was updated
+            const updatedExport = await prisma.googleDocExport.findUnique({
+                where: { id: exportRecord.id },
+            });
+            expect(updatedExport?.lastCommentSyncAt).not.toBeNull();
+        });
+
+        it("skips already-imported comments on second sync", async () => {
+            const project = await ProjectsController.createProject({ title: "Dedup Test" });
+            const chapter = await StructureController.createNode({
+                projectId: project.id,
+                type: "CHAPTER",
+                title: "Chapter 1",
+            });
+            const scene = await StructureController.createNode({
+                projectId: project.id,
+                type: "SCENE",
+                title: "Scene 1",
+                parentId: chapter.id,
+            });
+            await prisma.contentVersion.create({
+                data: {
+                    nodeId: scene.id,
+                    content: "The dragon roared.",
+                    wordCount: 3,
+                },
+            });
+            await prisma.googleDocExport.create({
+                data: {
+                    projectId: project.id,
+                    exportMode: "STORY_READER",
+                    googleDocId: "doc-dedup",
+                    googleDocUrl: "https://docs.google.com/document/d/doc-dedup/edit",
+                    lastSyncedAt: new Date(),
+                },
+            });
+
+            const mockComment = {
+                id: "comment-x",
+                content: "Dramatic!",
+                quotedFileContent: { value: "dragon roared" },
+                author: { displayName: "Alice" },
+                resolved: false,
+                replies: [],
+            };
+            vi.mocked(GoogleDocsApi.fetchComments).mockResolvedValue([mockComment]);
+
+            // First sync
+            const first = await GoogleDocsCommentSync.syncComments(project.id);
+            expect(first.imported).toBe(1);
+
+            // Second sync — same comment, should be skipped
+            const second = await GoogleDocsCommentSync.syncComments(project.id);
+            expect(second.imported).toBe(0);
+            expect(second.skipped).toBe(1);
+        });
+
+        it("counts comment as unresolvable when anchor text not found in any scene", async () => {
+            const project = await ProjectsController.createProject({ title: "Unresolvable" });
+            const chapter = await StructureController.createNode({
+                projectId: project.id,
+                type: "CHAPTER",
+                title: "Ch 1",
+            });
+            const scene = await StructureController.createNode({
+                projectId: project.id,
+                type: "SCENE",
+                title: "S1",
+                parentId: chapter.id,
+            });
+            await prisma.contentVersion.create({
+                data: {
+                    nodeId: scene.id,
+                    content: "Short content here.",
+                    wordCount: 3,
+                },
+            });
+            await prisma.googleDocExport.create({
+                data: {
+                    projectId: project.id,
+                    exportMode: "STORY_READER",
+                    googleDocId: "doc-unres",
+                    googleDocUrl: "https://docs.google.com/document/d/doc-unres/edit",
+                    lastSyncedAt: new Date(),
+                },
+            });
+
+            vi.mocked(GoogleDocsApi.fetchComments).mockResolvedValue([
+                {
+                    id: "comment-gone",
+                    content: "Where did this come from?",
+                    quotedFileContent: { value: "text that was deleted from the doc" },
+                    author: { displayName: "Bob" },
+                    resolved: false,
+                    replies: [],
+                },
+            ]);
+
+            const result = await GoogleDocsCommentSync.syncComments(project.id);
+            expect(result.imported).toBe(0);
+            expect(result.unresolvable).toBe(1);
+        });
+
+        it("includes replies in annotation content", async () => {
+            const project = await ProjectsController.createProject({ title: "Replies Test" });
+            const chapter = await StructureController.createNode({
+                projectId: project.id,
+                type: "CHAPTER",
+                title: "Ch 1",
+            });
+            const scene = await StructureController.createNode({
+                projectId: project.id,
+                type: "SCENE",
+                title: "S1",
+                parentId: chapter.id,
+            });
+            await prisma.contentVersion.create({
+                data: {
+                    nodeId: scene.id,
+                    content: "The castle stood tall.",
+                    wordCount: 4,
+                },
+            });
+            await prisma.googleDocExport.create({
+                data: {
+                    projectId: project.id,
+                    exportMode: "STORY_READER",
+                    googleDocId: "doc-replies",
+                    googleDocUrl: "https://docs.google.com/document/d/doc-replies/edit",
+                    lastSyncedAt: new Date(),
+                },
+            });
+
+            vi.mocked(GoogleDocsApi.fetchComments).mockResolvedValue([
+                {
+                    id: "c1",
+                    content: "Needs more description",
+                    quotedFileContent: { value: "castle stood" },
+                    author: { displayName: "Editor" },
+                    resolved: false,
+                    replies: [
+                        {
+                            content: "Agreed, let me revise",
+                            author: { displayName: "Author" },
+                        },
+                    ],
+                },
+            ]);
+
+            await GoogleDocsCommentSync.syncComments(project.id);
+
+            const annotations = await prisma.annotation.findMany({
+                where: { nodeId: scene.id },
+            });
+            expect(annotations[0].content).toContain("Editor");
+            expect(annotations[0].content).toContain("Needs more description");
+            expect(annotations[0].content).toContain("Author");
+            expect(annotations[0].content).toContain("Agreed, let me revise");
+        });
+    });
+
+    describe("getExportInfo", () => {
+        it("returns export records for a project", async () => {
+            const project = await ProjectsController.createProject({ title: "Info Test" });
+            await prisma.googleDocExport.create({
+                data: {
+                    projectId: project.id,
+                    exportMode: "STORY_READER",
+                    googleDocId: "doc-info",
+                    googleDocUrl: "https://docs.google.com/document/d/doc-info/edit",
+                    lastSyncedAt: new Date(),
+                },
+            });
+
+            const exports = await GoogleDocsCommentSync.getExportInfo(project.id);
+            expect(exports).toHaveLength(1);
+            expect(exports[0].exportMode).toBe("STORY_READER");
+            expect(exports[0].googleDocUrl).toContain("doc-info");
+            expect(exports[0].lastCommentSyncAt).toBeNull();
+        });
+    });
+});

--- a/src/app/api/integrations/google-docs/route.ts
+++ b/src/app/api/integrations/google-docs/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GoogleDocsCommentSync } from '@/lib/export/google-docs-comment-sync';
+import { getCurrentUserId, verifyProjectWriteAccess } from '@/lib/api-auth';
+import { logger } from '@/lib/logger';
+
+/**
+ * GET /api/integrations/google-docs?projectId=...
+ * Returns Google Doc export records for the project.
+ */
+export async function GET(request: NextRequest) {
+    try {
+        const { searchParams } = new URL(request.url);
+        const projectId = searchParams.get('projectId');
+        if (!projectId) {
+            return NextResponse.json({ error: 'projectId is required' }, { status: 400 });
+        }
+
+        const userId = getCurrentUserId(request);
+        const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get('x-user-email'));
+        if (!access.authorized) return access.response;
+
+        const exports = await GoogleDocsCommentSync.getExportInfo(projectId);
+        return NextResponse.json({ exports });
+    } catch (error) {
+        logger.error('GET /api/integrations/google-docs error', error);
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
+}
+
+/**
+ * POST /api/integrations/google-docs/sync-comments
+ * Body: { projectId: string }
+ * Fetches Google Docs comments and imports them as annotations.
+ */
+export async function POST(request: NextRequest) {
+    try {
+        const body = await request.json();
+        const { projectId } = body;
+
+        if (!projectId || typeof projectId !== 'string') {
+            return NextResponse.json({ error: 'projectId is required' }, { status: 400 });
+        }
+
+        const userId = getCurrentUserId(request);
+        const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get('x-user-email'));
+        if (!access.authorized) return access.response;
+
+        const result = await GoogleDocsCommentSync.syncComments(projectId);
+        return NextResponse.json(result);
+    } catch (error) {
+        logger.error('POST /api/integrations/google-docs error', error);
+        const message = error instanceof Error ? error.message : 'Internal server error';
+        const status = message.includes('No Google Doc export found') ? 404 : 500;
+        return NextResponse.json({ error: message }, { status });
+    }
+}

--- a/src/app/project/[id]/settings/page.tsx
+++ b/src/app/project/[id]/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, use } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Download, Save, Check, PenLine, FileText, BookOpen, Braces, Archive, ArchiveRestore, Trash2, AlertTriangle } from "lucide-react";
+import { ArrowLeft, Download, Save, Check, PenLine, FileText, BookOpen, Braces, Archive, ArchiveRestore, Trash2, AlertTriangle, RefreshCw } from "lucide-react";
 import { offlineFetch } from "@/lib/offline/sync-queue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -53,12 +53,32 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
   const [mediumConnected, setMediumConnected] = useState(false);
   const [mediumDialogOpen, setMediumDialogOpen] = useState(false);
 
+  // Google Docs integration
+  interface GoogleDocExportInfo {
+    id: string;
+    exportMode: string;
+    googleDocUrl: string;
+    lastSyncedAt: string;
+    lastCommentSyncAt: string | null;
+  }
+  const [googleDocExports, setGoogleDocExports] = useState<GoogleDocExportInfo[]>([]);
+  const [syncingComments, setSyncingComments] = useState(false);
+  const [syncResult, setSyncResult] = useState<{ imported: number; skipped: number; unresolvable: number } | null>(null);
+
   useEffect(() => {
     fetch("/api/integrations/medium")
       .then((r) => r.json())
       .then((d) => setMediumConnected(d.connected ?? false))
       .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    if (!projectId) return;
+    fetch(`/api/integrations/google-docs?projectId=${projectId}`)
+      .then((r) => r.json())
+      .then((d) => setGoogleDocExports(d.exports ?? []))
+      .catch(() => {});
+  }, [projectId]);
 
   useEffect(() => {
     fetch(`/api/projects/${projectId}`)
@@ -178,6 +198,30 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
       }
     } finally {
       setExporting(null);
+    }
+  };
+
+  const handleSyncComments = async () => {
+    setSyncingComments(true);
+    setSyncResult(null);
+    try {
+      const res = await fetch("/api/integrations/google-docs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Sync failed");
+      setSyncResult({ imported: data.imported, skipped: data.skipped, unresolvable: data.unresolvable });
+      // Refresh export info
+      const infoRes = await fetch(`/api/integrations/google-docs?projectId=${projectId}`);
+      const infoData = await infoRes.json();
+      setGoogleDocExports(infoData.exports ?? []);
+    } catch (err) {
+      setSyncResult(null);
+      alert(err instanceof Error ? err.message : "Comment sync failed");
+    } finally {
+      setSyncingComments(false);
     }
   };
 
@@ -465,6 +509,58 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
               </a>{" "}
               to publish directly to Medium.
             </p>
+          )}
+
+          {googleDocExports.length > 0 && (
+            <>
+              <p className="text-xs font-medium text-text-muted uppercase tracking-wider mt-5 mb-2">Google Docs</p>
+              <div className="space-y-3">
+                {googleDocExports.map((exp) => (
+                  <div key={exp.id} className="flex items-center justify-between gap-3 text-sm">
+                    <div className="min-w-0">
+                      <a
+                        href={exp.googleDocUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent hover:underline truncate block"
+                      >
+                        {exp.exportMode === "STORY_READER"
+                          ? "Reader Copy"
+                          : exp.exportMode === "STORY_INTERNAL"
+                          ? "Internal Draft"
+                          : "Export"}
+                      </a>
+                      {exp.lastCommentSyncAt && (
+                        <p className="text-xs text-text-muted">
+                          Comments synced {new Date(exp.lastCommentSyncAt).toLocaleDateString()}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                <Button
+                  variant="outline"
+                  onClick={handleSyncComments}
+                  disabled={syncingComments}
+                  className="gap-1.5 h-auto py-2 px-3"
+                >
+                  {syncingComments ? (
+                    <div className="h-4 w-4 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+                  ) : (
+                    <RefreshCw className="h-4 w-4" />
+                  )}
+                  <span className="text-xs">Sync comments from Google Docs</span>
+                </Button>
+                {syncResult && (
+                  <p className="text-xs text-text-muted">
+                    Imported {syncResult.imported} comment{syncResult.imported !== 1 ? "s" : ""} as annotations
+                    {syncResult.skipped > 0 ? `, ${syncResult.skipped} already imported` : ""}
+                    {syncResult.unresolvable > 0 ? `, ${syncResult.unresolvable} unresolvable` : ""}
+                    .
+                  </p>
+                )}
+              </div>
+            </>
           )}
         </div>
 

--- a/src/components/editor/annotations-sidebar.tsx
+++ b/src/components/editor/annotations-sidebar.tsx
@@ -93,7 +93,14 @@ export function AnnotationsSidebar({
                 )}
 
                 <div className="flex items-center justify-between text-xs text-text-muted pl-7">
-                  <span>{timeAgo(a.createdAt)}</span>
+                  <span className="flex items-center gap-1.5">
+                    {timeAgo(a.createdAt)}
+                    {a.externalId?.startsWith('gdoc:') && (
+                      <span className="px-1 py-0.5 rounded bg-surface-sunken text-text-muted border border-border-subtle leading-none">
+                        Google Docs
+                      </span>
+                    )}
+                  </span>
                   <Button
                     variant="ghost"
                     size="icon"

--- a/src/components/outline-tree.tsx
+++ b/src/components/outline-tree.tsx
@@ -223,6 +223,13 @@ function NodeContent({
         <BookOpen className="h-4 w-4 text-text-muted flex-shrink-0" aria-hidden="true" />
       )}
       <span className="truncate flex-1">{node.title}</span>
+      {isScene && node.hasNewFeedback && (
+        <span
+          className="flex-shrink-0 h-1.5 w-1.5 rounded-full bg-accent"
+          title="New feedback from Google Docs"
+          aria-label="New feedback"
+        />
+      )}
       {isScene && <StatusDot status={node.status as SceneStatus} />}
       {isScene && node.plotIndicators && node.plotIndicators.length > 0 && (
         <PlotThreadDots indicators={node.plotIndicators} />

--- a/src/lib/controllers/structure.ts
+++ b/src/lib/controllers/structure.ts
@@ -13,6 +13,7 @@ export interface OutlineNode {
     parentId: string | null;
     wordCount?: number;
     children: OutlineNode[];
+    hasNewFeedback?: boolean;
 }
 
 export class StructureController {
@@ -98,6 +99,17 @@ export class StructureController {
             },
         });
 
+        // Find scene IDs with unresolved Google Docs annotations
+        const newFeedbackAnnotations = await prisma.annotation.findMany({
+            where: {
+                node: { projectId },
+                resolved: false,
+                NOT: { externalId: null },
+            },
+            select: { nodeId: true },
+        });
+        const newFeedbackNodeIds = new Set(newFeedbackAnnotations.map((a: { nodeId: string }) => a.nodeId));
+
         const nodeMap = new Map<string, OutlineNode>();
         const roots: OutlineNode[] = [];
 
@@ -112,6 +124,7 @@ export class StructureController {
                 parentId: node.parentId,
                 wordCount: node.type === "SCENE" ? (node.contentVersions[0]?.wordCount ?? 0) : undefined,
                 children: [],
+                hasNewFeedback: newFeedbackNodeIds.has(node.id),
             });
         }
 

--- a/src/lib/export/google-docs-comment-sync.ts
+++ b/src/lib/export/google-docs-comment-sync.ts
@@ -1,0 +1,187 @@
+import { prisma } from "@/lib/db";
+import { GoogleDocsApi } from "../google-api";
+import { logger } from "@/lib/logger";
+
+export interface CommentSyncResult {
+    imported: number;
+    skipped: number;
+    unresolvable: number;
+    errors: string[];
+}
+
+/**
+ * Strips HTML tags and normalizes whitespace for text matching.
+ */
+function normalizeText(text: string): string {
+    return text
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+/**
+ * Find which scene node contains the given anchor text.
+ * Returns the nodeId and character offset of the first match.
+ */
+async function findSceneForAnchor(
+    projectId: string,
+    anchorText: string
+): Promise<{ nodeId: string; offset: number } | null> {
+    const normalized = anchorText.trim();
+    if (!normalized) return null;
+
+    // Get all scene nodes with their latest content
+    const scenes = await prisma.structureNode.findMany({
+        where: { projectId, type: 'SCENE' },
+        select: { id: true },
+    });
+
+    for (const scene of scenes) {
+        const version = await prisma.contentVersion.findFirst({
+            where: { nodeId: scene.id },
+            orderBy: { createdAt: 'desc' },
+        });
+        if (!version?.content) continue;
+
+        const plainText = normalizeText(version.content);
+        const idx = plainText.indexOf(normalized);
+        if (idx !== -1) {
+            return { nodeId: scene.id, offset: idx };
+        }
+    }
+
+    return null;
+}
+
+export class GoogleDocsCommentSync {
+    /**
+     * Sync comments from a Google Doc back to Annie as annotations.
+     * Skips comments already imported (tracked via Annotation.externalId).
+     * Returns a summary of what happened.
+     */
+    static async syncComments(projectId: string): Promise<CommentSyncResult> {
+        const result: CommentSyncResult = {
+            imported: 0,
+            skipped: 0,
+            unresolvable: 0,
+            errors: [],
+        };
+
+        // Find the export record for this project (prefer STORY_READER, fallback to STORY_INTERNAL)
+        const exportRecord = await prisma.googleDocExport.findFirst({
+            where: {
+                projectId,
+                exportMode: { in: ['STORY_READER', 'STORY_INTERNAL'] },
+            },
+            orderBy: { lastSyncedAt: 'desc' },
+        });
+
+        if (!exportRecord) {
+            throw new Error("No Google Doc export found for this project. Export the project first.");
+        }
+
+        let comments;
+        try {
+            comments = await GoogleDocsApi.fetchComments(exportRecord.googleDocId);
+        } catch (error) {
+            throw new Error(`Failed to fetch comments from Google Docs: ${error instanceof Error ? error.message : error}`);
+        }
+
+        for (const comment of comments) {
+            if (!comment.id || !comment.content) continue;
+
+            // Build a stable external ID: exportRecord.id + ":" + comment.id
+            const externalId = `gdoc:${exportRecord.googleDocId}:${comment.id}`;
+
+            // Skip already-imported comments
+            const existing = await prisma.annotation.findUnique({
+                where: { externalId },
+            });
+            if (existing) {
+                result.skipped++;
+                continue;
+            }
+
+            // Get anchor text from the comment's quotedFileContent
+            const anchorText = comment.quotedFileContent?.value ?? "";
+            const authorName = comment.author?.displayName ?? "Google Docs";
+
+            // Find matching scene
+            const match = anchorText
+                ? await findSceneForAnchor(projectId, normalizeText(anchorText))
+                : null;
+
+            if (!match && anchorText) {
+                // Comment has anchor text but we can't find the scene (content may have changed)
+                result.unresolvable++;
+                logger.warn(`Could not map Google Docs comment ${comment.id} anchor to any scene`);
+                continue;
+            }
+
+            if (!match) {
+                // No anchor text - skip (document-level comments without a quote)
+                result.skipped++;
+                continue;
+            }
+
+            // Format content: include author name and any replies
+            let content = `[${authorName}]: ${comment.content}`;
+            if (comment.replies && comment.replies.length > 0) {
+                const replyLines = comment.replies
+                    .filter((r) => r.content)
+                    .map((r) => `  ↳ [${r.author?.displayName ?? "Reply"}]: ${r.content}`)
+                    .join("\n");
+                if (replyLines) content += "\n" + replyLines;
+            }
+
+            try {
+                await prisma.annotation.create({
+                    data: {
+                        id: `manual_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+                        nodeId: match.nodeId,
+                        content,
+                        range: String(match.offset),
+                        selectedText: anchorText.slice(0, 500), // cap length
+                        externalId,
+                        resolved: comment.resolved === true,
+                        updatedAt: new Date(),
+                    },
+                });
+                result.imported++;
+            } catch (error) {
+                result.errors.push(`Failed to create annotation for comment ${comment.id}: ${error}`);
+                logger.error("Failed to create annotation from Google Docs comment", error);
+            }
+        }
+
+        // Update lastCommentSyncAt on the export record
+        await prisma.googleDocExport.update({
+            where: { id: exportRecord.id },
+            data: { lastCommentSyncAt: new Date() },
+        });
+
+        return result;
+    }
+
+    /**
+     * Get Google Doc export info for a project.
+     */
+    static async getExportInfo(projectId: string) {
+        return prisma.googleDocExport.findMany({
+            where: { projectId },
+            select: {
+                id: true,
+                exportMode: true,
+                googleDocUrl: true,
+                lastSyncedAt: true,
+                lastCommentSyncAt: true,
+            },
+            orderBy: { lastSyncedAt: 'desc' },
+        });
+    }
+}

--- a/src/lib/google-api.ts
+++ b/src/lib/google-api.ts
@@ -1,4 +1,4 @@
-import { google, docs_v1 } from 'googleapis';
+import { google, docs_v1, drive_v3 } from 'googleapis';
 import { GoogleAuthController } from './controllers/google-auth';
 
 export class GoogleDocsApi {
@@ -33,6 +33,28 @@ export class GoogleDocsApi {
             documentId,
             requestBody: { requests }
         });
+    }
+
+    static async fetchComments(documentId: string): Promise<drive_v3.Schema$Comment[]> {
+        const auth = await GoogleAuthController.getValidClient();
+        if (!auth) throw new Error("Not authenticated");
+
+        const drive = google.drive({ version: 'v3', auth });
+        const allComments: drive_v3.Schema$Comment[] = [];
+        let pageToken: string | undefined;
+
+        do {
+            const res = await drive.comments.list({
+                fileId: documentId,
+                fields: 'comments(id,content,quotedFileContent,author,resolved,replies,createdTime),nextPageToken',
+                includeDeleted: false,
+                pageToken,
+            });
+            allComments.push(...(res.data.comments ?? []));
+            pageToken = res.data.nextPageToken ?? undefined;
+        } while (pageToken);
+
+        return allComments;
     }
 
     static async replaceContent(documentId: string, text: string) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,6 +83,7 @@ export interface PlotlineIndicator {
 export interface OutlineNode extends StructureNode {
   children: OutlineNode[];
   plotIndicators?: PlotlineIndicator[];
+  hasNewFeedback?: boolean; // true when scene has unresolved annotations imported from Google Docs
 }
 
 export type StoryObjectType = "CHARACTER" | "LOCATION" | "PLOTLINE" | "WORLD_ELEMENT" | "NOTE";
@@ -134,6 +135,7 @@ export interface Annotation {
   content: string;
   range: string;
   selectedText?: string | null;
+  externalId?: string | null; // set for annotations imported from Google Docs
   resolved: boolean;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- Fetch Google Docs comments via Drive API
- Map comment anchor text to scenes, create Annie annotations
- Dedup via externalId on Annotation model
- DB migration: Annotation.externalId + GoogleDocExport.lastCommentSyncAt
- UI: sync button in project settings, new-feedback dot in outline, Google Docs label in annotations sidebar

Fixes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)