### PR TITLE
feat: persist peer reviews + history UI

### DIFF
--- a/prisma/migrations/20260501_add_peer_review/migration.sql
+++ b/prisma/migrations/20260501_add_peer_review/migration.sql
@@ -1,0 +1,18 @@
+-- Create PeerReview table
+CREATE TABLE "PeerReview" (
+  "id"        TEXT NOT NULL,
+  "projectId" TEXT NOT NULL,
+  "publisher" JSONB NOT NULL,
+  "reader"    JSONB NOT NULL,
+  "writer"    JSONB NOT NULL,
+  "consensus" JSONB NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PeerReview_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "PeerReview_projectId_createdAt_idx"
+  ON "PeerReview"("projectId", "createdAt" DESC);
+
+ALTER TABLE "PeerReview" ADD CONSTRAINT "PeerReview_projectId_fkey"
+  FOREIGN KEY ("projectId") REFERENCES "Project"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,66 +7,67 @@ datasource db {
 }
 
 model Annotation {
-  id            String        @id @default(cuid())
-  nodeId        String
-  content       String        @default("")
-  resolved      Boolean       @default(false)
-  range         String        @default("")
-  selectedText  String?
-  externalId    String?       @unique // Google Docs comment ID for imported annotations
-  createdAt     DateTime      @default(now())
-  updatedAt     DateTime      @updatedAt
-  node          StructureNode @relation(fields: [nodeId], references: [id], onDelete: Cascade)
+  id           String        @id @default(cuid())
+  nodeId       String
+  content      String        @default("")
+  resolved     Boolean       @default(false)
+  range        String        @default("")
+  selectedText String?
+  externalId   String?       @unique // Google Docs comment ID for imported annotations
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  node         StructureNode @relation(fields: [nodeId], references: [id], onDelete: Cascade)
 
   @@index([nodeId])
 }
 
 model ContentVersion {
-  id            String        @id @default(cuid())
-  nodeId        String
-  content       String        @default("")
-  wordCount     Int           @default(0)
-  createdAt     DateTime      @default(now())
-  node          StructureNode @relation(fields: [nodeId], references: [id], onDelete: Cascade)
+  id        String        @id @default(cuid())
+  nodeId    String
+  content   String        @default("")
+  wordCount Int           @default(0)
+  createdAt DateTime      @default(now())
+  node      StructureNode @relation(fields: [nodeId], references: [id], onDelete: Cascade)
 
   @@index([nodeId, createdAt(sort: Desc)])
 }
 
 model User {
-  id                String             @id @default(cuid())
-  email             String             @unique
-  googleId          String             @unique
-  name              String             @default("")
-  picture           String?
-  createdAt         DateTime           @default(now())
-  updatedAt         DateTime           @updatedAt
-  projects          Project[]
-  universes         Universe[]
-  aiSettings        UserAiSettings?
+  id         String          @id @default(cuid())
+  email      String          @unique
+  googleId   String          @unique
+  name       String          @default("")
+  picture    String?
+  createdAt  DateTime        @default(now())
+  updatedAt  DateTime        @updatedAt
+  projects   Project[]
+  universes  Universe[]
+  aiSettings UserAiSettings?
 }
 
 model Project {
-  id             String          @id @default(cuid())
-  universeId     String?
-  userId         String?
-  title          String
-  author         String          @default("")
-  synopsis       String          @default("")
-  genre          String          @default("")
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
-  archivedAt     DateTime?
-  storyObjects   StoryObject[]
-  structureNodes StructureNode[]
-  universe       Universe?       @relation(fields: [universeId], references: [id])
-  user           User?           @relation(fields: [userId], references: [id])
-  projectType    String          @default("FICTION") // FICTION, ARTICLE_COLLECTION, GENERAL
-  isSample       Boolean         @default(false)
-  conversations  Conversation[]
+  id               String            @id @default(cuid())
+  universeId       String?
+  userId           String?
+  title            String
+  author           String            @default("")
+  synopsis         String            @default("")
+  genre            String            @default("")
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+  archivedAt       DateTime?
+  storyObjects     StoryObject[]
+  structureNodes   StructureNode[]
+  universe         Universe?         @relation(fields: [universeId], references: [id])
+  user             User?             @relation(fields: [userId], references: [id])
+  projectType      String            @default("FICTION") // FICTION, ARTICLE_COLLECTION, GENERAL
+  isSample         Boolean           @default(false)
+  conversations    Conversation[]
   googleDocExports GoogleDocExport[]
-  hashnodeExports HashnodeExport[]
-  writingSessions WritingSession[]
-  shares         ProjectShare[]
+  hashnodeExports  HashnodeExport[]
+  writingSessions  WritingSession[]
+  shares           ProjectShare[]
+  peerReviews      PeerReview[]
 
   @@index([userId])
 }
@@ -78,28 +79,28 @@ model ProjectShare {
   role      String   @default("READER")
   createdAt DateTime @default(now())
 
-  project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   @@unique([projectId, email])
 }
 
 model Relationship {
-  id           String         @id @default(cuid())
-  type         String
-  label        String         @default("")
-  fromNodeId   String?
-  fromObjectId String?
+  id                String         @id @default(cuid())
+  type              String
+  label             String         @default("")
+  fromNodeId        String?
+  fromObjectId      String?
   fromWorldObjectId String?
-  toNodeId     String?
-  toObjectId   String?
+  toNodeId          String?
+  toObjectId        String?
   toWorldObjectId   String?
-  createdAt    DateTime       @default(now())
-  toObject     StoryObject?   @relation("Relationship_toObjectIdToStoryObject", fields: [toObjectId], references: [id], onDelete: Cascade)
-  toNode       StructureNode? @relation("Relationship_toNodeIdToStructureNode", fields: [toNodeId], references: [id], onDelete: Cascade)
-  toWorldObject WorldObject?  @relation("Relationship_toWorldObjectIdToWorldObject", fields: [toWorldObjectId], references: [id], onDelete: Cascade)
-  fromObject   StoryObject?   @relation("Relationship_fromObjectIdToStoryObject", fields: [fromObjectId], references: [id], onDelete: Cascade)
-  fromNode     StructureNode? @relation("Relationship_fromNodeIdToStructureNode", fields: [fromNodeId], references: [id], onDelete: Cascade)
-  fromWorldObject WorldObject? @relation("Relationship_fromWorldObjectIdToWorldObject", fields: [fromWorldObjectId], references: [id], onDelete: Cascade)
+  createdAt         DateTime       @default(now())
+  toObject          StoryObject?   @relation("Relationship_toObjectIdToStoryObject", fields: [toObjectId], references: [id], onDelete: Cascade)
+  toNode            StructureNode? @relation("Relationship_toNodeIdToStructureNode", fields: [toNodeId], references: [id], onDelete: Cascade)
+  toWorldObject     WorldObject?   @relation("Relationship_toWorldObjectIdToWorldObject", fields: [toWorldObjectId], references: [id], onDelete: Cascade)
+  fromObject        StoryObject?   @relation("Relationship_fromObjectIdToStoryObject", fields: [fromObjectId], references: [id], onDelete: Cascade)
+  fromNode          StructureNode? @relation("Relationship_fromNodeIdToStructureNode", fields: [fromNodeId], references: [id], onDelete: Cascade)
+  fromWorldObject   WorldObject?   @relation("Relationship_fromWorldObjectIdToWorldObject", fields: [fromWorldObjectId], references: [id], onDelete: Cascade)
 
   @@index([toObjectId])
   @@index([toNodeId])
@@ -110,19 +111,19 @@ model Relationship {
 }
 
 model StoryObject {
-  id             String         @id @default(cuid())
-  projectId      String
-  type           String
-  name           String
-  description    String         @default("")
-  notes          String         @default("")
-  role           String?
-  tags           String         @default("")
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
-  relationships  Relationship[] @relation("Relationship_toObjectIdToStoryObject")
-  relatedBy      Relationship[] @relation("Relationship_fromObjectIdToStoryObject")
-  project        Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  id            String         @id @default(cuid())
+  projectId     String
+  type          String
+  name          String
+  description   String         @default("")
+  notes         String         @default("")
+  role          String?
+  tags          String         @default("")
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+  relationships Relationship[] @relation("Relationship_toObjectIdToStoryObject")
+  relatedBy     Relationship[] @relation("Relationship_fromObjectIdToStoryObject")
+  project       Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   @@index([projectId, type])
 }
@@ -152,34 +153,34 @@ model StructureNode {
 }
 
 model Universe {
-  id           String        @id @default(cuid())
-  userId       String?
-  title        String
-  description  String        @default("")
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
-  projects     Project[]
-  worldObjects WorldObject[]
+  id               String            @id @default(cuid())
+  userId           String?
+  title            String
+  description      String            @default("")
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+  projects         Project[]
+  worldObjects     WorldObject[]
   googleDocExports GoogleDocExport[]
-  user         User?         @relation(fields: [userId], references: [id])
+  user             User?             @relation(fields: [userId], references: [id])
 
   @@index([userId])
 }
 
 model WorldObject {
-  id          String                     @id @default(cuid())
-  universeId  String
-  type        String // CHARACTER, LOCATION, WORLD_ELEMENT
-  name        String
-  description String                     @default("")
-  notes       String                     @default("")
-  tags        String                     @default("")
-  createdAt   DateTime                   @default(now())
-  updatedAt   DateTime                   @updatedAt
-  universe    Universe                   @relation(fields: [universeId], references: [id], onDelete: Cascade)
-  timeline    WorldObjectTimelineEntry[]
-  relationships Relationship[]           @relation("Relationship_toWorldObjectIdToWorldObject")
-  relatedBy     Relationship[]           @relation("Relationship_fromWorldObjectIdToWorldObject")
+  id            String                     @id @default(cuid())
+  universeId    String
+  type          String // CHARACTER, LOCATION, WORLD_ELEMENT
+  name          String
+  description   String                     @default("")
+  notes         String                     @default("")
+  tags          String                     @default("")
+  createdAt     DateTime                   @default(now())
+  updatedAt     DateTime                   @updatedAt
+  universe      Universe                   @relation(fields: [universeId], references: [id], onDelete: Cascade)
+  timeline      WorldObjectTimelineEntry[]
+  relationships Relationship[]             @relation("Relationship_toWorldObjectIdToWorldObject")
+  relatedBy     Relationship[]             @relation("Relationship_fromWorldObjectIdToWorldObject")
 
   @@index([universeId, type])
 }
@@ -201,7 +202,7 @@ model WorldObjectTimelineEntry {
 
 model GoogleCredential {
   id           String   @id @default(cuid())
-  userId       String   @unique  // "local" in single-user mode, actual user ID in multi-user
+  userId       String   @unique // "local" in single-user mode, actual user ID in multi-user
   accessToken  String
   refreshToken String
   expiresAt    DateTime
@@ -211,17 +212,17 @@ model GoogleCredential {
 }
 
 model Conversation {
-  id                         String        @id @default(cuid())
+  id                         String   @id @default(cuid())
   projectId                  String
-  title                      String        @default("New chat")
-  type                       String        @default("chat")
-  summary                    String?       @db.Text
+  title                      String   @default("New chat")
+  type                       String   @default("chat")
+  summary                    String?  @db.Text
   summarizedThroughMessageId String?
-  createdAt                  DateTime      @default(now())
-  updatedAt                  DateTime      @updatedAt
+  createdAt                  DateTime @default(now())
+  updatedAt                  DateTime @updatedAt
 
-  project   Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  messages  ChatMessage[]
+  project  Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  messages ChatMessage[]
 
   @@index([projectId, createdAt])
 }
@@ -229,7 +230,7 @@ model Conversation {
 model ChatMessage {
   id             String       @id @default(cuid())
   conversationId String
-  role           String       // "user" | "assistant"
+  role           String // "user" | "assistant"
   content        String       @default("")
   createdAt      DateTime     @default(now())
   conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
@@ -237,44 +238,58 @@ model ChatMessage {
   @@index([conversationId, createdAt])
 }
 
+model PeerReview {
+  id        String   @id @default(cuid())
+  projectId String
+  publisher Json
+  reader    Json
+  writer    Json
+  consensus Json
+  createdAt DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId, createdAt(sort: Desc)])
+}
+
 model AiSettings {
-  id         String   @id @default("default")
-  baseUrl    String   @default("")
-  apiKey     String   @default("")
-  model      String   @default("")
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  id        String   @id @default("default")
+  baseUrl   String   @default("")
+  apiKey    String   @default("")
+  model     String   @default("")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model UserAiSettings {
-  id                 String   @id @default(cuid())
-  userId             String   @unique
-  baseUrl            String   @default("")
-  apiKey             String   @default("")
-  model              String   @default("")
-  customInstructions String   @default("")
-  coachingStyle              String   @default("balanced")
-  responseLength             String   @default("moderate")
-  chatWindowSize             Int      @default(5)
-  messagesUntilCompression   Int      @default(15)
-  compressionModel           String   @default("")
-  createdAt                  DateTime @default(now())
-  updatedAt          DateTime @updatedAt
-  user               User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                       String   @id @default(cuid())
+  userId                   String   @unique
+  baseUrl                  String   @default("")
+  apiKey                   String   @default("")
+  model                    String   @default("")
+  customInstructions       String   @default("")
+  coachingStyle            String   @default("balanced")
+  responseLength           String   @default("moderate")
+  chatWindowSize           Int      @default(5)
+  messagesUntilCompression Int      @default(15)
+  compressionModel         String   @default("")
+  createdAt                DateTime @default(now())
+  updatedAt                DateTime @updatedAt
+  user                     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model GoogleDocExport {
-  id                  String    @id @default(cuid())
-  projectId           String?
-  universeId          String?
-  exportMode          String    // UNIVERSE, STORY_INTERNAL, STORY_READER
-  googleDocId         String
-  googleDocUrl        String
-  lastSyncedAt        DateTime
-  lastCommentSyncAt   DateTime? // Last time comments were pulled from Google Docs
-  createdAt           DateTime  @default(now())
-  project             Project?  @relation(fields: [projectId], references: [id], onDelete: SetNull)
-  universe            Universe? @relation(fields: [universeId], references: [id], onDelete: SetNull)
+  id                String    @id @default(cuid())
+  projectId         String?
+  universeId        String?
+  exportMode        String // UNIVERSE, STORY_INTERNAL, STORY_READER
+  googleDocId       String
+  googleDocUrl      String
+  lastSyncedAt      DateTime
+  lastCommentSyncAt DateTime? // Last time comments were pulled from Google Docs
+  createdAt         DateTime  @default(now())
+  project           Project?  @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  universe          Universe? @relation(fields: [universeId], references: [id], onDelete: SetNull)
 
   @@unique([projectId, universeId, exportMode])
   @@index([projectId])
@@ -282,15 +297,15 @@ model GoogleDocExport {
 }
 
 model WritingSession {
-  id              String        @id @default(cuid())
+  id              String         @id @default(cuid())
   projectId       String
   nodeId          String?
-  startedAt       DateTime      @default(now())
+  startedAt       DateTime       @default(now())
   endedAt         DateTime?
-  wordsWritten    Int           @default(0)
-  durationSeconds Int           @default(0)
-  date            String        @default("") // YYYY-MM-DD for heatmap grouping
-  project         Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  wordsWritten    Int            @default(0)
+  durationSeconds Int            @default(0)
+  date            String         @default("") // YYYY-MM-DD for heatmap grouping
+  project         Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
   node            StructureNode? @relation(fields: [nodeId], references: [id], onDelete: SetNull)
 
   @@index([projectId, date])
@@ -301,15 +316,15 @@ model WritingSession {
 model OAuthClient {
   id           String   @id
   clientName   String   @default("")
-  redirectUris String   // JSON array stored as string
+  redirectUris String // JSON array stored as string
   grantTypes   String   @default("[\"authorization_code\",\"refresh_token\"]")
   createdAt    DateTime @default(now())
 }
 
 model HashnodeCredential {
   id            String           @id @default(cuid())
-  userId        String           @unique  // "local" in single-user mode, actual user ID in multi-user
-  accessToken   String           // stored encrypted via lib/crypto
+  userId        String           @unique // "local" in single-user mode, actual user ID in multi-user
+  accessToken   String // stored encrypted via lib/crypto
   publicationId String           @default("")
   username      String           @default("")
   createdAt     DateTime         @default(now())

--- a/src/__tests__/peer-review-route.test.ts
+++ b/src/__tests__/peer-review-route.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 vi.mock("@/lib/api-auth", () => ({
   getCurrentUserId: vi.fn().mockReturnValue("user-1"),
   verifyProjectWriteAccess: vi.fn().mockResolvedValue({ authorized: true }),
+  verifyProjectReadAccess: vi.fn().mockResolvedValue({ authorized: true }),
 }));
 
 vi.mock("@/lib/ai/settings", () => ({
@@ -30,11 +31,25 @@ vi.mock("@/lib/logger", () => ({
   logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
-import { POST } from "@/app/api/projects/[id]/peer-review/route";
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    peerReview: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}));
+
+import { POST, GET as GET_LIST } from "@/app/api/projects/[id]/peer-review/route";
+import { GET as GET_DETAIL } from "@/app/api/projects/[id]/peer-review/[reviewId]/route";
 import { getAiConfig } from "@/lib/ai/settings";
 import { exportManuscript } from "@/mcp/tools/export";
 import { runSimpleCompletion } from "@/lib/ai/adk-agent";
 import { logger } from "@/lib/logger";
+import { verifyProjectReadAccess } from "@/lib/api-auth";
+import { prisma } from "@/lib/db";
 
 function makeRequest(projectId: string = "proj-1") {
   return new NextRequest(`http://localhost/api/projects/${projectId}/peer-review`, {
@@ -42,8 +57,22 @@ function makeRequest(projectId: string = "proj-1") {
   });
 }
 
+function makeListRequest(url: string = "http://localhost/api/projects/proj-1/peer-review") {
+  return new NextRequest(url, { method: "GET" });
+}
+
+function makeDetailRequest(projectId: string = "proj-1", reviewId: string = "rev-1") {
+  return new NextRequest(`http://localhost/api/projects/${projectId}/peer-review/${reviewId}`, {
+    method: "GET",
+  });
+}
+
 function makeParams(id: string = "proj-1") {
   return { params: Promise.resolve({ id }) };
+}
+
+function makeDetailParams(id: string = "proj-1", reviewId: string = "rev-1") {
+  return { params: Promise.resolve({ id, reviewId }) };
 }
 
 describe("POST /api/projects/:id/peer-review", () => {
@@ -61,6 +90,10 @@ describe("POST /api/projects/:id/peer-review", () => {
         recommendation: "publish",
       })
     );
+    vi.mocked(prisma.peerReview.create).mockResolvedValue({
+      id: "rev-default",
+      createdAt: new Date("2026-05-01T00:00:00Z"),
+    } as never);
   });
 
   // ─── parseJson unit tests ──────────────────────────────────────────────────
@@ -246,5 +279,139 @@ describe("POST /api/projects/:id/peer-review", () => {
       "Peer review synthesis failed",
       expect.any(Error)
     );
+  });
+
+  // ─── Persistence ──────────────────────────────────────────────────────────
+
+  it("persists the review and returns id + createdAt", async () => {
+    const createdAt = new Date("2026-05-01T12:00:00Z");
+    vi.mocked(prisma.peerReview.create).mockResolvedValueOnce({
+      id: "rev-1",
+      createdAt,
+    } as never);
+
+    const res = await POST(makeRequest("proj-7"), makeParams("proj-7"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("rev-1");
+    expect(new Date(body.createdAt).toISOString()).toBe(createdAt.toISOString());
+    expect(vi.mocked(prisma.peerReview.create)).toHaveBeenCalledTimes(1);
+    const callArg = vi.mocked(prisma.peerReview.create).mock.calls[0][0];
+    expect(callArg.data.projectId).toBe("proj-7");
+    expect(callArg.data.publisher).toBeDefined();
+    expect(callArg.data.reader).toBeDefined();
+    expect(callArg.data.writer).toBeDefined();
+    expect(callArg.data.consensus).toBeDefined();
+  });
+
+  it("does not 500 when persistence fails", async () => {
+    vi.mocked(prisma.peerReview.create).mockRejectedValueOnce(new Error("db down"));
+
+    const res = await POST(makeRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.publisher).toBeDefined();
+    expect(body.id).toBeNull();
+    expect(body.createdAt).toBeNull();
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+      "Failed to persist peer review",
+      expect.objectContaining({ projectId: "proj-1" })
+    );
+  });
+});
+
+describe("GET /api/projects/:id/peer-review (list)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(verifyProjectReadAccess).mockResolvedValue({ authorized: true } as never);
+  });
+
+  it("returns paginated list newest-first", async () => {
+    const r1 = { id: "r1", createdAt: new Date("2026-05-01T10:00:00Z"), consensus: { synthesizedRecommendation: "Tighten" } };
+    const r2 = { id: "r2", createdAt: new Date("2026-04-28T09:00:00Z"), consensus: { synthesizedRecommendation: "Revise" } };
+    vi.mocked(prisma.peerReview.findMany).mockResolvedValueOnce([r1, r2] as never);
+    vi.mocked(prisma.peerReview.count).mockResolvedValueOnce(2 as never);
+
+    const res = await GET_LIST(makeListRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(2);
+    expect(body.limit).toBe(20);
+    expect(body.offset).toBe(0);
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0]).toEqual({
+      id: "r1",
+      createdAt: r1.createdAt.toISOString(),
+      synthesizedRecommendation: "Tighten",
+    });
+    expect(body.data[1].synthesizedRecommendation).toBe("Revise");
+  });
+
+  it("clamps limit and offset and forwards them to Prisma", async () => {
+    vi.mocked(prisma.peerReview.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.peerReview.count).mockResolvedValueOnce(0 as never);
+
+    const res = await GET_LIST(
+      makeListRequest("http://localhost/api/projects/proj-1/peer-review?limit=5&offset=10"),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const findManyArg = vi.mocked(prisma.peerReview.findMany).mock.calls[0][0]!;
+    expect(findManyArg.take).toBe(5);
+    expect(findManyArg.skip).toBe(10);
+  });
+
+  it("returns the auth response when read access is denied", async () => {
+    const denyResponse = NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    vi.mocked(verifyProjectReadAccess).mockResolvedValueOnce({
+      authorized: false,
+      response: denyResponse,
+    } as never);
+
+    const res = await GET_LIST(makeListRequest(), makeParams());
+    expect(res.status).toBe(403);
+    expect(vi.mocked(prisma.peerReview.findMany)).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/projects/:id/peer-review/:reviewId (detail)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(verifyProjectReadAccess).mockResolvedValue({ authorized: true } as never);
+  });
+
+  it("returns the full review row when found", async () => {
+    const review = {
+      id: "rev-1",
+      projectId: "proj-1",
+      createdAt: new Date("2026-05-01T10:00:00Z"),
+      publisher: { overallImpression: "P" },
+      reader: { overallImpression: "R" },
+      writer: { overallImpression: "W" },
+      consensus: { synthesizedRecommendation: "S" },
+    };
+    vi.mocked(prisma.peerReview.findFirst).mockResolvedValueOnce(review as never);
+
+    const res = await GET_DETAIL(makeDetailRequest(), makeDetailParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("rev-1");
+    expect(body.publisher.overallImpression).toBe("P");
+    expect(body.consensus.synthesizedRecommendation).toBe("S");
+  });
+
+  it("returns 404 when the review is not found", async () => {
+    vi.mocked(prisma.peerReview.findFirst).mockResolvedValueOnce(null as never);
+
+    const res = await GET_DETAIL(makeDetailRequest(), makeDetailParams());
+    expect(res.status).toBe(404);
+  });
+
+  it("scopes the lookup to both reviewId and projectId (cross-project safety)", async () => {
+    vi.mocked(prisma.peerReview.findFirst).mockResolvedValueOnce(null as never);
+
+    await GET_DETAIL(makeDetailRequest("proj-A", "rev-from-B"), makeDetailParams("proj-A", "rev-from-B"));
+    const where = vi.mocked(prisma.peerReview.findFirst).mock.calls[0][0]?.where;
+    expect(where).toEqual({ id: "rev-from-B", projectId: "proj-A" });
   });
 });

--- a/src/app/api/projects/[id]/peer-review/[reviewId]/route.ts
+++ b/src/app/api/projects/[id]/peer-review/[reviewId]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { getCurrentUserId, verifyProjectReadAccess } from "@/lib/api-auth";
+import { prisma } from "@/lib/db";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; reviewId: string }> }
+) {
+  const { id: projectId, reviewId } = await params;
+  const userId = getCurrentUserId(request);
+  const access = await verifyProjectReadAccess(projectId, userId, request.headers.get("x-user-email"));
+  if (!access.authorized) return access.response;
+
+  try {
+    const review = await prisma.peerReview.findFirst({
+      where: { id: reviewId, projectId },
+    });
+    if (!review) {
+      return NextResponse.json({ error: "Review not found" }, { status: 404 });
+    }
+    return NextResponse.json(review);
+  } catch (error) {
+    logger.error("GET /api/projects/[id]/peer-review/[reviewId] error", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/projects/[id]/peer-review/route.ts
+++ b/src/app/api/projects/[id]/peer-review/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { logger } from "@/lib/logger";
-import { getCurrentUserId, verifyProjectWriteAccess } from "@/lib/api-auth";
+import { getCurrentUserId, verifyProjectReadAccess, verifyProjectWriteAccess } from "@/lib/api-auth";
 import { getAiConfig } from "@/lib/ai/settings";
 import { runSimpleCompletion } from "@/lib/ai/adk-agent";
 import { exportManuscript } from "@/mcp/tools/export";
+import { prisma } from "@/lib/db";
 
 export interface ReviewFeedback {
   overallImpression: string;
@@ -158,12 +160,77 @@ export async function POST(
       logger.error("Peer review synthesis failed", err);
     }
 
-    return NextResponse.json({ publisher, reader, writer, consensus });
+    let savedReviewId: string | null = null;
+    let savedCreatedAt: Date | null = null;
+    try {
+      const saved = await prisma.peerReview.create({
+        data: {
+          projectId,
+          publisher: publisher as unknown as Prisma.InputJsonValue,
+          reader: reader as unknown as Prisma.InputJsonValue,
+          writer: writer as unknown as Prisma.InputJsonValue,
+          consensus: consensus as unknown as Prisma.InputJsonValue,
+        },
+        select: { id: true, createdAt: true },
+      });
+      savedReviewId = saved.id;
+      savedCreatedAt = saved.createdAt;
+    } catch (err) {
+      logger.error("Failed to persist peer review", { err, projectId });
+    }
+
+    return NextResponse.json({
+      publisher,
+      reader,
+      writer,
+      consensus,
+      id: savedReviewId,
+      createdAt: savedCreatedAt,
+    });
   } catch (error) {
     logger.error("POST /api/projects/[id]/peer-review error", error);
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }
     );
+  }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: projectId } = await params;
+  const userId = getCurrentUserId(request);
+  const access = await verifyProjectReadAccess(projectId, userId, request.headers.get("x-user-email"));
+  if (!access.authorized) return access.response;
+
+  try {
+    const { searchParams } = request.nextUrl;
+    const limit = Math.min(Math.max(parseInt(searchParams.get("limit") || "20", 10) || 20, 1), 100);
+    const offset = Math.max(parseInt(searchParams.get("offset") || "0", 10) || 0, 0);
+
+    const [rows, total] = await Promise.all([
+      prisma.peerReview.findMany({
+        where: { projectId },
+        orderBy: { createdAt: "desc" },
+        select: { id: true, createdAt: true, consensus: true },
+        take: limit,
+        skip: offset,
+      }),
+      prisma.peerReview.count({ where: { projectId } }),
+    ]);
+
+    const data = rows.map((r) => ({
+      id: r.id,
+      createdAt: r.createdAt,
+      synthesizedRecommendation:
+        (r.consensus as { synthesizedRecommendation?: string } | null)?.synthesizedRecommendation ?? "",
+    }));
+
+    return NextResponse.json({ data, total, limit, offset });
+  } catch (error) {
+    logger.error("GET /api/projects/[id]/peer-review error", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/app/api/projects/[id]/peer-review/route.ts
+++ b/src/app/api/projects/[id]/peer-review/route.ts
@@ -105,10 +105,10 @@ const DEFAULT_CONSENSUS: ConsensusFeedback = {
   synthesizedRecommendation: "Unable to synthesize consensus",
 };
 
-function parseReview(raw: string, role: string): ReviewFeedback {
-  const parsed = parseJson<ReviewFeedback>(raw);
+function parseOrLog<T>(raw: string, role: string, fallback: T): T {
+  const parsed = parseJson<T>(raw);
   if (!parsed) logger.error(`Peer review: failed to parse ${role} JSON`, { raw: raw.slice(0, 300) });
-  return parsed ?? DEFAULT_REVIEW;
+  return parsed ?? fallback;
 }
 
 export async function POST(
@@ -141,9 +141,9 @@ export async function POST(
       runSimpleCompletion({ userMessage: buildWriterPrompt(truncated), aiConfig, maxTokens: 2000, ...JSON_OPTS }),
     ]);
 
-    const publisher = parseReview(publisherRaw, "publisher");
-    const reader = parseReview(readerRaw, "reader");
-    const writer = parseReview(writerRaw, "writer");
+    const publisher = parseOrLog(publisherRaw, "publisher", DEFAULT_REVIEW);
+    const reader = parseOrLog(readerRaw, "reader", DEFAULT_REVIEW);
+    const writer = parseOrLog(writerRaw, "writer", DEFAULT_REVIEW);
 
     let consensus: ConsensusFeedback = DEFAULT_CONSENSUS;
     try {
@@ -153,9 +153,7 @@ export async function POST(
         maxTokens: 2000,
         ...JSON_OPTS,
       });
-      const consensusParsed = parseJson<ConsensusFeedback>(synthesisRaw);
-      if (!consensusParsed) logger.error("Peer review: failed to parse synthesis JSON", { raw: synthesisRaw.slice(0, 300) });
-      consensus = consensusParsed ?? DEFAULT_CONSENSUS;
+      consensus = parseOrLog(synthesisRaw, "synthesis", DEFAULT_CONSENSUS);
     } catch (err) {
       logger.error("Peer review synthesis failed", err);
     }

--- a/src/components/editor/peer-review-panel.tsx
+++ b/src/components/editor/peer-review-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { Users, RefreshCw, MessageSquare } from "lucide-react";
+import { useState, useCallback, useEffect } from "react";
+import { Users, RefreshCw, MessageSquare, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -29,6 +29,17 @@ interface PeerReviewResult {
   warning?: string;
 }
 
+interface ReviewMeta {
+  id: string;
+  createdAt: string;
+}
+
+interface HistoryRow {
+  id: string;
+  createdAt: string;
+  synthesizedRecommendation: string;
+}
+
 interface PeerReviewPanelProps {
   projectId: string;
   onStartChat: (message: string) => void;
@@ -45,12 +56,69 @@ const TABS: { key: TabKey; label: string }[] = [
 
 const SECTION_HEADING = "text-xs font-semibold text-text-muted uppercase tracking-wider mb-1";
 
+const TIMESTAMP_FMT = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  return TIMESTAMP_FMT.format(d);
+}
+
 export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps) {
   const [review, setReview] = useState<PeerReviewResult | null>(null);
+  const [currentMeta, setCurrentMeta] = useState<ReviewMeta | null>(null);
   const [loading, setLoading] = useState(false);
   const [ran, setRan] = useState(false);
   const [activeTab, setActiveTab] = useState<TabKey>("publisher");
   const [error, setError] = useState<string | null>(null);
+
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [history, setHistory] = useState<HistoryRow[] | null>(null);
+  const [historyTotal, setHistoryTotal] = useState(0);
+  const [historyLoading, setHistoryLoading] = useState(false);
+
+  // Load latest saved review on mount / project change.
+  useEffect(() => {
+    let ignore = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const listRes = await fetch(`/api/projects/${projectId}/peer-review?limit=1`);
+        if (!listRes.ok) return;
+        const list = await listRes.json();
+        const latestId = list?.data?.[0]?.id;
+        if (!latestId) {
+          if (!ignore) setRan(false);
+          return;
+        }
+        const detailRes = await fetch(`/api/projects/${projectId}/peer-review/${latestId}`);
+        if (!detailRes.ok) return;
+        const detail = await detailRes.json();
+        if (ignore) return;
+        setReview({
+          publisher: detail.publisher,
+          reader: detail.reader,
+          writer: detail.writer,
+          consensus: detail.consensus,
+        });
+        setCurrentMeta({ id: detail.id, createdAt: detail.createdAt });
+        setRan(true);
+      } catch {
+        // Mount fetch failures are silent — user can still click "Run Peer Review".
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+    return () => {
+      ignore = true;
+    };
+  }, [projectId]);
 
   const runReview = useCallback(async () => {
     setLoading(true);
@@ -63,6 +131,11 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
           setError(data.warning);
         } else {
           setReview(data);
+          if (data.id && data.createdAt) {
+            setCurrentMeta({ id: data.id, createdAt: data.createdAt });
+          }
+          // Force history list to refetch on next open so the new review is visible.
+          setHistory(null);
         }
       } else {
         setError(`Request failed (${res.status})`);
@@ -72,6 +145,52 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
     } finally {
       setLoading(false);
       setRan(true);
+    }
+  }, [projectId]);
+
+  const fetchHistory = useCallback(async () => {
+    setHistoryLoading(true);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/peer-review?limit=20`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setHistory(data.data ?? []);
+      setHistoryTotal(data.total ?? 0);
+    } catch {
+      setHistory([]);
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, [projectId]);
+
+  const toggleHistory = useCallback(() => {
+    setHistoryOpen((open) => {
+      const next = !open;
+      if (next && history === null) {
+        void fetchHistory();
+      }
+      return next;
+    });
+  }, [history, fetchHistory]);
+
+  const loadFromHistory = useCallback(async (id: string) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/peer-review/${id}`);
+      if (!res.ok) return;
+      const detail = await res.json();
+      setReview({
+        publisher: detail.publisher,
+        reader: detail.reader,
+        writer: detail.writer,
+        consensus: detail.consensus,
+      });
+      setCurrentMeta({ id: detail.id, createdAt: detail.createdAt });
+      setRan(true);
+      setHistoryOpen(false);
+      setActiveTab("publisher");
+    } finally {
+      setLoading(false);
     }
   }, [projectId]);
 
@@ -190,6 +309,8 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
     </div>
   );
 
+  const savedLabel = currentMeta ? `Saved ${formatTimestamp(currentMeta.createdAt)}` : null;
+
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Header */}
@@ -199,6 +320,16 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
           <span className="text-sm font-medium">Peer Review</span>
         </div>
         <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn("h-7 w-7", historyOpen && "bg-accent/15 text-accent")}
+            onClick={toggleHistory}
+            aria-label="Toggle review history"
+            aria-pressed={historyOpen}
+          >
+            <Clock className="h-3.5 w-3.5" />
+          </Button>
           <Button
             variant="ghost"
             size="icon"
@@ -212,8 +343,56 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
         </div>
       </div>
 
+      {/* History view */}
+      {historyOpen && (
+        <div className="flex-1 overflow-y-auto">
+          {historyLoading && (
+            <div className="p-4 flex items-center justify-center gap-2">
+              <div className="h-4 w-4 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+              <span className="text-sm text-muted-foreground">Loading history…</span>
+            </div>
+          )}
+          {!historyLoading && history && history.length === 0 && (
+            <div className="p-4 text-center">
+              <p className="text-sm text-muted-foreground">No saved reviews yet.</p>
+            </div>
+          )}
+          {!historyLoading && history && history.length > 0 && (
+            <ul className="divide-y divide-border">
+              {history.map((row) => (
+                <li key={row.id}>
+                  <button
+                    type="button"
+                    onClick={() => loadFromHistory(row.id)}
+                    className={cn(
+                      "w-full text-left px-3 py-2 hover:bg-muted/50 transition-colors",
+                      currentMeta?.id === row.id && "bg-accent/10"
+                    )}
+                  >
+                    <div className="text-xs font-medium text-foreground">
+                      {formatTimestamp(row.createdAt)}
+                    </div>
+                    {row.synthesizedRecommendation && (
+                      <div className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                        {row.synthesizedRecommendation.slice(0, 80)}
+                        {row.synthesizedRecommendation.length > 80 ? "…" : ""}
+                      </div>
+                    )}
+                  </button>
+                </li>
+              ))}
+              {historyTotal > history.length && (
+                <li className="px-3 py-2 text-center text-xs text-muted-foreground">
+                  Showing {history.length} of {historyTotal}
+                </li>
+              )}
+            </ul>
+          )}
+        </div>
+      )}
+
       {/* Tabs */}
-      {review && (
+      {!historyOpen && review && (
         <div className="flex items-center gap-0.5 px-2 py-1.5 border-b border-border shrink-0">
           {TABS.map(({ key, label }) => (
             <button
@@ -233,41 +412,46 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
       )}
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto">
-        {!ran && !loading && (
-          <div className="p-4 text-center">
-            <p className="text-sm text-muted-foreground mb-3">
-              Get feedback from three AI reviewers: a Publisher, an Avid Reader, and an Experienced Writer.
-            </p>
-            <Button size="sm" onClick={runReview}>
-              Run Peer Review
-            </Button>
-          </div>
-        )}
+      {!historyOpen && (
+        <div className="flex-1 overflow-y-auto">
+          {!ran && !loading && (
+            <div className="p-4 text-center">
+              <p className="text-sm text-muted-foreground mb-3">
+                Get feedback from three AI reviewers: a Publisher, an Avid Reader, and an Experienced Writer.
+              </p>
+              <Button size="sm" onClick={runReview}>
+                Run Peer Review
+              </Button>
+            </div>
+          )}
 
-        {loading && (
-          <div className="p-4 flex items-center justify-center gap-2">
-            <div className="h-4 w-4 border-2 border-accent border-t-transparent rounded-full animate-spin" />
-            <span className="text-sm text-muted-foreground">Analysing manuscript…</span>
-          </div>
-        )}
+          {loading && (
+            <div className="p-4 flex items-center justify-center gap-2">
+              <div className="h-4 w-4 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+              <span className="text-sm text-muted-foreground">Analysing manuscript…</span>
+            </div>
+          )}
 
-        {ran && !loading && !review && (
-          <div className="p-4 text-center">
-            <p className="text-sm text-muted-foreground">
-              {error ?? "No review results available."}
-            </p>
-          </div>
-        )}
+          {ran && !loading && !review && (
+            <div className="p-4 text-center">
+              <p className="text-sm text-muted-foreground">
+                {error ?? "No review results available."}
+              </p>
+            </div>
+          )}
 
-        {review && !loading && (
-          <div className="p-3">
-            {activeTab === "consensus"
-              ? renderConsensusTab(review.consensus)
-              : renderReviewTab(review[activeTab])}
-          </div>
-        )}
-      </div>
+          {review && !loading && (
+            <div className="p-3">
+              {savedLabel && (
+                <p className="text-[11px] text-muted-foreground mb-2">{savedLabel}</p>
+              )}
+              {activeTab === "consensus"
+                ? renderConsensusTab(review.consensus)
+                : renderReviewTab(review[activeTab])}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/editor/peer-review-panel.tsx
+++ b/src/components/editor/peer-review-panel.tsx
@@ -83,6 +83,24 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
   const [historyTotal, setHistoryTotal] = useState(0);
   const [historyLoading, setHistoryLoading] = useState(false);
 
+  const applyReviewDetail = useCallback((detail: {
+    id: string;
+    createdAt: string;
+    publisher: ReviewFeedback;
+    reader: ReviewFeedback;
+    writer: ReviewFeedback;
+    consensus: ConsensusFeedback;
+  }) => {
+    setReview({
+      publisher: detail.publisher,
+      reader: detail.reader,
+      writer: detail.writer,
+      consensus: detail.consensus,
+    });
+    setCurrentMeta({ id: detail.id, createdAt: detail.createdAt });
+    setRan(true);
+  }, []);
+
   // Load latest saved review on mount / project change.
   useEffect(() => {
     let ignore = false;
@@ -101,14 +119,7 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
         if (!detailRes.ok) return;
         const detail = await detailRes.json();
         if (ignore) return;
-        setReview({
-          publisher: detail.publisher,
-          reader: detail.reader,
-          writer: detail.writer,
-          consensus: detail.consensus,
-        });
-        setCurrentMeta({ id: detail.id, createdAt: detail.createdAt });
-        setRan(true);
+        applyReviewDetail(detail);
       } catch {
         // Mount fetch failures are silent — user can still click "Run Peer Review".
       } finally {
@@ -118,7 +129,7 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
     return () => {
       ignore = true;
     };
-  }, [projectId]);
+  }, [projectId, applyReviewDetail]);
 
   const runReview = useCallback(async () => {
     setLoading(true);
@@ -179,20 +190,13 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
       const res = await fetch(`/api/projects/${projectId}/peer-review/${id}`);
       if (!res.ok) return;
       const detail = await res.json();
-      setReview({
-        publisher: detail.publisher,
-        reader: detail.reader,
-        writer: detail.writer,
-        consensus: detail.consensus,
-      });
-      setCurrentMeta({ id: detail.id, createdAt: detail.createdAt });
-      setRan(true);
+      applyReviewDetail(detail);
       setHistoryOpen(false);
       setActiveTab("publisher");
     } finally {
       setLoading(false);
     }
-  }, [projectId]);
+  }, [projectId, applyReviewDetail]);
 
   const renderReviewTab = (feedback: ReviewFeedback) => (
     <div className="space-y-3">


### PR DESCRIPTION
## Summary

Persists every peer review run to the database so closing the sidebar no longer discards results, and adds a History picker to revisit past reviews — the full path the plan in `artifacts/runs/479ee664…/plan.md` lays out for issue #538.

- `PeerReview` Prisma model on `Project` (four `Json` columns + `[projectId, createdAt(sort: Desc)]` index) with a CREATE TABLE-only migration that the `scripts/migrate.mjs` destructive-DDL guard accepts.
- `POST /api/projects/[id]/peer-review` now `prisma.peerReview.create(...)` after synthesis and returns `id` + `createdAt` alongside the existing payload. Persistence failure is logged but non-fatal — the LLM result is still returned (don't 500 after the user already paid for 4 LLM calls).
- New `GET /api/projects/[id]/peer-review` (paginated list, projected to `id`/`createdAt`/`synthesizedRecommendation`) and `GET /api/projects/[id]/peer-review/[reviewId]` (full detail). Detail uses `findFirst({ where: { id, projectId } })` to prevent cross-project leakage.
- `PeerReviewPanel` fetches the latest saved review on mount, surfaces the saved-at timestamp, and adds a Clock-icon History toggle that lazy-loads the list and lets the user jump to any past run.
- Tests: 8 new cases on top of the existing 9 (POST persists / persistence failure tolerated / list happy / list pagination clamping / list auth-denied / detail happy / detail 404 / detail cross-project scoping).

Side-by-side comparison UI is **explicitly out of scope** per the plan and issue #538 — the data foundation lands here so a future PR can build the diff view on top.

## Test plan

- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — 0 errors (139 pre-existing warnings unchanged)
- [x] `npm run test:run` — 822 passed (was 814; +8 new)
- [x] `npm run build` — both new routes mapped (`/api/projects/[id]/peer-review` and `/api/projects/[id]/peer-review/[reviewId]`)
- [ ] Visual regression: panel screenshot tests don't currently cover `PeerReviewPanel` (no `peer-review` matches in `e2e/visual.spec.ts`), so no snapshots needed for this change

Fixes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)