### PR TITLE
fix: privacy/terms bar no longer overflows viewport

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export function SiteFooter() {
   return (
-    <footer className="border-t border-border bg-surface py-6 text-center text-xs text-text-muted">
+    <footer className="fixed bottom-0 inset-x-0 z-50 border-t border-border bg-surface py-3 text-center text-xs text-text-muted">
       <div className="max-w-7xl mx-auto px-6 flex items-center justify-center gap-3">
         <Link href="/privacy" className="hover:text-text-primary transition-colors">
           Privacy


### PR DESCRIPTION
## Summary

- Fixed privacy/terms bar at bottom of page that was causing the page to be taller than the viewport
- Changed `SiteFooter` from default block layout to `position: fixed` (Tailwind `fixed bottom-0 inset-x-0 z-50`) so it overlays content rather than pushing it down
- Reduced vertical padding from `py-6` to `py-3` since the bar now floats over content

## Test plan

- [ ] Page no longer shows a vertical scrollbar caused by the bottom bar
- [ ] Privacy/terms bar is either removed or overlays content without affecting layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)