### PR TITLE
fix: restrict oauth_redirect to allowlisted app paths

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -5,6 +5,7 @@ import {
     createSessionToken,
     verifySessionToken,
     isAuthEnabled,
+    isAllowedRedirect,
 } from "@/lib/auth";
 
 describe("auth utilities", () => {
@@ -133,6 +134,45 @@ describe("isAuthEnabled", () => {
         delete process.env.API_TOKEN;
         process.env.GOOGLE_CLIENT_ID = "test-client-id";
         expect(isAuthEnabled()).toBe(true);
+    });
+});
+
+describe("isAllowedRedirect", () => {
+    it("allows known user-facing routes", () => {
+        expect(isAllowedRedirect("/")).toBe(true);
+        expect(isAllowedRedirect("/settings")).toBe(true);
+        expect(isAllowedRedirect("/settings/profile")).toBe(true);
+        expect(isAllowedRedirect("/setup")).toBe(true);
+        expect(isAllowedRedirect("/project/abc123")).toBe(true);
+        expect(isAllowedRedirect("/project/abc123/timeline")).toBe(true);
+        expect(isAllowedRedirect("/read/abc123")).toBe(true);
+        expect(isAllowedRedirect("/universe")).toBe(true);
+        expect(isAllowedRedirect("/universe/abc123")).toBe(true);
+    });
+
+    it("allows query strings on known routes", () => {
+        expect(isAllowedRedirect("/settings?tab=billing")).toBe(true);
+        expect(isAllowedRedirect("/project/abc123?view=graph")).toBe(true);
+    });
+
+    it("blocks cross-origin and protocol injection attempts", () => {
+        expect(isAllowedRedirect("//evil.com")).toBe(false);
+        expect(isAllowedRedirect("javascript:alert(1)")).toBe(false);
+        expect(isAllowedRedirect("/\\evil.com")).toBe(false);
+        expect(isAllowedRedirect("/path?redirect=http://evil.com")).toBe(false);
+    });
+
+    it("blocks unknown app paths", () => {
+        expect(isAllowedRedirect("/api/admin")).toBe(false);
+        expect(isAllowedRedirect("/login")).toBe(false);
+        expect(isAllowedRedirect("/dmca")).toBe(false);
+        expect(isAllowedRedirect("/privacy")).toBe(false);
+    });
+
+    it("blocks empty and non-string values", () => {
+        expect(isAllowedRedirect("")).toBe(false);
+        expect(isAllowedRedirect(null as unknown as string)).toBe(false);
+        expect(isAllowedRedirect(undefined as unknown as string)).toBe(false);
     });
 });
 

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -5,6 +5,7 @@ import {
     SESSION_COOKIE_NAME,
     SESSION_MAX_AGE,
     createSessionToken,
+    isAllowedRedirect,
 } from "@/lib/auth";
 import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
@@ -115,9 +116,7 @@ export async function GET(request: NextRequest) {
         // Use GOOGLE_REDIRECT_URI origin to avoid Docker container hostname in redirect
         const baseUrl = new URL(redirectUri).origin;
         const redirectTo = request.cookies.get("oauth_redirect")?.value;
-        const destination = redirectTo && redirectTo.startsWith("/") && !redirectTo.startsWith("//")
-            ? redirectTo
-            : "/";
+        const destination = redirectTo && isAllowedRedirect(redirectTo) ? redirectTo : "/";
         const response = NextResponse.redirect(new URL(destination, baseUrl));
         // Clear the OAuth state and redirect cookies
         response.cookies.set("oauth_redirect", "", {

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { google } from "googleapis";
 import crypto from "crypto";
 import { env } from "@/lib/env";
+import { isAllowedRedirect } from "@/lib/auth";
 import { logger } from "@/lib/logger";
 
 /**
@@ -48,7 +49,7 @@ export async function GET(request: NextRequest) {
         // Persist the post-login redirect destination (e.g. /read/...) so the
         // callback can send the user back where they came from.
         const from = request.nextUrl.searchParams.get("from");
-        if (from && from.startsWith("/") && !from.startsWith("//")) {
+        if (from && isAllowedRedirect(from)) {
             response.cookies.set("oauth_redirect", from, {
                 httpOnly: true,
                 secure: process.env.NODE_ENV === "production",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -124,3 +124,28 @@ export function safeEqual(a: string, b: string): boolean {
 export function isAuthEnabled(): boolean {
     return !!(env.API_TOKEN || env.GOOGLE_CLIENT_ID);
 }
+
+/**
+ * Validate that a post-login redirect destination is an allowed app path.
+ * Accepts only same-origin paths that match known user-facing routes.
+ * Rejects cross-origin attempts, protocol injections, and unknown paths.
+ */
+export function isAllowedRedirect(path: string): boolean {
+    if (!path || typeof path !== "string") return false;
+    if (!path.startsWith("/") || path.startsWith("//")) return false;
+    if (path.includes("\\")) return false;
+
+    const [pathname] = path.split("?");
+    if (pathname.includes(":")) return false; // blocks javascript: and http:
+
+    const ALLOWED_PATTERNS = [
+        /^\/$/,
+        /^\/settings(\/.*)?$/,
+        /^\/setup(\/.*)?$/,
+        /^\/project\/[a-zA-Z0-9_-]+(\/.*)?$/,
+        /^\/read\/[a-zA-Z0-9_-]+(\/.*)?$/,
+        /^\/universe(\/[a-zA-Z0-9_-]+(\/.*)?)?$/,
+    ];
+
+    return ALLOWED_PATTERNS.some((re) => re.test(pathname));
+}


### PR DESCRIPTION
## Summary

- Adds `isAllowedRedirect()` to `src/lib/auth.ts` — validates post-login redirect destinations against a regex allowlist of known user-facing routes
- Replaces the weak `startsWith("/")` check in `src/app/api/auth/google/route.ts` and callback with `isAllowedRedirect()`
- Adds unit tests covering allowed routes, query strings, cross-origin/protocol injection attempts, and unknown paths

## Test plan

- [x] `bun test src/__tests__/auth.test.ts` — all 19 tests pass
- [ ] Manual: visit `/api/auth/google?from=/api/admin` → after OAuth should land on `/` not `/api/admin`
- [ ] Manual: visit `/api/auth/google?from=/settings` → should preserve redirect to `/settings`

Fixes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)