### PR TITLE
fix: footer no longer overlaps editor — moved to content pages only

### DIFF
--- a/src/app/dmca/page.tsx
+++ b/src/app/dmca/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { SiteFooter } from "@/components/site-footer";
 
 export const metadata: Metadata = {
   title: "DMCA Policy",
@@ -9,6 +10,7 @@ export const metadata: Metadata = {
 
 export default function DmcaPage() {
   return (
+    <>
     <main id="main-content" className="min-h-screen">
       <div className="h-1 accent-gradient" />
 
@@ -177,5 +179,7 @@ export default function DmcaPage() {
         </div>
       </div>
     </main>
+    <SiteFooter />
+    </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,6 @@ import { UpdateBanner } from "@/components/update-banner";
 import { SwLifecycle } from "@/components/sw-lifecycle";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ToastProvider } from "@/components/ui/toast";
-import { SiteFooter } from "@/components/site-footer";
 
 export const metadata: Metadata = {
   title: {
@@ -66,7 +65,6 @@ export default function RootLayout({
             {children}
             <SyncToast />
           </ToastProvider>
-          <SiteFooter />
           <OfflineIndicator />
           <SwLifecycle />
         </ThemeProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { offlineFetch } from "@/lib/offline/sync-queue";
+import { SiteFooter } from "@/components/site-footer";
 import { Button } from "@/components/ui/button";
 import { UserMenu } from "@/components/user-menu";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -258,6 +259,7 @@ export default function Dashboard() {
     : [];
 
   return (
+    <>
     <main id="main-content" className="min-h-screen">
       <SetupWizard />
 
@@ -865,5 +867,7 @@ export default function Dashboard() {
         </DialogContent>
       </Dialog>
     </main>
+    <SiteFooter />
+    </>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { SiteFooter } from "@/components/site-footer";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
@@ -9,6 +10,7 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
+    <>
     <main id="main-content" className="min-h-screen">
       <div className="h-1 accent-gradient" />
 
@@ -141,5 +143,7 @@ export default function PrivacyPage() {
         </div>
       </div>
     </main>
+    <SiteFooter />
+    </>
   );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { SiteFooter } from "@/components/site-footer";
 
 export const metadata: Metadata = {
   title: "Terms of Service",
@@ -9,6 +10,7 @@ export const metadata: Metadata = {
 
 export default function TermsPage() {
   return (
+    <>
     <main id="main-content" className="min-h-screen">
       <div className="h-1 accent-gradient" />
 
@@ -182,5 +184,7 @@ export default function TermsPage() {
         </div>
       </div>
     </main>
+    <SiteFooter />
+    </>
   );
 }

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export function SiteFooter() {
   return (
-    <footer className="fixed bottom-0 inset-x-0 z-50 border-t border-border bg-surface py-3 text-center text-xs text-text-muted">
+    <footer className="border-t border-border bg-surface py-6 text-center text-xs text-text-muted">
       <div className="max-w-7xl mx-auto px-6 flex items-center justify-center gap-3">
         <Link href="/privacy" className="hover:text-text-primary transition-colors">
           Privacy


### PR DESCRIPTION
## Summary

- Removed `SiteFooter` from the root layout — it was rendering on every page including the full-screen editor, where it overlapped the word count bar and chat input
- Added `SiteFooter` explicitly to the pages that actually need it: home, privacy, terms, dmca
- Reverted `position: fixed` back to static positioning on the footer itself (no longer needed since it's not fighting a full-screen layout)

## Test plan

- [ ] Editor page: no footer visible, word count bar and chat input not obscured
- [ ] Home page: footer visible at the bottom
- [ ] /privacy, /terms, /dmca: footer visible at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)