### PR TITLE
fix: scope StructureNode lookup to projectId in hashnode-publish

### DIFF
--- a/src/lib/controllers/hashnode-publish.ts
+++ b/src/lib/controllers/hashnode-publish.ts
@@ -40,8 +40,8 @@ export class HashnodePublishController {
         if (titleOverride) {
             title = titleOverride;
         } else if (nodeId) {
-            const node = await prisma.structureNode.findUnique({
-                where: { id: nodeId },
+            const node = await prisma.structureNode.findFirst({
+                where: { id: nodeId, projectId },
                 select: { title: true },
             });
             if (!node) throw new Error(`Node not found: ${nodeId}`);


### PR DESCRIPTION
## Summary

- Switches `findUnique` to `findFirst` at `src/lib/controllers/hashnode-publish.ts:43` and adds `projectId` to the where clause
- Prevents an authenticated user from leaking another project's node title by supplying a foreign `nodeId` during Hashnode publish
- Mirrors the established pattern already used in `src/lib/controllers/structure.ts:263-265`

## Test plan

- [ ] Publish a node using the correct project's `nodeId` — succeeds as before
- [ ] Attempt to publish with a `nodeId` from a different project — should throw "Node not found"

Fixes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)