### PR TITLE
fix: peer review JSON parse failures — JSON mode + higher token budget

### DIFF
--- a/src/__tests__/peer-review-route.test.ts
+++ b/src/__tests__/peer-review-route.test.ts
@@ -136,7 +136,8 @@ describe("POST /api/projects/:id/peer-review", () => {
       expect(body.publisher.overallImpression).toBe("Unable to parse review");
       expect(body.reader.overallImpression).toBe("OK");
       expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
-        expect.stringContaining("publisher")
+        expect.stringContaining("publisher"),
+        expect.objectContaining({ raw: expect.any(String) })
       );
     });
   });

--- a/src/app/api/projects/[id]/peer-review/route.ts
+++ b/src/app/api/projects/[id]/peer-review/route.ts
@@ -105,7 +105,7 @@ const DEFAULT_CONSENSUS: ConsensusFeedback = {
 
 function parseReview(raw: string, role: string): ReviewFeedback {
   const parsed = parseJson<ReviewFeedback>(raw);
-  if (!parsed) logger.error(`Peer review: failed to parse ${role} JSON`);
+  if (!parsed) logger.error(`Peer review: failed to parse ${role} JSON`, { raw: raw.slice(0, 300) });
   return parsed ?? DEFAULT_REVIEW;
 }
 
@@ -129,14 +129,14 @@ export async function POST(
       return NextResponse.json({ warning: "Manuscript is empty" });
     }
 
-    // Limit to ~50 k chars to stay within prompt budget for 3 × 800-token completions.
-    // Users with longer manuscripts get a review of the opening; no truncation warning is shown.
     const truncated = manuscript.slice(0, 50000);
 
+    const JSON_OPTS = { responseMimeType: "application/json", temperature: 0.3 } as const;
+
     const [publisherRaw, readerRaw, writerRaw] = await Promise.all([
-      runSimpleCompletion({ userMessage: buildPublisherPrompt(truncated), aiConfig, maxTokens: 800, temperature: 0.3 }),
-      runSimpleCompletion({ userMessage: buildReaderPrompt(truncated), aiConfig, maxTokens: 800, temperature: 0.3 }),
-      runSimpleCompletion({ userMessage: buildWriterPrompt(truncated), aiConfig, maxTokens: 800, temperature: 0.3 }),
+      runSimpleCompletion({ userMessage: buildPublisherPrompt(truncated), aiConfig, maxTokens: 2000, ...JSON_OPTS }),
+      runSimpleCompletion({ userMessage: buildReaderPrompt(truncated), aiConfig, maxTokens: 2000, ...JSON_OPTS }),
+      runSimpleCompletion({ userMessage: buildWriterPrompt(truncated), aiConfig, maxTokens: 2000, ...JSON_OPTS }),
     ]);
 
     const publisher = parseReview(publisherRaw, "publisher");
@@ -148,11 +148,11 @@ export async function POST(
       const synthesisRaw = await runSimpleCompletion({
         userMessage: buildSynthesisPrompt(publisherRaw, readerRaw, writerRaw),
         aiConfig,
-        maxTokens: 1000, // was 600 — synthesis embeds all 3 raw reviews; needs more headroom
-        temperature: 0.3,
+        maxTokens: 2000,
+        ...JSON_OPTS,
       });
       const consensusParsed = parseJson<ConsensusFeedback>(synthesisRaw);
-      if (!consensusParsed) logger.error("Peer review: failed to parse synthesis JSON");
+      if (!consensusParsed) logger.error("Peer review: failed to parse synthesis JSON", { raw: synthesisRaw.slice(0, 300) });
       consensus = consensusParsed ?? DEFAULT_CONSENSUS;
     } catch (err) {
       logger.error("Peer review synthesis failed", err);

--- a/src/lib/ai/adk-agent.ts
+++ b/src/lib/ai/adk-agent.ts
@@ -35,6 +35,7 @@ export async function runSimpleCompletion(params: {
   aiConfig: { apiKey: string; model: string };
   maxTokens?: number;
   temperature?: number;
+  responseMimeType?: string;
 }): Promise<string> {
   const llm = new Gemini({
     model: params.aiConfig.model,
@@ -49,6 +50,7 @@ export async function runSimpleCompletion(params: {
     generateContentConfig: {
       temperature: params.temperature,
       maxOutputTokens: params.maxTokens,
+      ...(params.responseMimeType ? { responseMimeType: params.responseMimeType } : {}),
     } as Record<string, unknown>,
   });
 


### PR DESCRIPTION
## Summary

- Root cause: 800-token limit was truncating JSON responses mid-stream, causing all parse failures
- Added `responseMimeType: "application/json"` support to `runSimpleCompletion` — forces Gemini to output raw JSON without markdown fences or preamble
- Raised `maxTokens` from 800 → 2000 per reviewer, 1000 → 2000 for synthesis
- Now logs the raw response (first 300 chars) when parsing fails, so failures are debuggable

## Test plan

- [ ] Run Peer Review on a project with content — all 4 tabs should populate
- [ ] Check Railway logs — no "failed to parse" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)