### PR TITLE
fix(security): tighten CSP and add HSTS header (SEC-011, SEC-012, SEC-013)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -51,7 +51,15 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              // SEC-011: 'unsafe-eval' removed — not required by Next.js in production.
+              // 'unsafe-inline' is retained for script-src because next-themes injects an
+              // inline FOUC-prevention script at render time that cannot be hashed without
+              // nonce-based middleware. Tracking removal as a follow-up requiring a
+              // custom middleware layer to inject per-request nonces.
+              "script-src 'self' 'unsafe-inline'",
+              // SEC-011: 'unsafe-inline' retained for style-src — 22+ component-level
+              // inline style= attributes and styled-jsx require it. Full removal needs a
+              // separate refactor to eliminate inline styles or add nonces.
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' data: blob: https://lh3.googleusercontent.com https://github.com/user-attachments/",
               "font-src 'self' https://fonts.gstatic.com",
@@ -59,7 +67,9 @@ const nextConfig: NextConfig = {
               "object-src 'none'",
               "frame-ancestors 'none'",
               "base-uri 'self'",
-              "form-action *",
+              // SEC-012: Replaced wildcard form-action with explicit self-origin only.
+              // The only form POST in this app is oauth/authorize posting to itself.
+              "form-action 'self'",
             ].join("; "),
           },
           {
@@ -73,6 +83,14 @@ const nextConfig: NextConfig = {
           {
             key: "Referrer-Policy",
             value: "strict-origin-when-cross-origin",
+          },
+          // SEC-013: HSTS — 2-year max-age with includeSubDomains.
+          // preload omitted intentionally: requires HSTS preload list submission
+          // and is irreversible without a long lead time. Add preload once the
+          // domain is confirmed stable.
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains",
           },
         ],
       },


### PR DESCRIPTION
## Summary

Addresses three security issues in `next.config.ts` headers config. All changes are conservative — nothing that would break the running app is removed.

### SEC-013: Add HSTS header (#432)

Added `Strict-Transport-Security: max-age=63072000; includeSubDomains` to the global headers block.

- `preload` deliberately omitted: submitting to the HSTS preload list is irreversible without a long lead time. Can be added once the domain is confirmed stable.

### SEC-012: Replace `form-action *` with `form-action 'self'` (#431)

Audited all form `action=` attributes in the codebase. The only form POST is in `src/app/oauth/authorize/route.ts` line 399, which posts to `/oauth/authorize` (same origin). A wildcard `form-action` is not needed.

**Note:** `src/app/oauth/authorize/route.ts` also sets its own per-route CSP override at line 310 that still contains `form-action *`. That route's CSP is scoped to the OAuth authorization page (which intentionally serves an inline redirect script), so it's out of scope for this PR but worth a follow-up tightening.

### SEC-011: Remove `unsafe-eval` from `script-src` (#430)

`unsafe-eval` removed from `script-src` — Next.js does not require it in production (it's used by webpack HMR in dev mode only, and dev mode is already disabled for the PWA config).

**What could not be removed without breaking the app:**

- **`unsafe-inline` in `script-src`**: `next-themes` (v0.4.6) injects an inline script into `<head>` at render time to prevent flash-of-unstyled-content (FOUC). This script has no stable hash (it reads from `localStorage` and the DOM). Removing `unsafe-inline` here requires adding a custom Next.js middleware that injects a per-request nonce into both the CSP header and the next-themes provider. This is a meaningful refactor tracked as a follow-up.

- **`unsafe-inline` in `style-src`**: 22+ components use inline `style=` JSX attributes (React inline styles), and styled-jsx (Next.js default CSS-in-JS) also emits inline styles. Removing this directive requires either eliminating all inline styles from components or adding nonce support. Also tracked as a follow-up.

## Files changed

- `next.config.ts` — headers block only, no logic changes

## Test plan

- [ ] Build the app locally and verify no CSP console errors in browser devtools
- [ ] Verify theme switching (dark/light) works — confirms `unsafe-inline` script-src didn't regress
- [ ] Load a page with Google Fonts — confirms font-src / style-src still allow font loading
- [ ] Check Sentry error reports still appear in Sentry dashboard (connect-src unchanged)
- [ ] Verify the OAuth flow (`/oauth/authorize`) still works
- [ ] Use `curl -I <prod-url>` to confirm `Strict-Transport-Security` header is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)