### PR TITLE
fix: Hashnode update uses wrong ID field names (draftId/postId)

### DIFF
--- a/src/__tests__/hashnode-publish-controller.test.ts
+++ b/src/__tests__/hashnode-publish-controller.test.ts
@@ -304,7 +304,7 @@ describe("HashnodePublishController", () => {
             const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
             const requestBody = JSON.parse(fetchCall[1].body);
             expect(requestBody.query).toContain("updateDraft");
-            expect(requestBody.variables.input.id).toBe("existing-draft-id");
+            expect(requestBody.variables.input.draftId).toBe("existing-draft-id");
         });
 
         it("calls updatePost when existing export has public status", async () => {
@@ -330,7 +330,7 @@ describe("HashnodePublishController", () => {
             const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
             const requestBody = JSON.parse(fetchCall[1].body);
             expect(requestBody.query).toContain("updatePost");
-            expect(requestBody.variables.input.id).toBe("existing-post-id");
+            expect(requestBody.variables.input.postId).toBe("existing-post-id");
         });
 
         it("updates lastSyncedAt on the export record", async () => {

--- a/src/lib/controllers/hashnode-publish.ts
+++ b/src/lib/controllers/hashnode-publish.ts
@@ -74,7 +74,7 @@ export class HashnodePublishController {
 
             if (isDraft) {
                 const input: Record<string, unknown> = {
-                    id: existingExport.hashnodePostId,
+                    draftId: existingExport.hashnodePostId,
                     title,
                     contentMarkdown,
                     tags: tagInput,
@@ -113,7 +113,7 @@ export class HashnodePublishController {
                 }
             } else {
                 const input: Record<string, unknown> = {
-                    id: existingExport.hashnodePostId,
+                    postId: existingExport.hashnodePostId,
                     title,
                     contentMarkdown,
                     tags: tagInput,


### PR DESCRIPTION
UpdateDraftInput expects draftId not id. UpdatePostInput expects postId not id. Fixes 500 error when updating existing Hashnode drafts.