### PR TITLE
feat: Add Connect Google Docs button with separate OAuth flow

### DIFF
--- a/src/app/api/auth/google-docs/callback/route.ts
+++ b/src/app/api/auth/google-docs/callback/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { GoogleAuthController } from "@/lib/controllers/google-auth";
+import { logger } from "@/lib/logger";
+
+/**
+ * GET /api/auth/google-docs/callback — Handle Google OAuth callback for Docs/Drive scopes.
+ * Exchanges auth code for tokens, stores GoogleCredential, redirects to /settings.
+ */
+export async function GET(request: NextRequest) {
+    const { searchParams, origin } = new URL(request.url);
+    const code = searchParams.get("code");
+    const state = searchParams.get("state");
+    const stateCookie = request.cookies.get("google_docs_oauth_state")?.value;
+
+    if (!code) {
+        return NextResponse.redirect(new URL("/settings?google_docs_error=missing_code", origin));
+    }
+
+    if (!state || !stateCookie || state !== stateCookie) {
+        return NextResponse.redirect(new URL("/settings?google_docs_error=invalid_state", origin));
+    }
+
+    try {
+        const redirectUri = `${origin}/api/auth/google-docs/callback`;
+        await GoogleAuthController.handleCallback(code, redirectUri);
+
+        const response = NextResponse.redirect(new URL("/settings?google_docs=connected", origin));
+        response.cookies.set("google_docs_oauth_state", "", {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            sameSite: "lax",
+            maxAge: 0,
+            path: "/",
+        });
+        return response;
+    } catch (error) {
+        logger.error("GET /api/auth/google-docs/callback error", error);
+        return NextResponse.redirect(new URL("/settings?google_docs_error=callback_failed", origin));
+    }
+}

--- a/src/app/api/auth/google-docs/route.ts
+++ b/src/app/api/auth/google-docs/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { GoogleAuthController } from "@/lib/controllers/google-auth";
+import { env } from "@/lib/env";
+import { logger } from "@/lib/logger";
+import crypto from "crypto";
+
+/**
+ * GET /api/auth/google-docs — Redirect to Google OAuth for Docs/Drive scopes.
+ * Separate from /api/auth/google (login) — this grants document access only.
+ */
+export async function GET(request: NextRequest) {
+    if (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET) {
+        return NextResponse.json(
+            { error: "Google OAuth not configured" },
+            { status: 501 }
+        );
+    }
+
+    try {
+        const baseUrl = new URL(request.url).origin;
+        const redirectUri = `${baseUrl}/api/auth/google-docs/callback`;
+
+        const state = crypto.randomUUID();
+        const authUrl = GoogleAuthController.getAuthUrl(redirectUri) + `&state=${state}`;
+
+        const response = NextResponse.redirect(authUrl);
+        response.cookies.set("google_docs_oauth_state", state, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            sameSite: "lax",
+            maxAge: 600,
+            path: "/",
+        });
+
+        return response;
+    } catch (error) {
+        logger.error("GET /api/auth/google-docs error", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/integrations/google-docs/route.ts
+++ b/src/app/api/integrations/google-docs/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GoogleDocsCommentSync } from '@/lib/export/google-docs-comment-sync';
+import { GoogleAuthController } from '@/lib/controllers/google-auth';
 import { getCurrentUserId, verifyProjectWriteAccess } from '@/lib/api-auth';
 import { logger } from '@/lib/logger';
 
@@ -11,18 +12,38 @@ export async function GET(request: NextRequest) {
     try {
         const { searchParams } = new URL(request.url);
         const projectId = searchParams.get('projectId');
+
+        // If no projectId, return connection status only (used by global settings page)
         if (!projectId) {
-            return NextResponse.json({ error: 'projectId is required' }, { status: 400 });
+            const status = await GoogleAuthController.getStatus();
+            return NextResponse.json({ connected: status.connected });
         }
 
         const userId = getCurrentUserId(request);
         const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get('x-user-email'));
         if (!access.authorized) return access.response;
 
-        const exports = await GoogleDocsCommentSync.getExportInfo(projectId);
-        return NextResponse.json({ exports });
+        const [exports, status] = await Promise.all([
+            GoogleDocsCommentSync.getExportInfo(projectId),
+            GoogleAuthController.getStatus(),
+        ]);
+        return NextResponse.json({ exports, connected: status.connected });
     } catch (error) {
         logger.error('GET /api/integrations/google-docs error', error);
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
+}
+
+/**
+ * DELETE /api/integrations/google-docs
+ * Disconnects Google Docs by removing the stored credential.
+ */
+export async function DELETE() {
+    try {
+        await GoogleAuthController.disconnect();
+        return NextResponse.json({ disconnected: true });
+    } catch (error) {
+        logger.error('DELETE /api/integrations/google-docs error', error);
         return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
     }
 }

--- a/src/app/project/[id]/settings/page.tsx
+++ b/src/app/project/[id]/settings/page.tsx
@@ -62,6 +62,7 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
     lastCommentSyncAt: string | null;
   }
   const [googleDocExports, setGoogleDocExports] = useState<GoogleDocExportInfo[]>([]);
