### PR TITLE
fix: scope GoogleCredential operations to userId (issue #429)

### DIFF
--- a/prisma/migrations/20260425_add_user_id_to_google_credential/migration.sql
+++ b/prisma/migrations/20260425_add_user_id_to_google_credential/migration.sql
@@ -1,0 +1,7 @@
+-- Add userId to GoogleCredential for per-user credential isolation.
+-- Existing rows (if any) are assigned to 'local' (single-user default),
+-- matching the HashnodeCredential convention used elsewhere in this codebase.
+
+ALTER TABLE "GoogleCredential" ADD COLUMN "userId" TEXT NOT NULL DEFAULT 'local';
+
+CREATE UNIQUE INDEX "GoogleCredential_userId_key" ON "GoogleCredential"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -201,6 +201,7 @@ model WorldObjectTimelineEntry {
 
 model GoogleCredential {
   id           String   @id @default(cuid())
+  userId       String   @unique  // "local" in single-user mode, actual user ID in multi-user
   accessToken  String
   refreshToken String
   expiresAt    DateTime

--- a/src/__tests__/google-auth-controller.test.ts
+++ b/src/__tests__/google-auth-controller.test.ts
@@ -33,13 +33,14 @@ describe("GoogleAuthController", () => {
 
     describe("getStatus", () => {
         it("returns disconnected when no credentials", async () => {
-            const status = await GoogleAuthController.getStatus();
+            const status = await GoogleAuthController.getStatus(null);
             expect(status.connected).toBe(false);
         });
 
         it("returns connected with credentials", async () => {
             await testPrisma.googleCredential.create({
                 data: {
+                    userId: "local",
                     accessToken: "test-token",
                     refreshToken: "test-refresh",
                     expiresAt: new Date(Date.now() + 3600000),
@@ -47,7 +48,7 @@ describe("GoogleAuthController", () => {
                 }
             });
 
-            const status = await GoogleAuthController.getStatus();
+            const status = await GoogleAuthController.getStatus(null);
             expect(status.connected).toBe(true);
             expect(status.isExpired).toBe(false);
         });
@@ -55,6 +56,7 @@ describe("GoogleAuthController", () => {
         it("returns expired status for expired token", async () => {
             await testPrisma.googleCredential.create({
                 data: {
+                    userId: "local",
                     accessToken: "test-token",
                     refreshToken: "test-refresh",
                     expiresAt: new Date(Date.now() - 3600000), // expired
@@ -62,25 +64,44 @@ describe("GoogleAuthController", () => {
                 }
             });
 
-            const status = await GoogleAuthController.getStatus();
+            const status = await GoogleAuthController.getStatus(null);
             expect(status.connected).toBe(true);
             expect(status.isExpired).toBe(true);
+        });
+
+        it("scopes status to the requesting user", async () => {
+            await testPrisma.googleCredential.create({
+                data: {
+                    userId: "user-A",
+                    accessToken: "token-a",
+                    refreshToken: "refresh-a",
+                    expiresAt: new Date(Date.now() + 3600000),
+                    scope: "test-scope"
+                }
+            });
+
+            const statusA = await GoogleAuthController.getStatus("user-A");
+            const statusB = await GoogleAuthController.getStatus("user-B");
+
+            expect(statusA.connected).toBe(true);
+            expect(statusB.connected).toBe(false);
         });
     });
 
     describe("handleCallback", () => {
         it("stores credentials from OAuth callback", async () => {
-            await GoogleAuthController.handleCallback("test-code");
+            await GoogleAuthController.handleCallback("test-code", undefined, null);
 
-            const cred = await testPrisma.googleCredential.findFirst();
+            const cred = await testPrisma.googleCredential.findUnique({ where: { userId: "local" } });
             expect(cred).not.toBeNull();
             expect(cred!.accessToken).toBe("test-access-token");
             expect(cred!.refreshToken).toBe("test-refresh-token");
         });
 
-        it("replaces existing credentials", async () => {
+        it("replaces existing credentials for the same user only", async () => {
             await testPrisma.googleCredential.create({
                 data: {
+                    userId: "local",
                     accessToken: "old-token",
                     refreshToken: "old-refresh",
                     expiresAt: new Date(),
@@ -88,23 +109,48 @@ describe("GoogleAuthController", () => {
                 }
             });
 
-            await GoogleAuthController.handleCallback("test-code");
+            await GoogleAuthController.handleCallback("test-code", undefined, null);
 
             const creds = await testPrisma.googleCredential.findMany();
             expect(creds).toHaveLength(1);
             expect(creds[0].accessToken).toBe("test-access-token");
+            expect(creds[0].userId).toBe("local");
+        });
+
+        it("does not replace credentials belonging to other users", async () => {
+            await testPrisma.googleCredential.create({
+                data: {
+                    userId: "user-B",
+                    accessToken: "user-b-token",
+                    refreshToken: "user-b-refresh",
+                    expiresAt: new Date(Date.now() + 3600000),
+                    scope: "test-scope"
+                }
+            });
+
+            // User A connects — must NOT delete user B's credentials
+            await GoogleAuthController.handleCallback("test-code", undefined, "user-A");
+
+            const credB = await testPrisma.googleCredential.findUnique({ where: { userId: "user-B" } });
+            expect(credB).not.toBeNull();
+            expect(credB!.accessToken).toBe("user-b-token");
+
+            const credA = await testPrisma.googleCredential.findUnique({ where: { userId: "user-A" } });
+            expect(credA).not.toBeNull();
+            expect(credA!.accessToken).toBe("test-access-token");
         });
     });
 
     describe("getValidClient", () => {
         it("returns null when no credentials", async () => {
-            const client = await GoogleAuthController.getValidClient();
+            const client = await GoogleAuthController.getValidClient(null);
             expect(client).toBeNull();
         });
 
         it("returns client when credentials exist", async () => {
             await testPrisma.googleCredential.create({
                 data: {
+                    userId: "local",
                     accessToken: "test-token",
                     refreshToken: "test-refresh",
                     expiresAt: new Date(Date.now() + 3600000),
@@ -112,15 +158,61 @@ describe("GoogleAuthController", () => {
                 }
             });
 
-            const client = await GoogleAuthController.getValidClient();
+            const client = await GoogleAuthController.getValidClient(null);
             expect(client).not.toBeNull();
+        });
+
+        it("returns null for a different user with no credentials", async () => {
+            await testPrisma.googleCredential.create({
+                data: {
+                    userId: "user-A",
+                    accessToken: "token-a",
+                    refreshToken: "refresh-a",
+                    expiresAt: new Date(Date.now() + 3600000),
+                    scope: "test-scope"
+                }
+            });
+
+            const client = await GoogleAuthController.getValidClient("user-B");
+            expect(client).toBeNull();
         });
     });
 
     describe("disconnect", () => {
-        it("removes all credentials", async () => {
+        it("removes credentials for the specified user only", async () => {
+            await testPrisma.googleCredential.createMany({
+                data: [
+                    {
+                        userId: "user-A",
+                        accessToken: "token-a",
+                        refreshToken: "refresh-a",
+                        expiresAt: new Date(),
+                        scope: "test-scope"
+                    },
+                    {
+                        userId: "user-B",
+                        accessToken: "token-b",
+                        refreshToken: "refresh-b",
+                        expiresAt: new Date(),
+                        scope: "test-scope"
+                    }
+                ]
+            });
+
+            // Disconnect user A — must NOT touch user B
+            await GoogleAuthController.disconnect("user-A");
+
+            const credA = await testPrisma.googleCredential.findUnique({ where: { userId: "user-A" } });
+            const credB = await testPrisma.googleCredential.findUnique({ where: { userId: "user-B" } });
+
+            expect(credA).toBeNull();
+            expect(credB).not.toBeNull();
+        });
+
+        it("removes local credentials when userId is null", async () => {
             await testPrisma.googleCredential.create({
                 data: {
+                    userId: "local",
                     accessToken: "test-token",
                     refreshToken: "test-refresh",
                     expiresAt: new Date(),
@@ -128,7 +220,7 @@ describe("GoogleAuthController", () => {
                 }
             });
 
-            await GoogleAuthController.disconnect();
+            await GoogleAuthController.disconnect(null);
 
             const creds = await testPrisma.googleCredential.findMany();
             expect(creds).toHaveLength(0);

--- a/src/__tests__/google-docs-comment-sync.test.ts
+++ b/src/__tests__/google-docs-comment-sync.test.ts
@@ -75,7 +75,7 @@ describe("GoogleDocsCommentSync", () => {
             expect(result.imported).toBe(1);
             expect(result.skipped).toBe(0);
             expect(result.unresolvable).toBe(0);
-            expect(GoogleDocsApi.fetchComments).toHaveBeenCalledWith("doc-abc");
+            expect(GoogleDocsApi.fetchComments).toHaveBeenCalledWith("doc-abc", undefined);
 
             // Verify annotation was created
             const annotations = await prisma.annotation.findMany({

--- a/src/__tests__/google-docs-exporter.test.ts
+++ b/src/__tests__/google-docs-exporter.test.ts
@@ -38,11 +38,12 @@ describe("GoogleDocsExporter", () => {
 
             expect(result.googleDocId).toBe("new-doc-id");
             expect(result.googleDocUrl).toContain("new-doc-id");
-            expect(GoogleDocsApi.createDocument).toHaveBeenCalledWith("My Novel - Reader Copy");
+            expect(GoogleDocsApi.createDocument).toHaveBeenCalledWith("My Novel - Reader Copy", undefined);
             expect(exportManuscript).toHaveBeenCalledWith(project.id, { includeBeats: false });
             expect(GoogleDocsApi.replaceContent).toHaveBeenCalledWith(
                 "new-doc-id",
-                "Chapter 1\n\nOnce upon a time..."
+                "Chapter 1\n\nOnce upon a time...",
+                undefined
             );
         });
     });
@@ -60,7 +61,8 @@ describe("GoogleDocsExporter", () => {
 
             expect(result.googleDocId).toBe("doc-internal");
             expect(GoogleDocsApi.createDocument).toHaveBeenCalledWith(
-                "My Novel - Internal Draft (with Notes)"
+                "My Novel - Internal Draft (with Notes)",
+                undefined
             );
             expect(exportStoryBible).toHaveBeenCalledWith(project.id);
             expect(exportManuscript).toHaveBeenCalledWith(project.id, { includeBeats: true });
@@ -80,7 +82,7 @@ describe("GoogleDocsExporter", () => {
             const result = await GoogleDocsExporter.exportToGoogleDocs(universe.id, "UNIVERSE");
 
             expect(result.googleDocId).toBe("doc-universe");
-            expect(GoogleDocsApi.createDocument).toHaveBeenCalledWith("My Universe - World Bible");
+            expect(GoogleDocsApi.createDocument).toHaveBeenCalledWith("My Universe - World Bible", undefined);
             expect(exportUniverse).toHaveBeenCalledWith(universe.id);
         });
     });

--- a/src/app/api/auth/google-docs/callback/route.ts
+++ b/src/app/api/auth/google-docs/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GoogleAuthController } from "@/lib/controllers/google-auth";
+import { getCurrentUserId } from "@/lib/api-auth";
 import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
 
@@ -25,7 +26,8 @@ export async function GET(request: NextRequest) {
 
     try {
         const redirectUri = `${origin}/api/auth/google-docs/callback`;
-        await GoogleAuthController.handleCallback(code, redirectUri);
+        const userId = getCurrentUserId(request);
+        await GoogleAuthController.handleCallback(code, redirectUri, userId);
 
         const response = NextResponse.redirect(new URL("/settings?google_docs=connected", origin));
         response.cookies.set("google_docs_oauth_state", "", {

--- a/src/app/api/integrations/google-docs/export/route.ts
+++ b/src/app/api/integrations/google-docs/export/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
         const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get('x-user-email'));
         if (!access.authorized) return access.response;
 
-        const result = await GoogleDocsExporter.exportToGoogleDocs(projectId, exportMode as ExportMode);
+        const result = await GoogleDocsExporter.exportToGoogleDocs(projectId, exportMode as ExportMode, userId);
         return NextResponse.json(result);
     } catch (error) {
         logger.error('POST /api/integrations/google-docs/export error', error);

--- a/src/app/api/integrations/google-docs/route.ts
+++ b/src/app/api/integrations/google-docs/route.ts
@@ -13,19 +13,20 @@ export async function GET(request: NextRequest) {
         const { searchParams } = new URL(request.url);
         const projectId = searchParams.get('projectId');
 
+        const userId = getCurrentUserId(request);
+
         // If no projectId, return connection status only (used by global settings page)
         if (!projectId) {
-            const status = await GoogleAuthController.getStatus();
+            const status = await GoogleAuthController.getStatus(userId);
             return NextResponse.json({ connected: status.connected });
         }
 
-        const userId = getCurrentUserId(request);
         const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get('x-user-email'));
         if (!access.authorized) return access.response;
 
         const [exports, status] = await Promise.all([
             GoogleDocsCommentSync.getExportInfo(projectId),
-            GoogleAuthController.getStatus(),
+            GoogleAuthController.getStatus(userId),
         ]);
         return NextResponse.json({ exports, connected: status.connected });
     } catch (error) {
@@ -36,11 +37,12 @@ export async function GET(request: NextRequest) {
 
 /**
  * DELETE /api/integrations/google-docs
- * Disconnects Google Docs by removing the stored credential.
+ * Disconnects Google Docs by removing the stored credential for the current user.
  */
-export async function DELETE() {
+export async function DELETE(request: NextRequest) {
     try {
-        await GoogleAuthController.disconnect();
+        const userId = getCurrentUserId(request);
+        await GoogleAuthController.disconnect(userId);
         return NextResponse.json({ disconnected: true });
     } catch (error) {
         logger.error('DELETE /api/integrations/google-docs error', error);
@@ -66,7 +68,7 @@ export async function POST(request: NextRequest) {
         const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get('x-user-email'));
         if (!access.authorized) return access.response;
 
-        const result = await GoogleDocsCommentSync.syncComments(projectId);
+        const result = await GoogleDocsCommentSync.syncComments(projectId, userId);
         return NextResponse.json(result);
     } catch (error) {
         logger.error('POST /api/integrations/google-docs error', error);

--- a/src/lib/controllers/google-auth.ts
+++ b/src/lib/controllers/google-auth.ts
@@ -25,15 +25,17 @@ export class GoogleAuthController {
         });
     }
 
-    static async handleCallback(code: string, redirectUri?: string) {
+    static async handleCallback(code: string, redirectUri?: string, userId?: string | null) {
         const client = this.getClient(redirectUri ?? env.GOOGLE_REDIRECT_URI);
         const { tokens } = await client.getToken(code);
+        const resolvedUserId = userId ?? 'local';
 
-        // In local single-user mode, we replace any existing credentials
-        await prisma.googleCredential.deleteMany();
+        // Replace existing credentials for this user only
+        await prisma.googleCredential.deleteMany({ where: { userId: resolvedUserId } });
 
         await prisma.googleCredential.create({
             data: {
+                userId: resolvedUserId,
                 accessToken: encrypt(tokens.access_token!),
                 refreshToken: encrypt(tokens.refresh_token!), // This might be undefined if not first time/consent
                 expiresAt: new Date(tokens.expiry_date!),
@@ -44,8 +46,9 @@ export class GoogleAuthController {
         return tokens;
     }
 
-    static async getValidClient(): Promise<OAuth2Client | null> {
-        const cred = await prisma.googleCredential.findFirst();
+    static async getValidClient(userId?: string | null): Promise<OAuth2Client | null> {
+        const resolvedUserId = userId ?? 'local';
+        const cred = await prisma.googleCredential.findUnique({ where: { userId: resolvedUserId } });
         if (!cred) return null;
 
         const client = this.getClient(undefined);
@@ -74,8 +77,9 @@ export class GoogleAuthController {
         return client;
     }
 
-    static async getStatus() {
-        const cred = await prisma.googleCredential.findFirst();
+    static async getStatus(userId?: string | null) {
+        const resolvedUserId = userId ?? 'local';
+        const cred = await prisma.googleCredential.findUnique({ where: { userId: resolvedUserId } });
         if (!cred) return { connected: false };
 
         // Check if token is expired, though client handles refresh
@@ -87,8 +91,8 @@ export class GoogleAuthController {
         };
     }
 
-    static async disconnect() {
-        // Optionally revoke token here
-        await prisma.googleCredential.deleteMany();
+    static async disconnect(userId?: string | null) {
+        const resolvedUserId = userId ?? 'local';
+        await prisma.googleCredential.deleteMany({ where: { userId: resolvedUserId } });
     }
 }

--- a/src/lib/export/google-docs-comment-sync.ts
+++ b/src/lib/export/google-docs-comment-sync.ts
@@ -64,7 +64,7 @@ export class GoogleDocsCommentSync {
      * Skips comments already imported (tracked via Annotation.externalId).
      * Returns a summary of what happened.
      */
-    static async syncComments(projectId: string): Promise<CommentSyncResult> {
+    static async syncComments(projectId: string, userId?: string | null): Promise<CommentSyncResult> {
         const result: CommentSyncResult = {
             imported: 0,
             skipped: 0,
@@ -87,7 +87,7 @@ export class GoogleDocsCommentSync {
 
         let comments;
         try {
-            comments = await GoogleDocsApi.fetchComments(exportRecord.googleDocId);
+            comments = await GoogleDocsApi.fetchComments(exportRecord.googleDocId, userId);
         } catch (error) {
             throw new Error(`Failed to fetch comments from Google Docs: ${error instanceof Error ? error.message : error}`);
         }

--- a/src/lib/export/google-docs-exporter.ts
+++ b/src/lib/export/google-docs-exporter.ts
@@ -9,7 +9,8 @@ export class GoogleDocsExporter {
 
     static async exportToGoogleDocs(
         entityId: string,
-        mode: ExportMode
+        mode: ExportMode,
+        userId?: string | null
     ): Promise<{ googleDocId: string; googleDocUrl: string }> {
 
         // 1. Resolve Project/Universe
@@ -43,7 +44,7 @@ export class GoogleDocsExporter {
         // 3. Create Doc if not exists
         if (!googleDocId) {
             const docTitle = `${title} - ${this.getModeLabel(mode)}`;
-            googleDocId = await GoogleDocsApi.createDocument(docTitle);
+            googleDocId = await GoogleDocsApi.createDocument(docTitle, userId);
 
             // Save mapping
             exportRecord = await prisma.googleDocExport.create({
@@ -83,7 +84,7 @@ export class GoogleDocsExporter {
 
         // 5. Update Doc Content
         try {
-            await GoogleDocsApi.replaceContent(googleDocId, content);
+            await GoogleDocsApi.replaceContent(googleDocId, content, userId);
         } catch (error: unknown) {
             // Handle 404 (doc deleted externally) -> remove mapping and retry?
             // For now, just throw.

--- a/src/lib/google-api.ts
+++ b/src/lib/google-api.ts
@@ -143,8 +143,8 @@ function buildDocsRequests(markdown: string, insertIndex: number): { plainText: 
 
 export class GoogleDocsApi {
 
-    static async createDocument(title: string): Promise<string> {
-        const auth = await GoogleAuthController.getValidClient();
+    static async createDocument(title: string, userId?: string | null): Promise<string> {
+        const auth = await GoogleAuthController.getValidClient(userId);
         if (!auth) throw new Error("Not authenticated");
 
         const docs = google.docs({ version: 'v1', auth });
@@ -155,8 +155,8 @@ export class GoogleDocsApi {
         return res.data.documentId!;
     }
 
-    static async getDocument(documentId: string): Promise<docs_v1.Schema$Document> {
-        const auth = await GoogleAuthController.getValidClient();
+    static async getDocument(documentId: string, userId?: string | null): Promise<docs_v1.Schema$Document> {
+        const auth = await GoogleAuthController.getValidClient(userId);
         if (!auth) throw new Error("Not authenticated");
 
         const docs = google.docs({ version: 'v1', auth });
@@ -164,8 +164,8 @@ export class GoogleDocsApi {
         return res.data;
     }
 
-    static async updateDocument(documentId: string, requests: docs_v1.Schema$Request[]) {
-        const auth = await GoogleAuthController.getValidClient();
+    static async updateDocument(documentId: string, requests: docs_v1.Schema$Request[], userId?: string | null) {
+        const auth = await GoogleAuthController.getValidClient(userId);
         if (!auth) throw new Error("Not authenticated");
 
         const docs = google.docs({ version: 'v1', auth });
@@ -175,8 +175,8 @@ export class GoogleDocsApi {
         });
     }
 
-    static async fetchComments(documentId: string): Promise<drive_v3.Schema$Comment[]> {
-        const auth = await GoogleAuthController.getValidClient();
+    static async fetchComments(documentId: string, userId?: string | null): Promise<drive_v3.Schema$Comment[]> {
+        const auth = await GoogleAuthController.getValidClient(userId);
         if (!auth) throw new Error("Not authenticated");
 
         const drive = google.drive({ version: 'v3', auth });
@@ -197,8 +197,8 @@ export class GoogleDocsApi {
         return allComments;
     }
 
-    static async replaceContent(documentId: string, markdown: string) {
-        const doc = await this.getDocument(documentId);
+    static async replaceContent(documentId: string, markdown: string, userId?: string | null) {
+        const doc = await this.getDocument(documentId, userId);
         const endIndex = doc.body?.content?.[doc.body.content.length - 1]?.endIndex || 1;
 
         const requests: docs_v1.Schema$Request[] = [];
@@ -226,7 +226,7 @@ export class GoogleDocsApi {
         }
 
         if (requests.length > 0) {
-            await this.updateDocument(documentId, requests);
+            await this.updateDocument(documentId, requests, userId);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes **HIGH severity security bug** reported in issue #429.

`GoogleAuthController.deleteMany()` was called without a `where` clause in both `handleCallback()` and `disconnect()`. In a multi-user deployment, any user connecting Google Docs would delete **all** users' credentials.

### Changes

- **`prisma/schema.prisma`**: Added `userId String @unique` to `GoogleCredential`, mirroring the `HashnodeCredential` convention (`"local"` for single-user/dev mode)
- **Migration** (`20260425_add_user_id_to_google_credential`): `ALTER TABLE` adds `userId` column with `DEFAULT 'local'` — existing rows safe, no data loss
- **`google-auth.ts`**: All 5 Prisma operations now scoped to `resolvedUserId` (`userId ?? 'local'`); method signatures updated with optional `userId?: string | null`
- **`google-api.ts`**: `GoogleDocsApi` static methods accept and thread optional `userId` down to `getValidClient`
- **`google-docs-exporter.ts`** + **`google-docs-comment-sync.ts`**: Accept and forward `userId` to `GoogleDocsApi`
- **API routes** (callback, integrations GET/DELETE/POST, export POST): Extract `userId` via `getCurrentUserId(request)` and pass downstream
- **Tests**: Updated to pass explicit `userId`, added cross-user isolation tests that directly assert the bug is fixed (User A disconnect cannot touch User B credentials)

### Backward compatibility

`userId` defaults to `'local'` everywhere when null/undefined (API_TOKEN mode, MCP tools, ADK tools). No breaking change for existing single-user deployments.

Closes #429

## Test plan

- [ ] Run `npx vitest run src/__tests__/google-auth-controller.test.ts` — all tests pass including new isolation tests
- [ ] Run `prisma migrate dev` on a dev DB to verify migration applies cleanly
- [ ] In a multi-user environment: connect Google Docs as User A, then disconnect as User B — verify User A credentials are untouched