### PR TITLE
feat: add chat threads UI with create/rename/delete per project

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -435,17 +435,78 @@ Get all context needed for focus mode.
 
 ---
 
-## AI Chat
+## Chat Threads
 
-### `POST /api/chat`
-Stream an AI chat response for a project.
+Conversations are named thread containers scoped to a project. Each project has one or more threads; `POST /api/chat` messages are always sent to a specific thread via `conversationId`.
+
+### `GET /api/conversations`
+List all conversation threads for a project, ordered by most recently updated.
+
+**Query params**: `projectId=<id>` (required)
+
+**Response**: `{ conversations: [{ id, title, updatedAt }] }`
+
+**Errors**: `400` if `projectId` missing; `403` if not authorized.
+
+---
+
+### `POST /api/conversations`
+Create a new conversation thread.
 
 **Body**:
 ```json
 {
   "projectId": "string",
+  "title": "string (optional — defaults to \"New chat\")"
+}
+```
+
+**Response** (`201`): `{ id, title, projectId, createdAt, updatedAt }`
+
+**Errors**: `400` if `projectId` missing; `403` if not authorized.
+
+---
+
+### `PATCH /api/conversations/[id]`
+Rename a conversation thread.
+
+**Body**: `{ "title": "string" }`
+
+**Response**: `{ id, title, updatedAt }`
+
+**Errors**: `400` if title missing; `404` if conversation not found; `403` if not authorized.
+
+---
+
+### `DELETE /api/conversations/[id]`
+Delete a conversation thread and cascade-delete all its messages.
+
+**Response**: `{ success: true }`
+
+**Errors**: `404` if conversation not found; `403` if not authorized.
+
+---
+
+## AI Chat
+
+### `GET /api/chat`
+Load conversation metadata and message history.
+
+**Query params**: `conversationId=<id>` — OR — `projectId=<id>` (returns or creates the default conversation for the project)
+
+**Response**: `{ conversation: { id, title, projectId, ... }, messages: [...] }`
+
+---
+
+### `POST /api/chat`
+Stream an AI chat response within a conversation thread.
+
+**Body**:
+```json
+{
+  "conversationId": "string",
   "message": "string",
-  "sceneId": "string (optional — injects scene content into context)"
+  "sceneContext": "string (optional — injects scene content into context)"
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,7 @@ src/
 │   │   ├── annotations/        # Scene annotations (inline comments)
 │   │   ├── auth/               # Authentication (login, Google OAuth)
 │   │   ├── chat/               # Streaming AI chat
+│   │   ├── conversations/      # Chat thread CRUD
 │   │   ├── feedback/           # GitHub issue feedback
 │   │   ├── focus/              # Focus mode scene context
 │   │   ├── health/             # Health check
@@ -93,7 +94,8 @@ Project (1) ──────────────────┬─── (
                               │         └─── (N) ContentVersion (versioned content)
                               │         └─── (N) Annotation (inline comments)
                               └─── (N) StoryObject (CHARACTER | LOCATION | PLOTLINE | WORLD_ELEMENT | NOTE)
-                              └─── (N) ChatMessage (AI chat history)
+                              └─── (N) Conversation (named chat thread)
+                                        └─── (N) ChatMessage (AI chat history)
 
 Universe (1) ─────────────────┬─── (N) WorldObject (CHARACTER | LOCATION | WORLD_ELEMENT)
                               │         └─── (N) WorldObjectTimelineEntry

--- a/src/__tests__/chat-route.test.ts
+++ b/src/__tests__/chat-route.test.ts
@@ -36,6 +36,8 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import { getCurrentUserId, verifyProjectWriteAccess } from "@/lib/api-auth";
+import { runSimpleCompletion } from "@/lib/ai/adk-agent";
+import { logger } from "@/lib/logger";
 import { NextRequest } from "next/server";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -120,6 +122,99 @@ describe("POST /api/chat", () => {
     const userMsg = messages.find((m) => m.role === "user");
     expect(userMsg).toBeDefined();
     expect(userMsg!.content).not.toContain("<script>");
+  });
+});
+
+describe("POST /api/chat — auto-title", () => {
+  let projectId: string;
+  let conversationId: string;
+
+  async function drainStream(res: Response) {
+    const reader = res.body!.getReader();
+    while (!(await reader.read()).done) {}
+    // Allow the fire-and-forget IIFE microtasks to settle.
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(verifyProjectWriteAccess).mockResolvedValue({ authorized: true } as never);
+    vi.mocked(runSimpleCompletion).mockResolvedValue("Generated title");
+
+    const project = await testPrisma.project.create({
+      data: { title: "Auto-title Test", author: "Author" },
+    });
+    projectId = project.id;
+    const conversation = await testPrisma.conversation.create({
+      data: { projectId, title: "New chat" },
+    });
+    conversationId = conversation.id;
+  });
+
+  it("auto-titles the conversation on first assistant reply", async () => {
+    const { POST } = await import("@/app/api/chat/route");
+    const res = await POST(makePostRequest({ conversationId, message: "Help me outline" }));
+    await drainStream(res);
+
+    expect(runSimpleCompletion).toHaveBeenCalledTimes(1);
+    const updated = await testPrisma.conversation.findUnique({ where: { id: conversationId } });
+    expect(updated!.title).toBe("Generated title");
+  });
+
+  it("does NOT auto-title when conversation already has a custom title", async () => {
+    await testPrisma.conversation.update({
+      where: { id: conversationId },
+      data: { title: "User-renamed thread" },
+    });
+
+    const { POST } = await import("@/app/api/chat/route");
+    const res = await POST(makePostRequest({ conversationId, message: "Another message" }));
+    await drainStream(res);
+
+    expect(runSimpleCompletion).not.toHaveBeenCalled();
+    const after = await testPrisma.conversation.findUnique({ where: { id: conversationId } });
+    expect(after!.title).toBe("User-renamed thread");
+  });
+
+  it("does NOT auto-title on the second assistant reply", async () => {
+    await testPrisma.chatMessage.create({
+      data: { conversationId, role: "assistant", content: "earlier reply" },
+    });
+
+    const { POST } = await import("@/app/api/chat/route");
+    const res = await POST(makePostRequest({ conversationId, message: "Follow-up" }));
+    await drainStream(res);
+
+    expect(runSimpleCompletion).not.toHaveBeenCalled();
+  });
+
+  it("strips wrapping quotes and clamps to 100 chars", async () => {
+    vi.mocked(runSimpleCompletion).mockResolvedValueOnce(`"${"x".repeat(150)}"`);
+
+    const { POST } = await import("@/app/api/chat/route");
+    const res = await POST(makePostRequest({ conversationId, message: "Long titler" }));
+    await drainStream(res);
+
+    const updated = await testPrisma.conversation.findUnique({ where: { id: conversationId } });
+    expect(updated!.title).toHaveLength(100);
+    expect(updated!.title.startsWith('"')).toBe(false);
+    expect(updated!.title.endsWith('"')).toBe(false);
+  });
+
+  it("leaves title unchanged and logs when runSimpleCompletion rejects", async () => {
+    vi.mocked(runSimpleCompletion).mockRejectedValueOnce(new Error("rate limited"));
+
+    const { POST } = await import("@/app/api/chat/route");
+    const res = await POST(makePostRequest({ conversationId, message: "Will fail to title" }));
+    await drainStream(res);
+
+    const updated = await testPrisma.conversation.findUnique({ where: { id: conversationId } });
+    expect(updated!.title).toBe("New chat");
+    expect(vi.mocked(logger).error).toHaveBeenCalledWith(
+      "autoTitle failed",
+      expect.objectContaining({ conversationId }),
+    );
   });
 });
 

--- a/src/__tests__/chat-route.test.ts
+++ b/src/__tests__/chat-route.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/ai/adk-agent", () => ({
     finalContent: "Annie says hello!",
     toolLog: [],
   })),
+  runSimpleCompletion: vi.fn(async () => "Draft and Revision"),
 }));
 
 vi.mock("@/lib/ai/settings", () => ({

--- a/src/__tests__/conversations-route.test.ts
+++ b/src/__tests__/conversations-route.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { testPrisma } from "./setup";
+
+vi.mock("@/lib/api-auth", () => ({
+  getCurrentUserId: vi.fn(() => null),
+  verifyProjectWriteAccess: vi.fn(async () => ({ authorized: true })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { getCurrentUserId, verifyProjectWriteAccess } from "@/lib/api-auth";
+import { NextRequest } from "next/server";
+
+function makeGetRequest(projectId?: string): NextRequest {
+  const url = projectId
+    ? `http://localhost/api/conversations?projectId=${projectId}`
+    : "http://localhost/api/conversations";
+  return new NextRequest(url, { method: "GET" });
+}
+
+function makePostRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/conversations", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makePatchRequest(id: string, body: Record<string, unknown>): NextRequest {
+  return new NextRequest(`http://localhost/api/conversations/${id}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteRequest(id: string): NextRequest {
+  return new NextRequest(`http://localhost/api/conversations/${id}`, {
+    method: "DELETE",
+  });
+}
+
+describe("GET /api/conversations", () => {
+  let projectId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(verifyProjectWriteAccess).mockResolvedValue({ authorized: true } as never);
+
+    const project = await testPrisma.project.create({
+      data: { title: "Test Novel", author: "Author" },
+    });
+    projectId = project.id;
+  });
+
+  it("returns 400 without projectId", async () => {
+    const { GET } = await import("@/app/api/conversations/route");
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns conversations ordered by updatedAt desc", async () => {
+    await testPrisma.conversation.create({
+      data: { projectId, title: "Older chat" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    await testPrisma.conversation.create({
+      data: { projectId, title: "Newer chat" },
+    });
+
+    const { GET } = await import("@/app/api/conversations/route");
+    const res = await GET(makeGetRequest(projectId));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.conversations).toHaveLength(2);
+    expect(body.conversations[0].title).toBe("Newer chat");
+    expect(body.conversations[1].title).toBe("Older chat");
+  });
+
+  it("returns 403 for forbidden project", async () => {
+    vi.mocked(verifyProjectWriteAccess).mockResolvedValue({
+      authorized: false,
+      response: new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    } as never);
+
+    const { GET } = await import("@/app/api/conversations/route");
+    const res = await GET(makeGetRequest(projectId));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/conversations", () => {
+  let projectId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(verifyProjectWriteAccess).mockResolvedValue({ authorized: true } as never);
+
+    const project = await testPrisma.project.create({
+      data: { title: "Test Novel", author: "Author" },
+    });
+    projectId = project.id;
+  });
+
+  it("returns 400 without projectId", async () => {
+    const { POST } = await import("@/app/api/conversations/route");
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates conversation with default title", async () => {
+    const { POST } = await import("@/app/api/conversations/route");
+    const res = await POST(makePostRequest({ projectId }));
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.title).toBe("New chat");
+    expect(body.id).toBeDefined();
+  });
+
+  it("creates conversation with supplied title", async () => {
+    const { POST } = await import("@/app/api/conversations/route");
+    const res = await POST(makePostRequest({ projectId, title: "My Thread" }));
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.title).toBe("My Thread");
+  });
+});
+
+describe("PATCH /api/conversations/[id]", () => {
+  let conversationId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(verifyProjectWriteAccess).mockResolvedValue({ authorized: true } as never);
+
+    const project = await testPrisma.project.create({
+      data: { title: "Test Novel", author: "Author" },
+    });
+    projectId = project.id;
+    const conversation = await testPrisma.conversation.create({
+      data: { projectId, title: "Original Title" },
+    });
+    conversationId = conversation.id;
+  });
+
+  it("returns 400 without title", async () => {
+    const { PATCH } = await import("@/app/api/conversations/[id]/route");
+    const req = makePatchRequest(conversationId, {});
+    const res = await PATCH(req, { params: Promise.resolve({ id: conversationId }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown id", async () => {
+    const { PATCH } = await import("@/app/api/conversations/[id]/route");
+    const req = makePatchRequest("nonexistent", { title: "New Title" });
+    const res = await PATCH(req, { params: Promise.resolve({ id: "nonexistent" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("updates conversation title", async () => {
+    const { PATCH } = await import("@/app/api/conversations/[id]/route");
+    const req = makePatchRequest(conversationId, { title: "Renamed Thread" });
+    const res = await PATCH(req, { params: Promise.resolve({ id: conversationId }) });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.title).toBe("Renamed Thread");
+  });
+});
+
+describe("DELETE /api/conversations/[id]", () => {
+  let conversationId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(verifyProjectWriteAccess).mockResolvedValue({ authorized: true } as never);
+
+    const project = await testPrisma.project.create({
+      data: { title: "Test Novel", author: "Author" },
+    });
+    projectId = project.id;
+    const conversation = await testPrisma.conversation.create({
+      data: { projectId, title: "To Delete" },
+    });
+    conversationId = conversation.id;
+  });
+
+  it("returns 404 for unknown id", async () => {
+    const { DELETE } = await import("@/app/api/conversations/[id]/route");
+    const req = makeDeleteRequest("nonexistent");
+    const res = await DELETE(req, { params: Promise.resolve({ id: "nonexistent" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("deletes conversation and cascades messages", async () => {
+    await testPrisma.chatMessage.create({
+      data: { conversationId, role: "user", content: "Hello" },
+    });
+    await testPrisma.chatMessage.create({
+      data: { conversationId, role: "assistant", content: "Hi there" },
+    });
+
+    const { DELETE } = await import("@/app/api/conversations/[id]/route");
+    const req = makeDeleteRequest(conversationId);
+    const res = await DELETE(req, { params: Promise.resolve({ id: conversationId }) });
+    expect(res.status).toBe(200);
+
+    const remaining = await testPrisma.conversation.findUnique({ where: { id: conversationId } });
+    expect(remaining).toBeNull();
+
+    const messages = await testPrisma.chatMessage.findMany({ where: { conversationId } });
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/src/__tests__/conversations-route.test.ts
+++ b/src/__tests__/conversations-route.test.ts
@@ -134,6 +134,28 @@ describe("POST /api/conversations", () => {
     const body = await res.json();
     expect(body.title).toBe("My Thread");
   });
+
+  it("returns 403 for forbidden project", async () => {
+    vi.mocked(verifyProjectWriteAccess).mockResolvedValue({
+      authorized: false,
+      response: new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    } as never);
+
+    const { POST } = await import("@/app/api/conversations/route");
+    const res = await POST(makePostRequest({ projectId }));
+    expect(res.status).toBe(403);
+  });
+
+  it("sanitizes title before saving", async () => {
+    const { POST } = await import("@/app/api/conversations/route");
+    const res = await POST(makePostRequest({ projectId, title: "<script>alert('xss')</script>Thread" }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.title).not.toContain("<script>");
+  });
 });
 
 describe("PATCH /api/conversations/[id]", () => {
@@ -177,6 +199,30 @@ describe("PATCH /api/conversations/[id]", () => {
 
     const body = await res.json();
     expect(body.title).toBe("Renamed Thread");
+  });
+
+  it("returns 403 for forbidden project", async () => {
+    vi.mocked(verifyProjectWriteAccess).mockResolvedValue({
+      authorized: false,
+      response: new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    } as never);
+
+    const { PATCH } = await import("@/app/api/conversations/[id]/route");
+    const req = makePatchRequest(conversationId, { title: "Attempt" });
+    const res = await PATCH(req, { params: Promise.resolve({ id: conversationId }) });
+    expect(res.status).toBe(403);
+  });
+
+  it("sanitizes title before saving", async () => {
+    const { PATCH } = await import("@/app/api/conversations/[id]/route");
+    const req = makePatchRequest(conversationId, { title: "<script>alert('xss')</script>Renamed" });
+    const res = await PATCH(req, { params: Promise.resolve({ id: conversationId }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.title).not.toContain("<script>");
   });
 });
 
@@ -224,5 +270,20 @@ describe("DELETE /api/conversations/[id]", () => {
 
     const messages = await testPrisma.chatMessage.findMany({ where: { conversationId } });
     expect(messages).toHaveLength(0);
+  });
+
+  it("returns 403 for forbidden project", async () => {
+    vi.mocked(verifyProjectWriteAccess).mockResolvedValue({
+      authorized: false,
+      response: new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    } as never);
+
+    const { DELETE } = await import("@/app/api/conversations/[id]/route");
+    const req = makeDeleteRequest(conversationId);
+    const res = await DELETE(req, { params: Promise.resolve({ id: conversationId }) });
+    expect(res.status).toBe(403);
   });
 });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -4,7 +4,7 @@ import { getAiConfig, getAiPreferences, buildPreferenceInstructions, getCompress
 import { getCurrentUserId, verifyProjectWriteAccess } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 import { sanitizeInput } from "@/lib/sanitize-server";
-import { runChatAgent } from "@/lib/ai/adk-agent";
+import { runChatAgent, runSimpleCompletion } from "@/lib/ai/adk-agent";
 import { compressConversation } from "@/lib/ai/chat-compression";
 
 async function buildSystemPrompt(projectId: string): Promise<string> {
@@ -302,6 +302,42 @@ export async function POST(request: NextRequest) {
             await prisma.chatMessage.create({
               data: { conversationId, role: "assistant", content: finalContent },
             });
+          }
+
+          // Auto-title: fire-and-forget on first assistant reply
+          if (conversation.title === "New chat" && finalContent) {
+            (async () => {
+              const assistantCount = await prisma.chatMessage.count({
+                where: { conversationId, role: "assistant" },
+              });
+              if (assistantCount === 1) {
+                const firstUserMsg = await prisma.chatMessage.findFirst({
+                  where: { conversationId, role: "user" },
+                  orderBy: { createdAt: "asc" },
+                  select: { content: true },
+                });
+                if (firstUserMsg) {
+                  const title = await runSimpleCompletion({
+                    systemPrompt:
+                      "Generate a short title (3–6 words) for a writing coach conversation. Return only the title, no quotes, no punctuation at the end.",
+                    userMessage: firstUserMsg.content.slice(0, 500),
+                    aiConfig,
+                    maxTokens: 20,
+                    temperature: 0.3,
+                  });
+                  const cleanTitle = title
+                    .replace(/^["']|["']$/g, "")
+                    .trim()
+                    .slice(0, 100);
+                  if (cleanTitle) {
+                    await prisma.conversation.update({
+                      where: { id: conversationId },
+                      data: { title: cleanTitle },
+                    });
+                  }
+                }
+              }
+            })().catch((err) => logger.error("autoTitle failed", err));
           }
 
           controller.enqueue(encoder.encode("data: [DONE]\n\n"));

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -6,6 +6,7 @@ import { logger } from "@/lib/logger";
 import { sanitizeInput } from "@/lib/sanitize-server";
 import { runChatAgent, runSimpleCompletion } from "@/lib/ai/adk-agent";
 import { compressConversation } from "@/lib/ai/chat-compression";
+import type { AiProviderConfig } from "@/lib/ai/settings";
 
 async function buildSystemPrompt(projectId: string): Promise<string> {
   const project = await prisma.project.findUnique({
@@ -82,6 +83,36 @@ ${objectsSummary || "(No characters/locations yet)"}
 - Keep responses concise unless asked to elaborate
 - Use the story's existing characters and locations — don't invent new ones unless asked
 - You have tools available to read and modify the project. Use them when the user asks you to look up details, make changes, or explore the story structure.`;
+}
+
+async function autoTitleConversation(conversationId: string, aiConfig: AiProviderConfig): Promise<void> {
+  const assistantCount = await prisma.chatMessage.count({
+    where: { conversationId, role: "assistant" },
+  });
+  if (assistantCount !== 1) return;
+
+  const firstUserMsg = await prisma.chatMessage.findFirst({
+    where: { conversationId, role: "user" },
+    orderBy: { createdAt: "asc" },
+    select: { content: true },
+  });
+  if (!firstUserMsg) return;
+
+  const title = await runSimpleCompletion({
+    systemPrompt:
+      "Generate a short title (3–6 words) for a writing coach conversation. Return only the title, no quotes, no punctuation at the end.",
+    userMessage: firstUserMsg.content.slice(0, 500),
+    aiConfig,
+    maxTokens: 20,
+    temperature: 0.3,
+  });
+  const cleanTitle = title.replace(/^["']|["']$/g, "").trim().slice(0, 100);
+  if (cleanTitle) {
+    await prisma.conversation.update({
+      where: { id: conversationId },
+      data: { title: cleanTitle },
+    });
+  }
 }
 
 // GET /api/chat?conversationId=X or ?projectId=X — load conversation + chat history
@@ -189,21 +220,19 @@ export async function POST(request: NextRequest) {
     });
 
     // Load all messages since last compaction
+    let afterDate: Date | undefined;
+    if (conversation.summarizedThroughMessageId) {
+      const pivot = await prisma.chatMessage.findUnique({
+        where: { id: conversation.summarizedThroughMessageId },
+        select: { createdAt: true },
+      });
+      afterDate = pivot?.createdAt ?? new Date(0);
+    }
+
     const allMessages = await prisma.chatMessage.findMany({
       where: {
         conversationId,
-        ...(conversation.summarizedThroughMessageId
-          ? {
-              createdAt: {
-                gt: (
-                  await prisma.chatMessage.findUnique({
-                    where: { id: conversation.summarizedThroughMessageId },
-                    select: { createdAt: true },
-                  })
-                )?.createdAt ?? new Date(0),
-              },
-            }
-          : {}),
+        ...(afterDate ? { createdAt: { gt: afterDate } } : {}),
       },
       orderBy: { createdAt: "asc" },
     });
@@ -306,38 +335,9 @@ export async function POST(request: NextRequest) {
 
           // Auto-title: fire-and-forget on first assistant reply
           if (conversation.title === "New chat" && finalContent) {
-            (async () => {
-              const assistantCount = await prisma.chatMessage.count({
-                where: { conversationId, role: "assistant" },
-              });
-              if (assistantCount === 1) {
-                const firstUserMsg = await prisma.chatMessage.findFirst({
-                  where: { conversationId, role: "user" },
-                  orderBy: { createdAt: "asc" },
-                  select: { content: true },
-                });
-                if (firstUserMsg) {
-                  const title = await runSimpleCompletion({
-                    systemPrompt:
-                      "Generate a short title (3–6 words) for a writing coach conversation. Return only the title, no quotes, no punctuation at the end.",
-                    userMessage: firstUserMsg.content.slice(0, 500),
-                    aiConfig,
-                    maxTokens: 20,
-                    temperature: 0.3,
-                  });
-                  const cleanTitle = title
-                    .replace(/^["']|["']$/g, "")
-                    .trim()
-                    .slice(0, 100);
-                  if (cleanTitle) {
-                    await prisma.conversation.update({
-                      where: { id: conversationId },
-                      data: { title: cleanTitle },
-                    });
-                  }
-                }
-              }
-            })().catch((err) => logger.error("autoTitle failed", { conversationId, error: err }));
+            autoTitleConversation(conversationId, aiConfig).catch(
+              (err) => logger.error("autoTitle failed", { conversationId, error: err })
+            );
           }
 
           controller.enqueue(encoder.encode("data: [DONE]\n\n"));

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -337,7 +337,7 @@ export async function POST(request: NextRequest) {
                   }
                 }
               }
-            })().catch((err) => logger.error("autoTitle failed", err));
+            })().catch((err) => logger.error("autoTitle failed", { conversationId, error: err }));
           }
 
           controller.enqueue(encoder.encode("data: [DONE]\n\n"));

--- a/src/app/api/conversations/[id]/route.ts
+++ b/src/app/api/conversations/[id]/route.ts
@@ -9,8 +9,9 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  let id: string | undefined;
   try {
-    const { id } = await params;
+    ({ id } = await params);
     const body = await request.json();
     const parsed = ConversationUpdateSchema.safeParse(body);
     if (!parsed.success) {
@@ -34,7 +35,7 @@ export async function PATCH(
 
     return NextResponse.json(updated);
   } catch (error) {
-    logger.error("PATCH /api/conversations/[id] error", error);
+    logger.error("PATCH /api/conversations/[id] error", { id, error });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
@@ -43,8 +44,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  let id: string | undefined;
   try {
-    const { id } = await params;
+    ({ id } = await params);
     const conversation = await prisma.conversation.findUnique({ where: { id } });
     if (!conversation) {
       return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
@@ -57,7 +59,7 @@ export async function DELETE(
     await prisma.conversation.delete({ where: { id } });
     return NextResponse.json({ success: true });
   } catch (error) {
-    logger.error("DELETE /api/conversations/[id] error", error);
+    logger.error("DELETE /api/conversations/[id] error", { id, error });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/app/api/conversations/[id]/route.ts
+++ b/src/app/api/conversations/[id]/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getCurrentUserId, verifyProjectWriteAccess } from "@/lib/api-auth";
+import { logger } from "@/lib/logger";
+import { sanitizeInput } from "@/lib/sanitize-server";
+import { ConversationUpdateSchema } from "@/schemas/conversations";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = ConversationUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.errors[0].message }, { status: 400 });
+    }
+
+    const conversation = await prisma.conversation.findUnique({ where: { id } });
+    if (!conversation) {
+      return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectWriteAccess(conversation.projectId, userId, request.headers.get("x-user-email"));
+    if (!access.authorized) return access.response;
+
+    const updated = await prisma.conversation.update({
+      where: { id },
+      data: { title: sanitizeInput(parsed.data.title.trim()) },
+      select: { id: true, title: true, updatedAt: true },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error("PATCH /api/conversations/[id] error", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const conversation = await prisma.conversation.findUnique({ where: { id } });
+    if (!conversation) {
+      return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectWriteAccess(conversation.projectId, userId, request.headers.get("x-user-email"));
+    if (!access.authorized) return access.response;
+
+    await prisma.conversation.delete({ where: { id } });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error("DELETE /api/conversations/[id] error", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -24,12 +24,13 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ conversations });
   } catch (error) {
-    logger.error("GET /api/conversations error", error);
+    logger.error("GET /api/conversations error", { projectId: request.nextUrl.searchParams.get("projectId"), error });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 
 export async function POST(request: NextRequest) {
+  let projectId: string | undefined;
   try {
     const body = await request.json();
     const parsed = ConversationCreateSchema.safeParse(body);
@@ -37,7 +38,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: parsed.error.errors[0].message }, { status: 400 });
     }
 
-    const { projectId, title } = parsed.data;
+    ({ projectId } = parsed.data);
+    const { title } = parsed.data;
     const userId = getCurrentUserId(request);
     const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get("x-user-email"));
     if (!access.authorized) return access.response;
@@ -49,7 +51,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(conversation, { status: 201 });
   } catch (error) {
-    logger.error("POST /api/conversations error", error);
+    logger.error("POST /api/conversations error", { projectId, error });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getCurrentUserId, verifyProjectWriteAccess } from "@/lib/api-auth";
+import { logger } from "@/lib/logger";
+import { sanitizeInput } from "@/lib/sanitize-server";
+import { ConversationCreateSchema } from "@/schemas/conversations";
+
+export async function GET(request: NextRequest) {
+  try {
+    const projectId = request.nextUrl.searchParams.get("projectId");
+    if (!projectId) {
+      return NextResponse.json({ error: "projectId required" }, { status: 400 });
+    }
+
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get("x-user-email"));
+    if (!access.authorized) return access.response;
+
+    const conversations = await prisma.conversation.findMany({
+      where: { projectId },
+      orderBy: { updatedAt: "desc" },
+      select: { id: true, title: true, updatedAt: true },
+    });
+
+    return NextResponse.json({ conversations });
+  } catch (error) {
+    logger.error("GET /api/conversations error", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = ConversationCreateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.errors[0].message }, { status: 400 });
+    }
+
+    const { projectId, title } = parsed.data;
+    const userId = getCurrentUserId(request);
+    const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get("x-user-email"));
+    if (!access.authorized) return access.response;
+
+    const conversation = await prisma.conversation.create({
+      data: { projectId, title: title ? sanitizeInput(title.trim()) : "New chat" },
+      select: { id: true, title: true, updatedAt: true },
+    });
+
+    return NextResponse.json(conversation, { status: 201 });
+  } catch (error) {
+    logger.error("POST /api/conversations error", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/components/ai-chat-panel.tsx
+++ b/src/components/ai-chat-panel.tsx
@@ -103,6 +103,7 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const initialMessageFiredRef = useRef(false);
+  const titleRefreshFiredRef = useRef<string | null>(null);
 
   const scrollToBottom = useCallback(() => {
     if (scrollRef.current) {
@@ -281,6 +282,7 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
       setConversationId(conv.id);
       setMessages([]);
       setThreadsOpen(false);
+      titleRefreshFiredRef.current = null;
     } catch (err) {
       console.error(err);
     } finally {
@@ -336,18 +338,26 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
     }
   }, [deleteTarget, conversations, conversationId, switchThread, createThread]);
 
-  // Refresh conversation title after first assistant reply completes
+  // Refresh conversation title once after first assistant reply completes.
+  // The ref guards against unbounded polling when auto-title silently fails
+  // (runSimpleCompletion returns "" on model failure — title stays "New chat").
   useEffect(() => {
     if (!conversationId || isStreaming) return;
+    if (titleRefreshFiredRef.current === conversationId) return;
     const active = conversations.find((c) => c.id === conversationId);
     if (!active || active.title !== "New chat") return;
     const hasAssistantMsg = messages.some((m) => m.role === "assistant");
     if (!hasAssistantMsg) return;
+
+    titleRefreshFiredRef.current = conversationId;
     const timer = setTimeout(() => {
       fetch(`/api/conversations?projectId=${projectId}`)
-        .then((r) => r.json())
+        .then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json();
+        })
         .then((d) => { if (d.conversations) setConversations(d.conversations); })
-        .catch(console.error);
+        .catch((err) => console.error("title refresh failed:", err));
     }, 2000);
     return () => clearTimeout(timer);
   }, [isStreaming, conversationId, conversations, messages, projectId]);

--- a/src/components/ai-chat-panel.tsx
+++ b/src/components/ai-chat-panel.tsx
@@ -250,6 +250,10 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
     setThreadsOpen(false);
     try {
       const res = await fetch(`/api/chat?conversationId=${id}`);
+      if (!res.ok) {
+        console.error("switchThread failed", res.status);
+        return;
+      }
       const data = await res.json();
       if (data.messages) setMessages(data.messages);
     } catch (err) {
@@ -267,6 +271,11 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ projectId }),
       });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        console.error("createThread failed", res.status, body);
+        return;
+      }
       const conv = await res.json();
       setConversations((prev) => [conv, ...prev]);
       setConversationId(conv.id);
@@ -288,6 +297,10 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title }),
       });
+      if (!res.ok) {
+        console.error("submitRename failed", res.status);
+        return;
+      }
       const updated = await res.json();
       setConversations((prev) => prev.map((c) => c.id === id ? { ...c, title: updated.title, updatedAt: updated.updatedAt } : c));
     } catch (err) {
@@ -301,7 +314,12 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
     if (!deleteTarget) return;
     const { id } = deleteTarget;
     try {
-      await fetch(`/api/conversations/${id}`, { method: "DELETE" });
+      const res = await fetch(`/api/conversations/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        console.error("handleDelete failed", res.status);
+        setDeleteTarget(null);
+        return;
+      }
       const remaining = conversations.filter((c) => c.id !== id);
       setConversations(remaining);
       setDeleteTarget(null);
@@ -314,6 +332,7 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
       }
     } catch (err) {
       console.error(err);
+      setDeleteTarget(null);
     }
   }, [deleteTarget, conversations, conversationId, switchThread, createThread]);
 

--- a/src/components/ai-chat-panel.tsx
+++ b/src/components/ai-chat-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Send, Trash2, Loader2, ChevronDown, ChevronRight, Wrench, WifiOff } from "lucide-react";
+import { Send, Trash2, Loader2, ChevronDown, ChevronRight, Wrench, WifiOff, Plus, Pencil } from "lucide-react";
 import { offlineFetch } from "@/lib/offline/sync-queue";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -10,6 +10,11 @@ import { AiSettingsDialog } from "@/components/ai-settings-dialog";
 import { cn } from "@/lib/utils";
 import { sanitizeMessageContent } from "@/lib/sanitize";
 import { useNetworkStatus } from "@/lib/offline/use-network-status";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { timeAgo } from "@/components/editor/editor-config";
 
 interface ChatMessage {
   id: string;
@@ -89,6 +94,12 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState("");
   const [toolActivities, setToolActivities] = useState<ToolActivity[]>([]);
+  const [conversations, setConversations] = useState<{id: string; title: string; updatedAt: string}[]>([]);
+  const [threadsOpen, setThreadsOpen] = useState(false);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<{id: string; title: string} | null>(null);
+  const [isCreatingThread, setIsCreatingThread] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const initialMessageFiredRef = useRef(false);
@@ -99,8 +110,13 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
     }
   }, []);
 
-  // Load chat history (GET returns or creates a default conversation for the project)
+  // Load thread list and default conversation
   useEffect(() => {
+    fetch(`/api/conversations?projectId=${projectId}`)
+      .then((r) => r.json())
+      .then((d) => { if (d.conversations) setConversations(d.conversations); })
+      .catch(console.error);
+
     fetch(`/api/chat?projectId=${projectId}`)
       .then((res) => res.json())
       .then((data) => {
@@ -226,11 +242,96 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
     sendMessageText(text);
   };
 
-  const clearHistory = async () => {
-    if (!conversationId) return;
-    await offlineFetch(`/api/chat?conversationId=${conversationId}`, { method: "DELETE" });
+  const switchThread = useCallback(async (id: string) => {
+    if (id === conversationId || isStreaming) return;
+    setLoadingHistory(true);
     setMessages([]);
-  };
+    setConversationId(id);
+    setThreadsOpen(false);
+    try {
+      const res = await fetch(`/api/chat?conversationId=${id}`);
+      const data = await res.json();
+      if (data.messages) setMessages(data.messages);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoadingHistory(false);
+    }
+  }, [conversationId, isStreaming]);
+
+  const createThread = useCallback(async () => {
+    setIsCreatingThread(true);
+    try {
+      const res = await fetch("/api/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId }),
+      });
+      const conv = await res.json();
+      setConversations((prev) => [conv, ...prev]);
+      setConversationId(conv.id);
+      setMessages([]);
+      setThreadsOpen(false);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsCreatingThread(false);
+    }
+  }, [projectId]);
+
+  const submitRename = useCallback(async (id: string) => {
+    const title = renameValue.trim();
+    if (!title) { setRenamingId(null); return; }
+    try {
+      const res = await fetch(`/api/conversations/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title }),
+      });
+      const updated = await res.json();
+      setConversations((prev) => prev.map((c) => c.id === id ? { ...c, title: updated.title, updatedAt: updated.updatedAt } : c));
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setRenamingId(null);
+    }
+  }, [renameValue]);
+
+  const handleDelete = useCallback(async () => {
+    if (!deleteTarget) return;
+    const { id } = deleteTarget;
+    try {
+      await fetch(`/api/conversations/${id}`, { method: "DELETE" });
+      const remaining = conversations.filter((c) => c.id !== id);
+      setConversations(remaining);
+      setDeleteTarget(null);
+      if (id === conversationId) {
+        if (remaining.length > 0) {
+          switchThread(remaining[0].id);
+        } else {
+          createThread();
+        }
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }, [deleteTarget, conversations, conversationId, switchThread, createThread]);
+
+  // Refresh conversation title after first assistant reply completes
+  useEffect(() => {
+    if (!conversationId || isStreaming) return;
+    const active = conversations.find((c) => c.id === conversationId);
+    if (!active || active.title !== "New chat") return;
+    const hasAssistantMsg = messages.some((m) => m.role === "assistant");
+    if (!hasAssistantMsg) return;
+    const timer = setTimeout(() => {
+      fetch(`/api/conversations?projectId=${projectId}`)
+        .then((r) => r.json())
+        .then((d) => { if (d.conversations) setConversations(d.conversations); })
+        .catch(console.error);
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [isStreaming, conversationId, conversations, messages, projectId]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     // Enter (without Shift) or Cmd/Ctrl+Enter sends the message
@@ -242,25 +343,90 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2">
-        <span className="text-xs font-medium text-text-muted uppercase tracking-wider">
-          AI Assistant
-        </span>
-        <div className="flex items-center gap-1">
-          <AiSettingsDialog />
-          {messages.length > 0 && (
+      {/* Thread list header */}
+      <div className="shrink-0 border-b border-border">
+        <div className="flex items-center justify-between px-3 py-2">
+          <button
+            onClick={() => setThreadsOpen((o) => !o)}
+            className="flex items-center gap-1.5 text-xs font-medium text-text-muted hover:text-text-primary transition-colors min-w-0"
+          >
+            {threadsOpen ? <ChevronDown className="h-3 w-3 flex-shrink-0" /> : <ChevronRight className="h-3 w-3 flex-shrink-0" />}
+            <span className="truncate">
+              {conversations.find((c) => c.id === conversationId)?.title ?? "AI Assistant"}
+            </span>
+          </button>
+          <div className="flex items-center gap-1">
             <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6 text-text-muted hover:text-danger"
-              onClick={clearHistory}
-              aria-label="Clear chat history"
+              variant="ghost" size="icon"
+              className="h-6 w-6 text-text-muted hover:text-text-primary"
+              onClick={createThread}
+              disabled={isCreatingThread || isStreaming}
+              aria-label="New chat"
+              title="New chat"
             >
-              <Trash2 className="h-3.5 w-3.5" />
+              <Plus className="h-3.5 w-3.5" />
             </Button>
-          )}
+            <AiSettingsDialog />
+          </div>
         </div>
+
+        {threadsOpen && (
+          <div className="space-y-0.5 px-2 pb-2 max-h-48 overflow-y-auto">
+            {conversations.length === 0 && (
+              <p className="text-xs text-text-muted text-center py-2">No threads yet</p>
+            )}
+            {conversations.map((conv) => (
+              <div
+                key={conv.id}
+                className={cn(
+                  "group flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-xs transition-all",
+                  conv.id === conversationId
+                    ? "bg-accent/10 border border-accent/20"
+                    : "hover:bg-surface-overlay/50 cursor-pointer"
+                )}
+                onClick={() => conv.id !== conversationId && switchThread(conv.id)}
+              >
+                {renamingId === conv.id ? (
+                  <input
+                    className="flex-1 bg-transparent border-b border-accent text-xs focus:outline-none text-text-primary"
+                    value={renameValue}
+                    autoFocus
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onBlur={() => submitRename(conv.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") submitRename(conv.id);
+                      if (e.key === "Escape") setRenamingId(null);
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                ) : (
+                  <>
+                    <span className="flex-1 truncate text-text-secondary">{conv.title}</span>
+                    <span className="text-text-muted/60 whitespace-nowrap tabular-nums">{timeAgo(conv.updatedAt)}</span>
+                    <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <Button
+                        variant="ghost" size="icon"
+                        className="h-5 w-5 text-text-muted hover:text-text-primary"
+                        onClick={(e) => { e.stopPropagation(); setRenamingId(conv.id); setRenameValue(conv.title); }}
+                        aria-label="Rename thread"
+                      >
+                        <Pencil className="h-2.5 w-2.5" />
+                      </Button>
+                      <Button
+                        variant="ghost" size="icon"
+                        className="h-5 w-5 text-text-muted hover:text-danger"
+                        onClick={(e) => { e.stopPropagation(); setDeleteTarget({ id: conv.id, title: conv.title }); }}
+                        aria-label="Delete thread"
+                      >
+                        <Trash2 className="h-2.5 w-2.5" />
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Offline notice */}
@@ -422,6 +588,27 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
           </Button>
         </div>
       </div>
+
+      {/* Delete thread confirmation */}
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete &ldquo;{deleteTarget?.title}&rdquo;?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete this thread and all its messages.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/schemas/conversations.ts
+++ b/src/schemas/conversations.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const ConversationCreateSchema = z.object({
+  projectId: z.string().min(1, "projectId is required"),
+  title: z.string().optional(),
+});
+
+export const ConversationUpdateSchema = z.object({
+  title: z.string().min(1, "Title is required").max(200, "Title too long"),
+});
+
+export type ConversationCreateInput = z.infer<typeof ConversationCreateSchema>;
+export type ConversationUpdateInput = z.infer<typeof ConversationUpdateSchema>;


### PR DESCRIPTION
## Summary

Adds thread-aware chat UI to `ai-chat-panel.tsx` so users can manage multiple chat conversations per project. Users can now create, switch between, rename, and delete chat threads, with automatic titling of new threads after the first exchange.

## Changes

### New Files
- **`src/schemas/conversations.ts`** — Zod schemas for conversation CRUD operations
- **`src/app/api/conversations/route.ts`** — GET (list threads) and POST (create thread) endpoints
- **`src/app/api/conversations/[id]/route.ts`** — PATCH (rename) and DELETE endpoints
- **`src/__tests__/conversations-route.test.ts`** — Comprehensive tests for all conversation routes

### Modified Files
- **`src/app/api/chat/route.ts`** — Added fire-and-forget auto-titling after first assistant reply
- **`src/components/ai-chat-panel.tsx`** — Added collapsible thread list with create/rename/delete UI

## Key Features

✅ **Thread List UI** — Collapsible header showing all threads ordered by recency, with active thread highlighted
✅ **Create Thread** — `+ New chat` button creates blank thread with default title
✅ **Rename Thread** — Inline pencil button enables editing thread title
✅ **Delete Thread** — Trash button with confirmation dialog; automatically creates new thread if last one is deleted
✅ **Auto-Title** — Fire-and-forget server-side job generates 3–6 word title after first assistant reply
✅ **Thread Switching** — Click to switch threads; loads correct message history; streaming blocks switching for UX

## Validation

- ✅ Type checking: `npm run typecheck` passed
- ✅ Linting: `npm run lint` passed (0 errors)
- ✅ Tests: `npm run test:run` — all 797 tests passed
- ✅ Build: `npm run build` compiled successfully

## Related Issues

Fixes #503