### PR TITLE
fix: use forwarded headers for Google Docs OAuth redirect URI

### DIFF
--- a/src/app/api/auth/google-docs/callback/route.ts
+++ b/src/app/api/auth/google-docs/callback/route.ts
@@ -7,7 +7,11 @@ import { logger } from "@/lib/logger";
  * Exchanges auth code for tokens, stores GoogleCredential, redirects to /settings.
  */
 export async function GET(request: NextRequest) {
-    const { searchParams, origin } = new URL(request.url);
+    const { searchParams } = new URL(request.url);
+    const proto = request.headers.get("x-forwarded-proto") || "https";
+    const host = request.headers.get("x-forwarded-host") || request.headers.get("host") || new URL(request.url).host;
+    const origin = `${proto}://${host}`;
+
     const code = searchParams.get("code");
     const state = searchParams.get("state");
     const stateCookie = request.cookies.get("google_docs_oauth_state")?.value;

--- a/src/app/api/auth/google-docs/route.ts
+++ b/src/app/api/auth/google-docs/route.ts
@@ -17,7 +17,9 @@ export async function GET(request: NextRequest) {
     }
 
     try {
-        const baseUrl = new URL(request.url).origin;
+        const proto = request.headers.get("x-forwarded-proto") || "https";
+        const host = request.headers.get("x-forwarded-host") || request.headers.get("host") || new URL(request.url).host;
+        const baseUrl = `${proto}://${host}`;
         const redirectUri = `${baseUrl}/api/auth/google-docs/callback`;
 
         const state = crypto.randomUUID();


### PR DESCRIPTION
Behind Railway proxy, request.url resolves to 0.0.0.0:3000 instead of the public URL. Use x-forwarded-proto/host headers.