### PR TITLE
feat: Hashnode update/re-publish existing drafts

### DIFF
--- a/src/__tests__/hashnode-publish-controller.test.ts
+++ b/src/__tests__/hashnode-publish-controller.test.ts
@@ -30,6 +30,28 @@ const HASHNODE_PUBLISH_RESPONSE = {
     },
 };
 
+const HASHNODE_UPDATE_DRAFT_RESPONSE = {
+    data: {
+        updateDraft: {
+            draft: {
+                id: "existing-draft-id",
+                title: "Test Article",
+            },
+        },
+    },
+};
+
+const HASHNODE_UPDATE_POST_RESPONSE = {
+    data: {
+        updatePost: {
+            post: {
+                id: "existing-post-id",
+                url: "https://testuser.hashnode.dev/existing-post",
+            },
+        },
+    },
+};
+
 function mockFetchDraft() {
     global.fetch = vi.fn().mockResolvedValue({
         ok: true,
@@ -56,6 +78,20 @@ function mockFetchGraphQLError(message: string) {
     global.fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: vi.fn().mockResolvedValue({ errors: [{ message }] }),
+    } as unknown as Response);
+}
+
+function mockFetchUpdateDraft() {
+    global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(HASHNODE_UPDATE_DRAFT_RESPONSE),
+    } as unknown as Response);
+}
+
+function mockFetchUpdatePost() {
+    global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(HASHNODE_UPDATE_POST_RESPONSE),
     } as unknown as Response);
 }
 
@@ -243,9 +279,36 @@ describe("HashnodePublishController", () => {
         });
     });
 
