### PR TITLE
feat: persona picker for Send to Review (editor / genre fan / professional author)

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -124,14 +124,22 @@ ${objectsSummary || "(No characters/locations yet)"}${universeSummary}
 - You have tools available to read and modify the project. Use them when the user asks you to look up details, make changes, or explore the story structure.`;
 }
 
-async function buildReviewSystemPrompt(projectId: string): Promise<string> {
+async function buildReviewSystemPrompt(projectId: string, conversationType: string): Promise<string> {
   const project = await prisma.project.findUnique({ where: { id: projectId } });
   if (!project) throw new Error("Project not found");
-  return `You are an experienced story editor. The writer has shared their full manuscript from "${project.title}" for editorial review.
-Your role: provide honest, constructive feedback on the story as a whole.
-Focus on: narrative arc, pacing, character development, theme, opening and closing strength, any structural issues.
-Do NOT rewrite sentences. Flag specific passages by quoting a short excerpt when relevant.
-After your initial review, stay in conversation — answer follow-up questions, go deeper on any area the writer wants to explore.`;
+
+  const personaInstructions: Record<string, string> = {
+    "review-editor": `You are an experienced editor and publisher evaluating "${project.title}" for publication. Focus on: commercial viability, narrative structure, pacing, marketability, opening hook strength, and publication readiness. Be direct about what works and what would need to change before submission.`,
+    "review-fan": `You are an enthusiastic genre fan reading "${project.title}" for enjoyment. Focus on: how engaging and fun it is, whether it meets genre expectations, moments that excited or disappointed you as a reader, and whether you'd recommend it to other fans.`,
+    "review-author": `You are a professional author in the same genre as "${project.title}" giving craft-level feedback. Focus on: prose quality, sentence-level technique, POV consistency, dialogue, show-don't-tell, pacing at the scene level, and the mechanics of storytelling.`,
+  };
+
+  const instruction = personaInstructions[conversationType] ?? personaInstructions["review-editor"];
+
+  return `${instruction}
+The writer has shared their full manuscript. Provide honest, constructive feedback.
+Do NOT rewrite sentences. Quote short excerpts when flagging specific passages.
+After your initial review, stay in conversation — answer follow-up questions and go deeper on any area the writer wants to explore.`;
 }
 
 async function autoTitleConversation(conversationId: string, aiConfig: AiProviderConfig): Promise<void> {
@@ -298,8 +306,9 @@ export async function POST(request: NextRequest) {
 
     const windowMessages = allMessages.slice(-chatWindowSize);
 
-    const systemPrompt = conversation.type === "review"
-      ? await buildReviewSystemPrompt(conversation.projectId)
+    const isReview = conversation.type.startsWith("review");
+    const systemPrompt = isReview
+      ? await buildReviewSystemPrompt(conversation.projectId, conversation.type)
       : await buildSystemPrompt(conversation.projectId);
     const summaryBlock = conversation.summary
       ? `\n\n## Conversation so far\n${conversation.summary}`

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -129,9 +129,23 @@ async function buildReviewSystemPrompt(projectId: string, conversationType: stri
   if (!project) throw new Error("Project not found");
 
   const personaInstructions: Record<string, string> = {
-    "review-editor": `You are an experienced editor and publisher evaluating "${project.title}" for publication. Focus on: commercial viability, narrative structure, pacing, marketability, opening hook strength, and publication readiness. Be direct about what works and what would need to change before submission.`,
-    "review-fan": `You are an enthusiastic genre fan reading "${project.title}" for enjoyment. Focus on: how engaging and fun it is, whether it meets genre expectations, moments that excited or disappointed you as a reader, and whether you'd recommend it to other fans.`,
-    "review-author": `You are a professional author in the same genre as "${project.title}" giving craft-level feedback. Focus on: prose quality, sentence-level technique, POV consistency, dialogue, show-don't-tell, pacing at the scene level, and the mechanics of storytelling.`,
+    "review-editor": `You are a seasoned acquisitions editor evaluating "${project.title}" for publication. Be direct, professional, and commercially minded.
+
+Your focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.
+
+Tone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.`,
+
+    "review-fan": `You are an avid fan of this genre who just finished reading "${project.title}". React like a real reader — enthusiastic, personal, opinionated.
+
+Your focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."
+
+Tone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.`,
+
+    "review-author": `You are a published author in the same genre as "${project.title}", giving craft-level peer feedback.
+
+Your focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.
+
+Tone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.`,
   };
 
   const instruction = personaInstructions[conversationType] ?? personaInstructions["review-editor"];

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -320,9 +320,9 @@ export async function POST(request: NextRequest) {
 
     const windowMessages = allMessages.slice(-chatWindowSize);
 
-    const isReview = conversation.type.startsWith("review");
+    const isReview = (conversation.type ?? "").startsWith("review");
     const systemPrompt = isReview
-      ? await buildReviewSystemPrompt(conversation.projectId, conversation.type)
+      ? await buildReviewSystemPrompt(conversation.projectId, conversation.type ?? "review-editor")
       : await buildSystemPrompt(conversation.projectId);
     const summaryBlock = conversation.summary
       ? `\n\n## Conversation so far\n${conversation.summary}`

--- a/src/app/api/projects/[id]/send-to-review/route.ts
+++ b/src/app/api/projects/[id]/send-to-review/route.ts
@@ -14,6 +14,10 @@ export async function POST(
     const access = await verifyProjectWriteAccess(projectId, userId, request.headers.get("x-user-email"));
     if (!access.authorized) return access.response;
 
+    const body = await request.json().catch(() => ({}));
+    const persona = (body.persona as "editor" | "fan" | "author") ?? "editor";
+    const type = `review-${persona}` as "review-editor" | "review-fan" | "review-author";
+
     const manuscript = await exportManuscript(projectId);
     const wordCount = manuscript.split(/\s+/).filter(Boolean).length;
     if (wordCount < 10) {
@@ -25,7 +29,7 @@ export async function POST(
       data: {
         projectId,
         title: `Editorial Review — ${date}`,
-        type: "review",
+        type,
       },
       select: { id: true },
     });

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -64,9 +64,16 @@ import { cn } from "@/lib/utils";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { PROJECT_TYPE_LABELS } from "@/lib/constants";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { ReviewPersonaDialog } from "@/components/review-persona-dialog";
 import type { Project, OutlineNode, PlotlineIndicator, StoryObject, StoryObjectType, SceneStatus } from "@/lib/types";
 
 type SidebarTab = "outline" | "characters" | "locations" | "plotlines" | "world" | "notes" | "ai-chat";
+
+const PERSONA_LABELS: Record<"editor" | "fan" | "author", string> = {
+  editor: "an editor/publisher",
+  fan: "a genre fan",
+  author: "a professional author in this genre",
+};
 
 function mergeIndicators(
   nodes: OutlineNode[],
@@ -125,6 +132,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
   const [isSendingToReview, setIsSendingToReview] = useState(false);
   const [reviewConversationId, setReviewConversationId] = useState<string | null>(null);
   const [reviewManuscript, setReviewManuscript] = useState<string | null>(null);
+  const [reviewPersonaOpen, setReviewPersonaOpen] = useState(false);
 
   // Data fetching
   const fetchProject = useCallback(async () => {
@@ -292,10 +300,19 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
 
   const hasScenes = useMemo(() => outline.some(n => n.type === "SCENE" || n.children.some(c => c.type === "SCENE")), [outline]);
 
-  const handleSendToReview = useCallback(async () => {
+  const handleSendToReview = useCallback(() => {
+    setReviewPersonaOpen(true);
+  }, []);
+
+  const handlePersonaSelected = useCallback(async (persona: "editor" | "fan" | "author") => {
+    setReviewPersonaOpen(false);
     setIsSendingToReview(true);
     try {
-      const res = await fetch(`/api/projects/${projectId}/send-to-review`, { method: "POST" });
+      const res = await fetch(`/api/projects/${projectId}/send-to-review`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ persona }),
+      });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         console.error("send-to-review failed", res.status, body);
@@ -303,7 +320,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
       }
       const { conversationId, manuscriptText } = await res.json();
       setReviewConversationId(conversationId);
-      setReviewManuscript(`Please review this manuscript:\n\n${manuscriptText}`);
+      setReviewManuscript(`Review this manuscript as ${PERSONA_LABELS[persona]}.\n\n${manuscriptText}`);
       setActiveTab("ai-chat");
       setSelectedNodeId(null);
       setSelectedObjectId(null);
@@ -766,6 +783,13 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
           )}
         </main>
       </div>
+
+      {/* Review Persona Picker */}
+      <ReviewPersonaDialog
+        open={reviewPersonaOpen}
+        onSelect={handlePersonaSelected}
+        onCancel={() => setReviewPersonaOpen(false)}
+      />
 
       {/* Add Node Dialog */}
       <Dialog open={addNodeDialogOpen} onOpenChange={setAddNodeDialogOpen}>

--- a/src/components/ai-chat-panel.tsx
+++ b/src/components/ai-chat-panel.tsx
@@ -445,7 +445,7 @@ export function AIChatPanel({ projectId, sceneContext, initialMessage, onPromptC
                 ) : (
                   <>
                     <span className="flex-1 truncate text-text-secondary">{conv.title}</span>
-                    {conv.type === "review" && (
+                    {conv.type.startsWith("review") && (
                       <span className="text-[10px] font-medium bg-accent/15 text-accent px-1.5 py-0.5 rounded">
                         Review
                       </span>

--- a/src/components/review-persona-dialog.tsx
+++ b/src/components/review-persona-dialog.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface ReviewPersonaDialogProps {
+  open: boolean;
+  onSelect: (persona: "editor" | "fan" | "author") => void;
+  onCancel: () => void;
+}
+
+const PERSONAS: {
+  value: "editor" | "fan" | "author";
+  title: string;
+  description: string;
+}[] = [
+  {
+    value: "editor",
+    title: "Editor / Publisher",
+    description:
+      "Commercial viability, structure, marketability, publication readiness",
+  },
+  {
+    value: "fan",
+    title: "Genre Fan",
+    description: "Reader enjoyment, engagement, genre expectations",
+  },
+  {
+    value: "author",
+    title: "Professional Author",
+    description:
+      "Craft, prose quality, technique, storytelling mechanics",
+  },
+];
+
+export function ReviewPersonaDialog({
+  open,
+  onSelect,
+  onCancel,
+}: ReviewPersonaDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onCancel(); }}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Choose a reviewer perspective</DialogTitle>
+          <DialogDescription>
+            Pick the lens through which your manuscript will be evaluated.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2 py-2">
+          {PERSONAS.map(({ value, title, description }) => (
+            <button
+              key={value}
+              onClick={() => onSelect(value)}
+              className={cn(
+                "w-full text-left rounded-lg border border-border/15 bg-surface-overlay px-4 py-3",
+                "transition-all hover:bg-surface-raised hover:border-accent/40",
+                "focus:outline-none focus:ring-2 focus:ring-accent/50"
+              )}
+            >
+              <p className="text-sm font-semibold text-text-primary">{title}</p>
+              <p className="text-xs text-text-muted mt-0.5">{description}</p>
+            </button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a `ReviewPersonaDialog` with three persona cards (Editor/Publisher, Genre Fan, Professional Author) that appears when the user clicks Send to Review
- Stores persona in the conversation type (`review-editor`, `review-fan`, `review-author`) for backward-compatible routing
- `buildReviewSystemPrompt` now dispatches a persona-specific system prompt; legacy `review` type falls back to editor persona
- Badge in `ai-chat-panel.tsx` updated to `startsWith("review")` so all review-type threads show the Review badge

## Test plan
- [ ] Click Send to Review — persona picker dialog appears
- [ ] Select each persona — chat opens with appropriate framing message
- [ ] Existing `review` conversations (pre-migration) still show Review badge and get editor-persona system prompt
- [ ] Cancel on the dialog closes without starting a review

🤖 Generated with [Claude Code](https://claude.com/claude-code)