### PR TITLE
fix: auto-close stale Deploy down issues from external monitor

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -9,6 +9,8 @@ jobs:
   check-production:
     name: Production Health Check
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Check health + data integrity
         id: check
@@ -58,6 +60,55 @@ jobs:
             -H "Title: Annie Production Down" \
             -d "Health check failed (status: ${STATUS}). Check: https://annie.interstellarai.net/api/health" \
             "$NTFY_URL"
+
+      - name: Auto-close stale Deploy down issues
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // External uptime monitors open "Deploy down: <URL> returning HTTP <code>" issues
+            // on transient blips and never close them. When this in-repo probe passes,
+            // close any such open issues for the production URL (mirrors the backup-alert
+            // auto-close pattern in the check-backup-freshness job below).
+            const titlePrefix = 'Deploy down: https://annie.interstellarai.net/api/health';
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'bug',
+              per_page: 100,
+            });
+
+            const stale = issues.filter(i => !i.pull_request && i.title.startsWith(titlePrefix));
+
+            if (stale.length === 0) {
+              console.log('No stale Deploy down issues to close.');
+              return;
+            }
+
+            for (const issue of stale) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  '✅ Production health check passed — auto-closing stale alert.',
+                  '',
+                  `Endpoint \`https://annie.interstellarai.net/api/health\` returned \`status: ok\` from the in-repo uptime probe at ${new Date().toISOString()}.`,
+                  '',
+                  `Triggered by workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                ].join('\n'),
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              console.log(`Closed stale Deploy down issue #${issue.number}`);
+            }
 
   check-staging:
     name: Staging Health Check


### PR DESCRIPTION
## Summary

External uptime monitor opens "Deploy down: <URL>" issues on transient network blips and never closes them. Production probe verifies health every 5 minutes but takes no action on those stale alerts. This PR extends the same workflow's existing `check-backup-freshness` auto-close pattern to Deploy-down issues so they self-resolve on the next successful health check.

This is the explicitly-deferred follow-up #3 from #541's resolution ("Self-healing / auto-close behavior on `uptime.yml`"). The companion PR #542 hardened the in-repo NTFY pipeline; this PR cleans up after the external monitor.

## Changes

- `.github/workflows/uptime.yml` (+51 / -0)
  - Grant `check-production` job `permissions: issues: write` so `actions/github-script@v7` can close issues with `${{ github.token }}`.
  - Append `Auto-close stale Deploy down issues` step (runs `if: success()`) that:
    - Lists open `bug`-labeled issues
    - Filters to titles starting with `Deploy down: https://annie.interstellarai.net/api/health`
    - Posts a recovery comment with a link back to the workflow run
    - Closes each with `state_reason: 'completed'`
  - Mirrors the close-on-recovery half of the `check-backup-freshness` job (lines 170–259 of the same file) — same library, same comment-then-close shape, same `console.log` per closed issue.

## Root cause

`HTTP 000` is curl's "no response received" sentinel — a transient network/CDN/DNS blip at the network layer. The external monitor that creates these issues lives outside this repo and has no retry, no dedup-on-create, and no auto-close. The endpoint is healthy now (`curl https://annie.interstellarai.net/api/health` → `HTTP 200` `{"status":"ok",...}`). The `check-production` job already verifies this every 5 minutes; it just wasn't acting on the stale alerts.

The same pattern hit twice on 2026-05-01 alone (#541 closed manually at 07:06 UTC, #544 opened at 13:30 UTC). Without auto-close these will keep accumulating.

## Scope boundaries

**In scope**: `.github/workflows/uptime.yml` only.

**Explicitly out of scope** (per the investigation artifact):
- External monitor itself — lives outside this repo.
- `jq parse error` aborts retry loop on non-JSON body — real bug, but affects the NTFY pipeline, not GitHub-issue creation. Filed separately.
- `/api/health` endpoint — already correct.

## Edge cases considered

- **Title-prefix collision** with a maintainer-authored issue: prefix is specific to the external monitor template; recoverable in one click if it ever happens.
- **Race between parallel runs**: GitHub's `issues.update({state: 'closed'})` on an already-closed issue is a no-op; duplicate comment is acceptable noise.
- **Permissions**: explicit `issues: write` on the job overrides any restrictive default token scope. Same pattern as `check-backup-freshness`.
- **Real outage that briefly recovers**: acceptable — production being healthy for an entire 5-min cron tick is a reasonable recovery signal; NTFY still pages on outages, GitHub issues are tracking-only; if outage returns, a fresh issue opens.
- **`listForRepo` paginates beyond 100**: only first 100 scanned per run; next cron tick picks up the rest.

## Validation

| Check | Result | Notes |
|-------|--------|-------|
| YAML syntax (`python3 -c "import yaml; yaml.safe_load(...)"`) | ✅ Pass | Workflow parses cleanly |
| `bun run lint` | ✅ Pass | 0 errors; 139 pre-existing `no-explicit-any` warnings, unrelated |
| `bun run typecheck` | ⚠️ Pre-existing only | 6 errors in `src/lib/google-api.ts` / `src/lib/controllers/google-auth.ts` (Google OAuth lib type mismatch, documented in #541's resolution). No new errors — change is YAML, not TS. |
| `bun run build` | ⚠️ Pre-existing only | Same pre-existing type errors as typecheck |
| Tests | ⏭️ Skipped | Requires `TEST_DATABASE_URL` (unavailable in this env); change has no JS/TS test surface — no automated tests for GitHub Actions workflows in this repo |

### Manual verification deferred to post-merge

Per the investigation artifact, runtime verification happens against GitHub's actual API:

## Test plan

- [ ] After merge, the next 5-minute cron tick (or `gh workflow run uptime.yml`) auto-closes #544 with a recovery comment that links to the workflow run.
- [ ] Synthetic close test: open a test issue titled `Deploy down: https://annie.interstellarai.net/api/health TEST` with the `bug` label, re-trigger the workflow, confirm it is closed with the recovery comment.
- [ ] Negative test: existing `backup-alert` issues and other non-`Deploy down:` bug-labeled issues are NOT touched by the new step.
- [ ] Confirm `check-production` logs `Attempt 1/3 — Response: {"status":"ok",...}` followed by either `No stale Deploy down issues to close.` or `Closed stale Deploy down issue #N`.

## Follow-ups (not bundled)

1. `uptime.yml`: `jq parse error` aborts retry loop when curl returns non-JSON body (P3) — evidenced by run failure at 2026-05-01 13:18:52 UTC.
2. External monitor retry hardening (P3) — tracked outside this repo.
3. Dockerfile startup chain hardening (P3) — DB-not-ready retry on `migrate.mjs` cold start.

Fixes #544