### PR TITLE
feat: add HR separator between scenes in read view (an-fnf)

### DIFF
--- a/src/app/read/[id]/reader-view.tsx
+++ b/src/app/read/[id]/reader-view.tsx
@@ -155,11 +155,7 @@ function ManuscriptNode({
           scenes.map((scene, i) => (
             <div key={scene.id}>
               {i > 0 && scene.content && scene.content !== "<p></p>" && (
-                <div className="flex justify-center my-10">
-                  <span className="text-text-muted tracking-[0.5em] text-sm select-none">
-                    * * *
-                  </span>
-                </div>
+                <hr className="my-10 border-0 h-px bg-border/30" />
               )}
               <SceneContent content={scene.content || ""} />
             </div>


### PR DESCRIPTION
Implements HR separator between scenes in the read view for better visual separation.

Fixes #an-fnf