+  const [googleDocsConnected, setGoogleDocsConnected] = useState(false);
   const [syncingComments, setSyncingComments] = useState(false);
   const [syncResult, setSyncResult] = useState<{ imported: number; skipped: number; unresolvable: number } | null>(null);
   const [googleExportMode, setGoogleExportMode] = useState<"STORY_READER" | "STORY_INTERNAL">("STORY_READER");
@@ -79,7 +80,10 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
     if (!projectId) return;
     fetch(`/api/integrations/google-docs?projectId=${projectId}`)
       .then((r) => r.json())
-      .then((d) => setGoogleDocExports(d.exports ?? []))
+      .then((d) => {
+        setGoogleDocExports(d.exports ?? []);
+        setGoogleDocsConnected(d.connected ?? false);
+      })
       .catch(() => {});
   }, [projectId]);
 
@@ -242,6 +246,7 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
       const infoRes = await fetch(`/api/integrations/google-docs?projectId=${projectId}`);
       const infoData = await infoRes.json();
       setGoogleDocExports(infoData.exports ?? []);
+      setGoogleDocsConnected(infoData.connected ?? false);
     } catch (err) {
       alert(err instanceof Error ? err.message : "Export to Google Docs failed");
     } finally {
@@ -545,6 +550,16 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
           <>
             <p className="text-xs font-medium text-text-muted uppercase tracking-wider mt-5 mb-2">Google Docs</p>
             <div className="space-y-3">
+              {!googleDocsConnected ? (
+                <p className="text-xs text-text-muted">
+                  Connect Google Docs in{" "}
+                  <a href="/settings" className="text-accent hover:underline">
+                    Settings
+                  </a>{" "}
+                  to export directly to Google Docs.
+                </p>
+              ) : (
+                <>
               <div className="flex gap-4">
                 <label className="flex items-center gap-2 cursor-pointer text-sm text-text-secondary">
                   <input
@@ -650,6 +665,8 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
                   )}
                 </>
               )}
+            </>
+          )}
             </div>
           </>
         </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -56,6 +56,11 @@ export default function SettingsPage() {
   const [coachingStyle, setCoachingStyle] = useState("balanced");
   const [responseLength, setResponseLength] = useState("moderate");
 
+  // Google Docs integration state
+  const [googleDocsLoading, setGoogleDocsLoading] = useState(true);
+  const [googleDocsConnected, setGoogleDocsConnected] = useState(false);
+  const [googleDocsDisconnecting, setGoogleDocsDisconnecting] = useState(false);
+
   // Hashnode integration state
   const [hashnodeLoading, setHashnodeLoading] = useState(true);
   const [hashnodeConnected, setHashnodeConnected] = useState(false);
@@ -92,6 +97,12 @@ export default function SettingsPage() {
       })
       .catch(console.error)
       .finally(() => setHashnodeLoading(false));
+
+    fetch("/api/integrations/google-docs")
+      .then((res) => res.json())
+      .then((data) => setGoogleDocsConnected(data.connected ?? false))
+      .catch(console.error)
+      .finally(() => setGoogleDocsLoading(false));
   }, []);
 
   const handleHashnodeConnect = async () => {
@@ -128,6 +139,16 @@ export default function SettingsPage() {
       setHashnodeDisconnectOpen(false);
     } finally {
       setHashnodeDisconnecting(false);
+    }
+  };
+
+  const handleGoogleDocsDisconnect = async () => {
+    setGoogleDocsDisconnecting(true);
+    try {
+      await fetch("/api/integrations/google-docs", { method: "DELETE" });
+      setGoogleDocsConnected(false);
+    } finally {
+      setGoogleDocsDisconnecting(false);
     }
   };
 