-    describe("re-publish guard", () => {
-        it("returns alreadyPublished when export record exists", async () => {
-            global.fetch = vi.fn();
+    describe("update flow (existing export)", () => {
+        it("calls updateDraft when existing export has draft status", async () => {
+            mockFetchUpdateDraft();
+
+            await testPrisma.hashnodeExport.create({
+                data: {
+                    projectId,
+                    nodeId: null,
+                    hashnodePostId: "existing-draft-id",
+                    hashnodePostUrl: "https://hashnode.com/draft/existing-draft-id",
+                    publishStatus: "draft",
+                    lastSyncedAt: new Date(),
+                    credentialId: credId,
+                },
+            });
+
+            const result = await HashnodePublishController.publish(projectId, null, {});
+
+            expect(result.updated).toBe(true);
+            expect(result.hashnodePostId).toBe("existing-draft-id");
+            expect(result.alreadyPublished).toBeUndefined();
+
+            const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+            const requestBody = JSON.parse(fetchCall[1].body);
+            expect(requestBody.query).toContain("updateDraft");
+            expect(requestBody.variables.input.id).toBe("existing-draft-id");
+        });
+
+        it("calls updatePost when existing export has public status", async () => {
+            mockFetchUpdatePost();
 
             await testPrisma.hashnodeExport.create({
                 data: {
@@ -261,9 +324,35 @@ describe("HashnodePublishController", () => {
 
             const result = await HashnodePublishController.publish(projectId, null, {});
 
-            expect(result.alreadyPublished).toBe(true);
+            expect(result.updated).toBe(true);
             expect(result.hashnodePostId).toBe("existing-post-id");
-            expect(global.fetch).not.toHaveBeenCalled();
+
+            const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+            const requestBody = JSON.parse(fetchCall[1].body);
+            expect(requestBody.query).toContain("updatePost");
+            expect(requestBody.variables.input.id).toBe("existing-post-id");
+        });
+
+        it("updates lastSyncedAt on the export record", async () => {
+            mockFetchUpdateDraft();
+            const oldDate = new Date("2024-01-01");
+
+            await testPrisma.hashnodeExport.create({
+                data: {
+                    projectId,
+                    nodeId: null,
+                    hashnodePostId: "existing-draft-id",
+                    hashnodePostUrl: "https://hashnode.com/draft/existing-draft-id",
+                    publishStatus: "draft",
+                    lastSyncedAt: oldDate,
+                    credentialId: credId,
+                },
+            });
+
+            await HashnodePublishController.publish(projectId, null, {});
+
+            const updated = await testPrisma.hashnodeExport.findFirst({ where: { projectId } });
+            expect(updated!.lastSyncedAt.getTime()).toBeGreaterThan(oldDate.getTime());
         });
     });
 

--- a/src/app/api/projects/[id]/publish-to-hashnode/route.ts
+++ b/src/app/api/projects/[id]/publish-to-hashnode/route.ts
@@ -45,10 +45,10 @@ export async function POST(
             canonicalUrl,
         });
 
-        if (result.alreadyPublished) {
+        if (result.updated) {
             return NextResponse.json(
                 {
-                    warning: 'This content has already been published to Hashnode.',
+                    updated: true,
                     hashnodePostUrl: result.hashnodePostUrl,
                     hashnodePostId: result.hashnodePostId,
                     publishStatus: result.publishStatus,

--- a/src/components/hashnode-publish-dialog.tsx
+++ b/src/components/hashnode-publish-dialog.tsx
@@ -48,7 +48,7 @@ export function HashnodePublishDialog({
   const [tagsInput, setTagsInput] = useState("");
   const [canonicalUrl, setCanonicalUrl] = useState("");
   const [publishing, setPublishing] = useState(false);
-  const [result, setResult] = useState<{ url: string; isDraft: boolean } | null>(null);
+  const [result, setResult] = useState<{ url: string; isDraft: boolean; updated?: boolean } | null>(null);
   const [error, setError] = useState("");
   const [existingExport, setExistingExport] = useState<HashnodeExport | null>(null);
 
@@ -104,7 +104,7 @@ export function HashnodePublishDialog({
         setError(data.error || "Publish failed");
         return;
       }
-      setResult({ url: data.hashnodePostUrl, isDraft: publishStatus === "draft" });
+      setResult({ url: data.hashnodePostUrl, isDraft: publishStatus === "draft", updated: data.updated });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Publish failed — check your connection");
     } finally {
@@ -125,9 +125,13 @@ export function HashnodePublishDialog({
         {result ? (
           <div className="space-y-4 pt-2">
             <p className="text-sm text-text-secondary">
-              {result.isDraft
-                ? "Draft created! Review and publish from your Hashnode dashboard."
-                : "Published successfully!"}
+              {result.updated
+                ? result.isDraft
+                  ? "Draft updated! Review and publish from your Hashnode dashboard."
+                  : "Post updated on Hashnode."
+                : result.isDraft
+                  ? "Draft created! Review and publish from your Hashnode dashboard."
+                  : "Published successfully!"}
             </p>
             <a
               href={result.url}
@@ -145,21 +149,18 @@ export function HashnodePublishDialog({
         ) : (
           <div className="space-y-4 pt-2">
             {existingExport && (
-              <div className="rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-3 text-sm">
-                <p className="font-medium text-amber-800 dark:text-amber-300 mb-1">
-                  Already published
-                </p>
-                <p className="text-amber-700 dark:text-amber-400 text-xs">
-                  A post already exists for this content on Hashnode.
+              <div className="rounded-md bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 p-3 text-sm">
+                <p className="font-medium text-blue-800 dark:text-blue-300 mb-1">
+                  Already published — clicking Update will sync new content
                 </p>
                 <a
                   href={existingExport.hashnodePostUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1 mt-1.5 text-xs text-accent hover:underline"
+                  className="flex items-center gap-1 mt-1 text-xs text-accent hover:underline"
                 >
                   <ExternalLink className="h-3 w-3" />
-                  View existing post
+                  View existing {existingExport.publishStatus === "draft" ? "draft" : "post"}
                 </a>
               </div>
             )}
@@ -243,7 +244,11 @@ export function HashnodePublishDialog({
                   <Send className="h-4 w-4" />
                 )}
                 {publishing
-                  ? "Publishing..."
+                  ? existingExport
+                    ? "Updating..."
+                    : "Publishing..."
+                  : existingExport
+                  ? "Update"
                   : publishStatus === "draft"
                   ? "Create Draft"
                   : "Publish"}

--- a/src/lib/controllers/hashnode-publish.ts
+++ b/src/lib/controllers/hashnode-publish.ts
@@ -17,6 +17,7 @@ export interface HashnodePublishResult {
     hashnodePostUrl: string;
     publishStatus: string;
     alreadyPublished?: boolean;
+    updated?: boolean;
 }
 
 export class HashnodePublishController {
@@ -54,18 +55,10 @@ export class HashnodePublishController {
             title = project.title;
         }
 
-        // Check for existing export (re-publish guard)
+        // Check for existing export — update if found
         const existingExport = await prisma.hashnodeExport.findFirst({
             where: { projectId, nodeId: nodeId ?? null, credentialId: cred.id },
         });
-        if (existingExport) {
-            return {
-                hashnodePostId: existingExport.hashnodePostId,
-                hashnodePostUrl: existingExport.hashnodePostUrl,
-                publishStatus: existingExport.publishStatus,
-                alreadyPublished: true,
-            };
-        }
 
         // Generate content
         const contentMarkdown = await exportHashnode(projectId, nodeId);
@@ -74,6 +67,104 @@ export class HashnodePublishController {
 
         // Build tag input for Hashnode
         const tagInput = tags.map((name) => ({ name, slug: name.toLowerCase().replace(/\s+/g, '-') }));
+
+        // If export record exists, update the existing post/draft instead of creating a new one
+        if (existingExport) {
+            const isDraft = existingExport.publishStatus === 'draft';
+
+            if (isDraft) {
+                const input: Record<string, unknown> = {
+                    id: existingExport.hashnodePostId,
+                    title,
+                    contentMarkdown,
+                    tags: tagInput,
+                };
+                if (canonicalUrl) input.originalArticleURL = canonicalUrl;
+
+                const response = await fetch(HASHNODE_GQL, {
+                    method: 'POST',
+                    headers: {
+                        Authorization: accessToken,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        query: `
+                            mutation UpdateDraft($input: UpdateDraftInput!) {
+                                updateDraft(input: $input) {
+                                    draft {
+                                        id
+                                        title
+                                    }
+                                }
+                            }
+                        `,
+                        variables: { input },
+                    }),
+                });
+
+                if (!response.ok) {
+                    const errorText = await response.text();
+                    throw new Error(`Hashnode API error (${response.status}): ${errorText}`);
+                }
+
+                const result = await response.json();
+                if (result.errors) {
+                    throw new Error(`Hashnode API error: ${result.errors[0]?.message ?? 'unknown'}`);
+                }
+            } else {
+                const input: Record<string, unknown> = {
+                    id: existingExport.hashnodePostId,
+                    title,
+                    contentMarkdown,
+                    tags: tagInput,
+                    settings: { isDelisted: existingExport.publishStatus === 'unlisted' },
+                };
+                if (canonicalUrl) input.originalArticleURL = canonicalUrl;
+
+                const response = await fetch(HASHNODE_GQL, {
+                    method: 'POST',
+                    headers: {
+                        Authorization: accessToken,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        query: `
+                            mutation UpdatePost($input: UpdatePostInput!) {
+                                updatePost(input: $input) {
+                                    post {
+                                        id
+                                        url
+                                    }
+                                }
+                            }
+                        `,
+                        variables: { input },
+                    }),
+                });
+
+                if (!response.ok) {
+                    const errorText = await response.text();
+                    throw new Error(`Hashnode API error (${response.status}): ${errorText}`);
+                }
+
+                const result = await response.json();
+                if (result.errors) {
+                    throw new Error(`Hashnode API error: ${result.errors[0]?.message ?? 'unknown'}`);
+                }
+            }
+
+            await prisma.hashnodeExport.update({
+                where: { id: existingExport.id },
+                data: { lastSyncedAt: new Date() },
+            });
+
+            return {
+                hashnodePostId: existingExport.hashnodePostId,
+                hashnodePostUrl: existingExport.hashnodePostUrl,
+                publishStatus: existingExport.publishStatus,
+                updated: true,
+            };
+        }
 
         let postId: string;
         let postUrl: string;


### PR DESCRIPTION
Update existing drafts/posts via updateDraft/updatePost mutations instead of returning alreadyPublished. UI shows Update button when export exists.