### PR TITLE
fix: version banner always showing due to build-time SHA mismatch

### DIFF
--- a/src/hooks/use-version-check.ts
+++ b/src/hooks/use-version-check.ts
@@ -7,9 +7,7 @@ const CHECK_INTERVAL = 60_000; // 60 seconds
 export function useVersionCheck() {
     const [updateAvailable, setUpdateAvailable] = useState(false);
     const [dismissed, setDismissed] = useState(false);
-    const loadedVersion = useRef<string | null>(
-        process.env.NEXT_PUBLIC_BUILD_VERSION || null
-    );
+    const loadedVersion = useRef<string | null>(null);
 
     const checkVersion = useCallback(async () => {
         try {


### PR DESCRIPTION
## Summary
- Initialize `loadedVersion` as null instead of from `NEXT_PUBLIC_BUILD_VERSION`
- The env var is baked in at build time, so after a deploy the client has the old SHA while `version.json` has the new one — triggering "update available" immediately on every page load

## Root cause
`NEXT_PUBLIC_BUILD_VERSION` = old deploy's SHA (baked into JS bundle)
`version.json` = new deploy's SHA (generated fresh each build)
→ mismatch on first check → banner always shows

## Fix
Let the first fetch of `version.json` set the baseline. Banner only shows when version.json changes *after* page load (i.e., a new deploy happened while the user has the tab open).

Fixes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)