### PR TITLE
security: add durable per-IP and global limits to OAuth registration

### DIFF
--- a/prisma/migrations/20260506_oauth_client_ip_limit/migration.sql
+++ b/prisma/migrations/20260506_oauth_client_ip_limit/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "OAuthClient" ADD COLUMN "registrationIp" TEXT;
+ALTER TABLE "OAuthClient" ADD COLUMN "registrationUserId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "OAuthClient_registrationIp_createdAt_idx" ON "OAuthClient"("registrationIp", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -314,11 +314,15 @@ model WritingSession {
 }
 
 model OAuthClient {
-  id           String   @id
-  clientName   String   @default("")
-  redirectUris String // JSON array stored as string
-  grantTypes   String   @default("[\"authorization_code\",\"refresh_token\"]")
-  createdAt    DateTime @default(now())
+  id                 String   @id
+  clientName         String   @default("")
+  redirectUris       String // JSON array stored as string
+  grantTypes         String   @default("[\"authorization_code\",\"refresh_token\"]")
+  createdAt          DateTime @default(now())
+  registrationIp     String?
+  registrationUserId String?
+
+  @@index([registrationIp, createdAt])
 }
 
 model HashnodeCredential {

--- a/src/__tests__/oauth-register-route.test.ts
+++ b/src/__tests__/oauth-register-route.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/oauth-store", () => ({
+  registerClient: vi.fn(),
+  countClientsByIpInWindow: vi.fn().mockResolvedValue(0),
+  countTotalClients: vi.fn().mockResolvedValue(0),
+  IP_REGISTRATION_LIMIT: 25,
+  GLOBAL_CLIENT_LIMIT: 10000,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockReturnValue({ allowed: true, remaining: 5, resetMs: 0 }),
+}));
+
+vi.mock("@/lib/auth", () => ({ isAuthEnabled: vi.fn().mockReturnValue(false) }));
+vi.mock("@/lib/api-auth", () => ({ getCurrentUserId: vi.fn().mockReturnValue(null) }));
+
+import { countClientsByIpInWindow, countTotalClients } from "@/lib/oauth-store";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { POST } from "@/app/oauth/register/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRegisterRequest(body: Record<string, unknown>, ip = "1.2.3.4"): NextRequest {
+  return new NextRequest("http://localhost/oauth/register", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = { redirect_uris: ["http://localhost:3000/cb"] };
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /oauth/register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkRateLimit).mockReturnValue({ allowed: true, remaining: 5, resetMs: 0 });
+    vi.mocked(countClientsByIpInWindow).mockResolvedValue(0);
+    vi.mocked(countTotalClients).mockResolvedValue(0);
+  });
+
+  it("returns 201 with client_id on valid registration", async () => {
+    const res = await POST(makeRegisterRequest(validBody));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.client_id).toBeTruthy();
+    expect(body.redirect_uris).toEqual(["http://localhost:3000/cb"]);
+  });
+
+  it("returns 429 when in-memory rate limit exceeded", async () => {
+    vi.mocked(checkRateLimit).mockReturnValue({
+      allowed: false,
+      remaining: 0,
+      resetMs: Date.now() + 1000,
+      retryAfterMs: 1000,
+    });
+    const res = await POST(makeRegisterRequest(validBody));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("rate_limited");
+  });
+
+  it("returns 429 when per-IP 24h DB limit exceeded", async () => {
+    vi.mocked(countClientsByIpInWindow).mockResolvedValue(25);
+    const res = await POST(makeRegisterRequest(validBody));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("rate_limited");
+  });
+
+  it("returns 503 when global client limit reached", async () => {
+    vi.mocked(countTotalClients).mockResolvedValue(10000);
+    const res = await POST(makeRegisterRequest(validBody));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("server_error");
+  });
+
+  it("returns 400 when redirect_uris missing", async () => {
+    const res = await POST(makeRegisterRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when redirect_uri uses plain HTTP (non-localhost)", async () => {
+    const res = await POST(makeRegisterRequest({ redirect_uris: ["http://evil.com/cb"] }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -1,8 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
-import { registerClient, type ClientRegistration } from "@/lib/oauth-store";
+import {
+  registerClient,
+  countClientsByIpInWindow,
+  countTotalClients,
+  IP_REGISTRATION_LIMIT,
+  GLOBAL_CLIENT_LIMIT,
+  type ClientRegistration,
+} from "@/lib/oauth-store";
 import { getCurrentUserId } from "@/lib/api-auth";
 import { isAuthEnabled } from "@/lib/auth";
 import { checkRateLimit } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
 
 /**
  * POST /oauth/register
@@ -23,15 +31,33 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  // DB-persisted per-IP limit (24h rolling window, survives deploys)
+  const ipCount = await countClientsByIpInWindow(ip);
+  if (ipCount >= IP_REGISTRATION_LIMIT) {
+    logger.warn("oauth-registration-rejected", { reason: "ip_limit", ip, ipCount });
+    return NextResponse.json(
+      { error: "rate_limited", error_description: "too many registrations from this IP" },
+      { status: 429 }
+    );
+  }
+
+  // Global client cap
+  const totalCount = await countTotalClients();
+  if (totalCount >= GLOBAL_CLIENT_LIMIT) {
+    logger.warn("oauth-registration-rejected", { reason: "global_limit", totalCount });
+    return NextResponse.json(
+      { error: "server_error", error_description: "registration capacity reached" },
+      { status: 503 }
+    );
+  }
+
   // Require an authenticated session when auth is enabled
-  if (isAuthEnabled()) {
-    const userId = getCurrentUserId(request);
-    if (!userId) {
-      return NextResponse.json(
-        { error: "invalid_client_metadata", error_description: "registration requires an authenticated session" },
-        { status: 401 }
-      );
-    }
+  const userId = isAuthEnabled() ? getCurrentUserId(request) : null;
+  if (isAuthEnabled() && !userId) {
+    return NextResponse.json(
+      { error: "invalid_client_metadata", error_description: "registration requires an authenticated session" },
+      { status: 401 }
+    );
   }
 
   let body: Record<string, unknown>;
@@ -118,7 +144,8 @@ export async function POST(request: NextRequest) {
     registered_at: Date.now(),
   };
 
-  await registerClient(registration);
+  await registerClient(registration, { ip, userId: userId ?? undefined });
+  logger.info("oauth-client-registered", { clientId, ip, userId: userId ?? null });
 
   return NextResponse.json(
     {

--- a/src/lib/oauth-store.ts
+++ b/src/lib/oauth-store.ts
@@ -7,6 +7,13 @@
 
 import { prisma } from "@/lib/db";
 
+const IP_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const IP_REGISTRATION_LIMIT = 25;
+export const GLOBAL_CLIENT_LIMIT = parseInt(
+  process.env.OAUTH_GLOBAL_CLIENT_LIMIT ?? "10000",
+  10
+);
+
 export interface ClientRegistration {
   client_id: string;
   client_name: string;
@@ -28,7 +35,8 @@ export interface AuthCode {
 
 /** Register an OAuth client (persisted to database). */
 export async function registerClient(
-  registration: ClientRegistration
+  registration: ClientRegistration,
+  options?: { ip?: string; userId?: string }
 ): Promise<void> {
   await prisma.oAuthClient.create({
     data: {
@@ -36,8 +44,25 @@ export async function registerClient(
       clientName: registration.client_name,
       redirectUris: JSON.stringify(registration.redirect_uris),
       grantTypes: JSON.stringify(registration.grant_types),
+      registrationIp: options?.ip ?? null,
+      registrationUserId: options?.userId ?? null,
     },
   });
+}
+
+/** Count clients registered from this IP within the rolling 24h window. */
+export async function countClientsByIpInWindow(ip: string): Promise<number> {
+  return prisma.oAuthClient.count({
+    where: {
+      registrationIp: ip,
+      createdAt: { gte: new Date(Date.now() - IP_WINDOW_MS) },
+    },
+  });
+}
+
+/** Count total OAuth clients (for global capacity cap). */
+export async function countTotalClients(): Promise<number> {
+  return prisma.oAuthClient.count();
 }
 
 /** Look up a registered OAuth client by ID. Returns null if not found. */


### PR DESCRIPTION
## Summary

OAuth client registration endpoint has no database-persisted limits. The in-memory rate limiter resets on deploy, allowing attackers to drain the database with unlimited registrations across deploys or by using multiple IPs.

This PR adds three layers of defense:
1. **DB-persisted per-IP limit**: 25 registrations per IP per 24h (survives deploys)
2. **Global client cap**: 10,000 clients max (configurable via `OAUTH_GLOBAL_CLIENT_LIMIT`)
3. **Audit trail**: IP and userId stored on each client + structured logging

## Changes

### Schema & Migration
- Added `registrationIp` and `registrationUserId` nullable fields to `OAuthClient`
- Created migration with compound index on `(registrationIp, createdAt)` for efficient rolling-window queries
- Both columns null for existing rows; no breaking changes

### Store Functions
- `countClientsByIpInWindow(ip)`: Query clients from same IP in last 24h
- `countTotalClients()`: Query total active clients
- Extended `registerClient()` to optionally accept `ip` and `userId` parameters

### Route Handler
- Check per-IP 24h count before registration (returns 429 if at limit)
- Check global client count before registration (returns 503 if at limit)
- Store IP and userId with each new client
- Emit structured `logger.warn` on rejection, `logger.info` on success

### Tests
- New test file: `src/__tests__/oauth-register-route.test.ts`
- 6 test cases: happy path (201), in-memory rate limit (429), per-IP DB limit (429), global limit (503), missing/invalid URIs (400)

## Validation

- **Tests**: 828 passed (74 test files), including 6 new tests for registration limits
- **Lint**: 0 errors in modified files, 0 new warnings
- **Build**: ✅ Passing

## Edge Cases Handled

- Missing `x-forwarded-for` header (IP set to `"anon"`) — limit applies equally
- `OAUTH_GLOBAL_CLIENT_LIMIT` env var not set — defaults to 10,000
- `DISABLE_RATE_LIMIT=true` — in-memory check skipped, DB checks always run (intended)
- Exactly at limit (25 per-IP) → rejected; at 24 → allowed

## Fixes #576