@@ -437,6 +458,63 @@ export default function SettingsPage() {
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
+
+        {/* Google Docs Integration */}
+        {!loading && (
+          <div className="glass-card p-6 mt-6">
+            <div className="flex items-center gap-2 mb-1">
+              <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 fill-current text-accent" aria-hidden="true">
+                <path d="M14.727 6.727H14V0H4.91C4.085 0 3.818.272 3.818 1.091v21.818c0 .82.267 1.091 1.09 1.091h14.19c.82 0 1.09-.271 1.09-1.09V6.727h-5.46zm.545 10.455H8.727v-1.364h6.545v1.364zm0-3.273H8.727v-1.364h6.545v1.364zm0-3.273H8.727V9.273h6.545v1.363zM14.727 6h6l-6-6v6z"/>
+              </svg>
+              <h2 className="text-lg font-semibold text-text-primary">Google Docs</h2>
+            </div>
+            <p className="text-sm text-text-secondary mb-4">
+              Export your stories to Google Docs and sync reader comments back as annotations. Requires a Google account with Docs and Drive access.
+            </p>
+
+            {googleDocsLoading ? (
+              <div className="flex items-center justify-center py-4">
+                <div className="h-5 w-5 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+              </div>
+            ) : googleDocsConnected ? (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm">
+                  <Link2 className="h-4 w-4 text-green-500" />
+                  <span className="text-text-secondary">Connected — Google Docs access granted</span>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleGoogleDocsDisconnect}
+                  disabled={googleDocsDisconnecting}
+                  className="gap-1.5"
+                >
+                  {googleDocsDisconnecting ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Link2Off className="h-4 w-4" />
+                  )}
+                  Disconnect
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <p className="text-sm text-text-primary">Not connected</p>
+                <p className="text-xs text-text-muted">
+                  Click Connect to authorize access to your Google Docs and Drive.
+                </p>
+                <Button
+                  size="sm"
+                  onClick={() => { window.location.href = "/api/auth/google-docs"; }}
+                  className="gap-1.5"
+                >
+                  <Link2 className="h-4 w-4" />
+                  Connect Google Docs
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Save Button */}
         {!loading && (

--- a/src/lib/ai/adk-tools.ts
+++ b/src/lib/ai/adk-tools.ts
@@ -685,6 +685,7 @@ import {
 } from "@/mcp/tools/coaching";
 import { GoogleAuthController } from "@/lib/controllers/google-auth";
 import { GoogleDocsExporter } from "@/lib/export/google-docs-exporter";
+import { env } from "@/lib/env";
 
 // ─── Handler dispatch map ────────────────────────────────────────────────────
 // Maps tool name → execute function for ADK's execute signature
@@ -805,9 +806,9 @@ const toolExecutors: Record<string, (args: Args) => Promise<unknown>> = {
   list_snapshots: async (a) => listDatabaseSnapshots(a.limit as number),
   restore_snapshot: async (a) => restoreDatabaseSnapshot(a.commitHash as string),
   google_auth_status: async () => GoogleAuthController.getStatus(),
-  google_auth_connect: async () => ({ authUrl: GoogleAuthController.getAuthUrl() }),
+  google_auth_connect: async () => ({ authUrl: GoogleAuthController.getAuthUrl(env.GOOGLE_REDIRECT_URI ?? '') }),
   google_auth_callback: async (a) => {
-    await GoogleAuthController.handleCallback(a.code as string);
+    await GoogleAuthController.handleCallback(a.code as string, env.GOOGLE_REDIRECT_URI ?? '');
     return { success: true };
   },
   google_auth_disconnect: async () => {

--- a/src/lib/controllers/google-auth.ts
+++ b/src/lib/controllers/google-auth.ts
@@ -5,16 +5,16 @@ import { encrypt, decrypt } from '@/lib/crypto';
 import { env } from '@/lib/env';
 
 export class GoogleAuthController {
-    private static getClient(): OAuth2Client {
+    private static getClient(redirectUri?: string): OAuth2Client {
         return new google.auth.OAuth2(
             env.GOOGLE_CLIENT_ID,
             env.GOOGLE_CLIENT_SECRET,
-            env.GOOGLE_REDIRECT_URI
+            redirectUri ?? env.GOOGLE_REDIRECT_URI
         );
     }
 
-    static getAuthUrl() {
-        const client = this.getClient();
+    static getAuthUrl(redirectUri?: string) {
+        const client = this.getClient(redirectUri ?? env.GOOGLE_REDIRECT_URI);
         return client.generateAuthUrl({
             access_type: 'offline', // Critical for refresh token
             scope: [
@@ -25,8 +25,8 @@ export class GoogleAuthController {
         });
     }
 
-    static async handleCallback(code: string) {
-        const client = this.getClient();
+    static async handleCallback(code: string, redirectUri?: string) {
+        const client = this.getClient(redirectUri ?? env.GOOGLE_REDIRECT_URI);
         const { tokens } = await client.getToken(code);
 
         // In local single-user mode, we replace any existing credentials
@@ -48,7 +48,7 @@ export class GoogleAuthController {
         const cred = await prisma.googleCredential.findFirst();
         if (!cred) return null;
 
-        const client = this.getClient();
+        const client = this.getClient(undefined);
         client.setCredentials({
             access_token: decrypt(cred.accessToken),
             refresh_token: decrypt(cred.refreshToken),

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1000,7 +1000,7 @@ server.tool(
     {},
     async () => {
         try {
-            const url = GoogleAuthController.getAuthUrl();
+            const url = GoogleAuthController.getAuthUrl(env.GOOGLE_REDIRECT_URI ?? '');
             return { content: [{ type: "text", text: `Please visit this URL to authorize: ${url}` }] };
         } catch (e) {
             return { content: [{ type: "text", text: `Error generating auth URL. Check environment variables (GOOGLE_CLIENT_ID, etc). Error: ${e}` }], isError: true };
@@ -1016,7 +1016,7 @@ server.tool(
     },
     async ({ code }) => {
         try {
-            await GoogleAuthController.handleCallback(code);
+            await GoogleAuthController.handleCallback(code, env.GOOGLE_REDIRECT_URI ?? '');
             return { content: [{ type: "text", text: "Successfully connected to Google!" }] };
         } catch (e) {
             return { content: [{ type: "text", text: `Error connecting: ${e}` }], isError: true };


### PR DESCRIPTION
Google Docs export failed because login OAuth only has profile scopes. Adds separate OAuth flow with documents+drive.file scopes. New routes, Connect/Disconnect in settings, connect prompt in project settings when not connected.