### PR TITLE
fix: use v1beta models endpoint, filter non-chat models

### DIFF
--- a/src/app/api/ai-settings/models/route.ts
+++ b/src/app/api/ai-settings/models/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const url = `https://generativelanguage.googleapis.com/v1/models?key=${aiConfig.apiKey}&pageSize=100`;
+    const url = `https://generativelanguage.googleapis.com/v1beta/models?key=${aiConfig.apiKey}&pageSize=200`;
     const res = await fetch(url);
 
     if (!res.ok) {
@@ -41,8 +41,14 @@ export async function GET(request: NextRequest) {
 
     const data = (await res.json()) as GoogleModelsResponse;
 
+    const EXCLUDE_PATTERNS = ["tts", "image", "robotics", "computer-use", "deep-research", "nano-", "lyria"];
+
     const models = (data.models ?? [])
       .filter((m) => m.supportedGenerationMethods?.includes("generateContent"))
+      .filter((m) => {
+        const id = m.name.replace("models/", "").toLowerCase();
+        return !EXCLUDE_PATTERNS.some((p) => id.includes(p));
+      })
       .map((m) => ({
         id: m.name.replace("models/", ""),
         displayName: m.displayName,


### PR DESCRIPTION
## Summary

- Switches the Gemini models fetch from `v1/models` (7 models) to `v1beta/models` (55 models) with `pageSize=200`
- Adds exclusion filtering to strip TTS, image, robotics, computer-use, deep-research, nano-, and lyria model families
- Only `generateContent`-capable models are returned, keeping the list clean for chat use cases

## Test plan

- [ ] Open AI Settings → model selector should now show the full Gemini chat model list (~20+ models vs 7 before)
- [ ] Verify excluded model families (TTS, image, etc.) are absent from the list
- [ ] Confirm the existing error handling and sorting still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)