### PR TITLE
feat: load Gemini models from API in AI settings, add 60s chat timeout

### DIFF
--- a/src/app/api/ai-settings/models/route.ts
+++ b/src/app/api/ai-settings/models/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCurrentUserId } from "@/lib/api-auth";
+import { getAiConfig } from "@/lib/ai/settings";
+import { logger } from "@/lib/logger";
+
+interface GoogleModel {
+  name: string;
+  displayName: string;
+  description?: string;
+  supportedGenerationMethods: string[];
+}
+
+interface GoogleModelsResponse {
+  models: GoogleModel[];
+}
+
+// GET /api/ai-settings/models — list available Gemini models using the user's API key
+export async function GET(request: NextRequest) {
+  try {
+    const userId = getCurrentUserId(request);
+    const aiConfig = await getAiConfig(userId);
+
+    if (!aiConfig.apiKey) {
+      return NextResponse.json(
+        { error: "No API key configured. Set one in AI Settings first." },
+        { status: 400 }
+      );
+    }
+
+    const url = `https://generativelanguage.googleapis.com/v1/models?key=${aiConfig.apiKey}&pageSize=100`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      const body = await res.text();
+      logger.error("Google models API error", { status: res.status, body });
+      return NextResponse.json(
+        { error: `Google API returned ${res.status}` },
+        { status: res.status }
+      );
+    }
+
+    const data = (await res.json()) as GoogleModelsResponse;
+
+    const models = (data.models ?? [])
+      .filter((m) => m.supportedGenerationMethods?.includes("generateContent"))
+      .map((m) => ({
+        id: m.name.replace("models/", ""),
+        displayName: m.displayName,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+
+    return NextResponse.json({ models });
+  } catch (error) {
+    logger.error("GET /api/ai-settings/models error", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/ai-settings/route.ts
+++ b/src/app/api/ai-settings/route.ts
@@ -28,8 +28,8 @@ export async function GET(request: NextRequest) {
             compressionModel: userSettings.compressionModel,
           });
         }
-      } catch {
-        // Table may not exist yet — fall through
+      } catch (err) {
+        logger.warn("GET /api/ai-settings: userAiSettings lookup failed, falling through to global", err);
       }
     }
 
@@ -45,8 +45,8 @@ export async function GET(request: NextRequest) {
       hasApiKey: !!decryptedKey,
       scope: "global",
     });
-  } catch {
-    // Table may not exist yet
+  } catch (err) {
+    logger.warn("GET /api/ai-settings: aiSettings lookup failed, returning empty defaults", err);
     return NextResponse.json({ apiKey: "", model: "", scope: "global" });
   }
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -313,12 +313,16 @@ export async function POST(request: NextRequest) {
     const prefInstructions = buildPreferenceInstructions(prefs);
 
     // Run ADK agent (handles tool loop, dynamic tool loading internally)
-    const { finalContent, toolLog } = await runChatAgent({
+    const agentPromise = runChatAgent({
       systemPrompt: systemPrompt + summaryBlock + sceneNote + "\n\n" + prefInstructions,
       chatHistory: windowMessages.map((m) => ({ role: m.role, content: m.content })),
       userMessage: sanitizedMessage,
       aiConfig,
     });
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`AI request timed out (model: ${aiConfig.model})`)), 60_000)
+    );
+    const { finalContent, toolLog } = await Promise.race([agentPromise, timeoutPromise]);
 
     // Save tool interactions as a system message if any tools were used
     if (toolLog.length > 0) {

--- a/src/components/ai-settings-dialog.tsx
+++ b/src/components/ai-settings-dialog.tsx
@@ -12,12 +12,24 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface AiSettingsData {
   apiKey: string;
   model: string;
   hasApiKey?: boolean;
   scope?: "user" | "global";
+}
+
+interface GeminiModel {
+  id: string;
+  displayName: string;
 }
 
 export function AiSettingsDialog() {
@@ -29,6 +41,8 @@ export function AiSettingsDialog() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const [models, setModels] = useState<GeminiModel[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -38,22 +52,30 @@ export function AiSettingsDialog() {
       .then((data: AiSettingsData) => {
         setModel(data.model || "");
         setMaskedKey(data.apiKey || "");
-        setApiKey(""); // Don't pre-fill with masked value
+        setApiKey("");
         setLoaded(true);
       })
       .catch(console.error);
   }, [open]);
 
+  // Fetch model list once settings are loaded (requires a saved API key)
+  useEffect(() => {
+    if (!loaded) return;
+    setModelsLoading(true);
+    fetch("/api/ai-settings/models")
+      .then((res) => res.json())
+      .then((data: { models?: GeminiModel[]; error?: string }) => {
+        if (data.models) setModels(data.models);
+      })
+      .catch(console.error)
+      .finally(() => setModelsLoading(false));
+  }, [loaded]);
+
   const handleSave = async () => {
     setSaving(true);
     setSaved(false);
-    const body: Record<string, string> = {
-      model,
-    };
-    // Only send apiKey if user actually typed a new one
-    if (apiKey) {
-      body.apiKey = apiKey;
-    }
+    const body: Record<string, string> = { model };
+    if (apiKey) body.apiKey = apiKey;
 
     try {
       const res = await offlineFetch("/api/ai-settings", {
@@ -132,13 +154,39 @@ export function AiSettingsDialog() {
             <div>
               <label htmlFor="ai-model" className="block text-sm font-medium text-text-secondary mb-1.5">
                 Model
+                {modelsLoading && (
+                  <span className="ml-2 inline-block h-3 w-3 border border-text-muted border-t-transparent rounded-full animate-spin align-middle" />
+                )}
               </label>
-              <Input
-                id="ai-model"
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                placeholder="gemini-2.0-flash-001"
-              />
+              {models.length > 0 ? (
+                <Select value={model} onValueChange={setModel}>
+                  <SelectTrigger id="ai-model">
+                    <SelectValue placeholder="Select a model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {models.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        {m.id}
+                        {m.displayName !== m.id && (
+                          <span className="text-text-muted ml-1 text-xs">— {m.displayName}</span>
+                        )}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  id="ai-model"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  placeholder="gemini-2.0-flash"
+                />
+              )}
+              {!modelsLoading && models.length === 0 && (
+                <p className="text-xs text-text-muted mt-1">
+                  Save a valid API key to load models from Google.
+                </p>
+              )}
             </div>
 
             <div className="flex items-center gap-2 pt-2">


### PR DESCRIPTION
## Summary

- **Gemini models dropdown**: New `GET /api/ai-settings/models` endpoint fetches available models from the Google Generative Language API using the user's saved API key, filtering to only those that support `generateContent`. The AI Settings dialog now shows a Select dropdown populated from this list (falls back to a free-text input when no models are returned — e.g. no key saved yet).
- **60-second chat timeout**: The `runChatAgent` call in `POST /api/chat` is now wrapped in a `Promise.race` against a 60-second timeout, so hung requests fail with a clear error message (`AI request timed out (model: <name>)`) rather than hanging indefinitely.
- **Bare catch fixes**: Two silent `catch {}` blocks in `GET /api/ai-settings` now log a `logger.warn` with the error, matching the style already used elsewhere in that file.

## Test plan

- [ ] Open AI Settings with a saved Gemini API key — confirm model dropdown populates
- [ ] Open AI Settings with no API key — confirm text input fallback is shown
- [ ] Verify chat requests that exceed 60 seconds surface a timeout error
- [ ] Check server logs for warn output when the `aiSettings` table is missing/unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)