### PR TITLE
refactor: consolidate all AI calls through ADK agent

### DIFF
--- a/src/app/api/ai-inline/route.ts
+++ b/src/app/api/ai-inline/route.ts
@@ -3,7 +3,7 @@ import { getAiConfig, getAiPreferences, buildPreferenceInstructions } from "@/li
 import { getCurrentUserId } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 import { sanitizeInput } from "@/lib/sanitize-server";
-import OpenAI from "openai";
+import { runSimpleCompletion } from "@/lib/ai/adk-agent";
 
 export type InlineAiAction =
   | "rewrite-tighter"
@@ -79,22 +79,13 @@ export async function POST(request: NextRequest) {
     const prefs = await getAiPreferences(userId);
     const prefInstructions = buildPreferenceInstructions(prefs);
 
-    const client = new OpenAI({
-      apiKey: aiConfig.apiKey,
-      baseURL: aiConfig.baseUrl || undefined,
-    });
-
-    const response = await client.chat.completions.create({
-      model: aiConfig.model,
-      messages: [
-        { role: "system", content: prefInstructions },
-        { role: "user", content: prompt },
-      ],
-      max_tokens: 1000,
+    const result = await runSimpleCompletion({
+      systemPrompt: prefInstructions,
+      userMessage: prompt,
+      aiConfig,
+      maxTokens: 1000,
       temperature: 0.7,
     });
-
-    const result = response.choices[0]?.message?.content?.trim() || "";
     return NextResponse.json({ result });
   } catch (error) {
     logger.error("POST /api/ai-inline error", error);

--- a/src/app/api/ai-manuscript/route.ts
+++ b/src/app/api/ai-manuscript/route.ts
@@ -3,7 +3,7 @@ import { getAiConfig, getAiPreferences, buildPreferenceInstructions } from "@/li
 import { getCurrentUserId } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 import { getManuscriptContext } from "@/mcp/tools/coaching";
-import OpenAI from "openai";
+import { runSimpleCompletion } from "@/lib/ai/adk-agent";
 
 export type ManuscriptAnalysisType =
   | "plot-threads"
@@ -96,22 +96,13 @@ export async function POST(request: NextRequest) {
     const prefs = await getAiPreferences(userId);
     const prefInstructions = buildPreferenceInstructions(prefs);
 
-    const client = new OpenAI({
-      apiKey: aiConfig.apiKey,
-      baseURL: aiConfig.baseUrl || undefined,
-    });
-
-    const response = await client.chat.completions.create({
-      model: aiConfig.model,
-      messages: [
-        { role: "system", content: prefInstructions },
-        { role: "user", content: prompt },
-      ],
-      max_tokens: 2000,
+    const result = await runSimpleCompletion({
+      systemPrompt: prefInstructions,
+      userMessage: prompt,
+      aiConfig,
+      maxTokens: 2000,
       temperature: 0.5,
     });
-
-    const result = response.choices[0]?.message?.content?.trim() || "";
     return NextResponse.json({ result, analysisType });
   } catch (error) {
     logger.error("POST /api/ai-manuscript error", error);

--- a/src/app/api/projects/[id]/consistency-check/route.ts
+++ b/src/app/api/projects/[id]/consistency-check/route.ts
@@ -3,7 +3,7 @@ import { logger } from "@/lib/logger";
 import { getCurrentUserId, verifyProjectWriteAccess } from "@/lib/api-auth";
 import { getAiConfig } from "@/lib/ai/settings";
 import { getConsistencyContext } from "@/mcp/tools/coaching";
-import OpenAI from "openai";
+import { runSimpleCompletion } from "@/lib/ai/adk-agent";
 
 export interface ConsistencyAlert {
   id: string;
@@ -95,19 +95,12 @@ For each issue found, provide a JSON object. Return ONLY a valid JSON array (no 
 If no contradictions are found, return [].
 Only report clear, specific contradictions. Do not report vague impressions.`;
 
-    const client = new OpenAI({
-      apiKey: aiConfig.apiKey,
-      baseURL: aiConfig.baseUrl || undefined,
-    });
-
-    const response = await client.chat.completions.create({
-      model: aiConfig.model,
-      messages: [{ role: "user", content: prompt }],
-      max_tokens: 1500,
+    const rawContent = await runSimpleCompletion({
+      userMessage: prompt,
+      aiConfig,
+      maxTokens: 1500,
       temperature: 0.1,
-    });
-
-    const rawContent = response.choices[0]?.message?.content ?? "[]";
+    }) || "[]";
     let parsed: {
       type: string;
       severity: string;

--- a/src/app/api/projects/[id]/voice-check/route.ts
+++ b/src/app/api/projects/[id]/voice-check/route.ts
@@ -3,7 +3,7 @@ import { logger } from "@/lib/logger";
 import { getCurrentUserId, verifyProjectWriteAccess } from "@/lib/api-auth";
 import { getAiConfig } from "@/lib/ai/settings";
 import { getVoiceContext } from "@/mcp/tools/coaching";
-import OpenAI from "openai";
+import { runSimpleCompletion } from "@/lib/ai/adk-agent";
 
 interface VoiceProfile {
   characterId: string;
@@ -115,19 +115,12 @@ Return ONLY valid JSON with this structure:
 
 The "feedback" array should be empty if the text is not dialogue or no voice issues are found.`;
 
-    const client = new OpenAI({
-      apiKey: aiConfig.apiKey,
-      baseURL: aiConfig.baseUrl || undefined,
-    });
-
-    const response = await client.chat.completions.create({
-      model: aiConfig.model,
-      messages: [{ role: "user", content: prompt }],
-      max_tokens: 1000,
+    const rawContent = await runSimpleCompletion({
+      userMessage: prompt,
+      aiConfig,
+      maxTokens: 1000,
       temperature: 0.1,
-    });
-
-    const rawContent = response.choices[0]?.message?.content ?? "{}";
+    }) || "{}";
     let parsed: { profiles?: VoiceProfile[]; feedback?: VoiceFeedback[] } = {};
     try {
       const jsonMatch = rawContent.match(/\{[\s\S]*\}/);

--- a/src/lib/ai/adk-agent.ts
+++ b/src/lib/ai/adk-agent.ts
@@ -13,11 +13,12 @@ import {
   getFunctionCalls,
   getFunctionResponses,
   stringifyContent,
+  type LlmRequest,
 } from "@google/adk";
 import type { Content } from "@google/genai";
 import { DynamicToolset } from "./adk-tools";
 import type { ToolCategory } from "./adk-tools";
-import { OpenAICompatibleLlm } from "./adk-openai-llm";
+import { OpenAICompatibleLlm, createOpenAILlmFromConfig } from "./adk-openai-llm";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { getTracer } from "@/lib/telemetry";
 
@@ -172,4 +173,48 @@ export async function runChatAgent(params: {
       span.end();
     }
   });
+}
+
+/**
+ * Run a simple single-turn completion through the ADK OpenAI shim.
+ * Use this for non-agentic routes (inline edits, consistency check, voice check)
+ * that just need one prompt → one response without tool use.
+ */
+export async function runSimpleCompletion(params: {
+  systemPrompt?: string;
+  userMessage: string;
+  aiConfig: { baseUrl: string; apiKey: string; model: string };
+  maxTokens?: number;
+  temperature?: number;
+}): Promise<string> {
+  const llm = createOpenAILlmFromConfig(params.aiConfig);
+
+  const contents: Content[] = [
+    { role: "user", parts: [{ text: params.userMessage }] },
+  ];
+
+  const request = {
+    model: params.aiConfig.model,
+    contents,
+    config: {
+      ...(params.systemPrompt
+        ? { systemInstruction: params.systemPrompt }
+        : {}),
+      ...(params.temperature !== undefined
+        ? { temperature: params.temperature }
+        : {}),
+      ...(params.maxTokens !== undefined
+        ? { maxOutputTokens: params.maxTokens }
+        : {}),
+    },
+  } as LlmRequest;
+
+  for await (const response of llm.generateContentAsync(request)) {
+    const text = response.content?.parts
+      ?.filter((p) => p.text != null)
+      .map((p) => p.text)
+      .join("") ?? "";
+    if (text) return text.trim();
+  }
+  return "";
 }


### PR DESCRIPTION
Migrate 3 remaining API routes from direct OpenAI SDK to ADK: ai-inline, consistency-check, voice-check. After this, only adk-openai-llm.ts imports openai — single abstraction point for the Google AI switch.