### PR TITLE
fix: add issues write permission to backup freshness job

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -43,6 +43,8 @@ jobs:
   check-backup-freshness:
     name: Backup Freshness Check
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Check Supabase backup age
         id: backup-check


### PR DESCRIPTION
## Summary

- The `check-backup-freshness` job in `.github/workflows/uptime.yml` was calling the GitHub Issues API (to create labels and alert issues) but had no `permissions` block, causing every run to fail with HTTP 403 `Resource not accessible by integration`
- Added `permissions: issues: write` to the `check-backup-freshness` job — the minimal required scope

## Root Cause

The job uses `actions/github-script@v7` with the automatic `GITHUB_TOKEN`. Without an explicit `permissions` block, the token only has read access. The `github.rest.issues.createLabel()` and `github.rest.issues.create()` calls all require `issues: write`. The error log explicitly showed `x-accepted-github-permissions: issues=write; pull_requests=write`.

Introduced in commit 735346c ("feat: add backup freshness monitoring to uptime workflow") — the permission was missing from the initial implementation.

## Changes

| File | Action |
|------|--------|
| `.github/workflows/uptime.yml` | Added `permissions: issues: write` to `check-backup-freshness` job (+2 lines) |

## Validation

- YAML lint: ✅
- TypeScript type check: ✅ (no errors)
- ESLint: ✅ (0 errors, 129 pre-existing warnings)
- Tests: ✅ 689 passed, 0 failed (61 test files)
- Build: ✅ Next.js production build successful

Fixes #462