### PR TITLE
fix: scope StructureNode lookup by projectId in Hashnode publish

### DIFF
--- a/src/__tests__/hashnode-publish-controller.test.ts
+++ b/src/__tests__/hashnode-publish-controller.test.ts
@@ -222,6 +222,20 @@ describe("HashnodePublishController", () => {
             const requestBody = JSON.parse(fetchCall[1].body);
             expect(requestBody.variables.input.title).toBe("My Article");
         });
+
+        it("throws when nodeId belongs to a different project", async () => {
+            const otherProject = await testPrisma.project.create({
+                data: { title: "Other Project", author: "Other Author" },
+            });
+            const node = await testPrisma.structureNode.create({
+                data: { projectId: otherProject.id, type: "SCENE", title: "Secret Title", orderIndex: 0 },
+            });
+            mockFetchDraft();
+
+            await expect(
+                HashnodePublishController.publish(projectId, null, { nodeId: node.id })
+            ).rejects.toThrow(`Node not found: ${node.id}`);
+        });
     });
 
     describe("tags and canonical URL", () => {

--- a/src/lib/controllers/hashnode-publish.ts
+++ b/src/lib/controllers/hashnode-publish.ts
@@ -40,8 +40,8 @@ export class HashnodePublishController {
         if (titleOverride) {
             title = titleOverride;
         } else if (nodeId) {
-            const node = await prisma.structureNode.findUnique({
-                where: { id: nodeId },
+            const node = await prisma.structureNode.findFirst({
+                where: { id: nodeId, projectId },
                 select: { title: true },
             });
             if (!node) throw new Error(`Node not found: ${nodeId}`);


### PR DESCRIPTION
## Summary

- Switches `findUnique({ where: { id: nodeId } })` to `findFirst({ where: { id: nodeId, projectId } })` in the Hashnode publish controller
- Prevents an authenticated user with write access to project A from leaking the title of a node belonging to project B by supplying a cross-project `nodeId`
- Mirrors the established pattern in `src/lib/controllers/structure.ts:263-265`

## Test plan

- [ ] Verify publishing with a valid `nodeId` belonging to the current project works as before
- [ ] Verify that supplying a `nodeId` from a different project returns "Node not found" rather than that node's title
- [ ] `bun run typecheck` passes (no new errors)

Fixes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)