### PR TITLE
fix: return 409 instead of 500 on concurrent project-share unique constraint

### DIFF
--- a/src/__tests__/share-route-p2002.test.ts
+++ b/src/__tests__/share-route-p2002.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Prisma } from "@prisma/client";
+import { NextRequest } from "next/server";
 
 // ─── Mocks ────────────────────────────────────────────────────────────
 
@@ -23,44 +24,6 @@ vi.mock("@/lib/logger", () => ({
   logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
-vi.mock("next/server", () => {
-  class MockResp {
-    status: number;
-    _data: unknown;
-    constructor(body: unknown, init?: { status?: number }) {
-      this._data = body;
-      this.status = init?.status || 200;
-    }
-    async json() { return this._data; }
-  }
-  return {
-    NextRequest: class {
-      private _body: unknown;
-      headers: Map<string, string>;
-      nextUrl: { searchParams: URLSearchParams };
-      constructor(url: string, init?: { body?: string; headers?: Record<string, string> }) {
-        this._body = init?.body ? JSON.parse(init.body) : null;
-        this.headers = new Map(Object.entries(init?.headers ?? {}));
-        this.nextUrl = { searchParams: new URL(url, "http://localhost").searchParams };
-      }
-      get(key: string) { return this.headers.get(key) ?? null; }
-      async json() { return this._body; }
-    },
-    NextResponse: Object.assign(
-      function (body: unknown, init?: { status?: number }) {
-        return new MockResp(body, init);
-      } as object,
-      {
-        json: (data: unknown, init?: { status?: number }) => {
-          const r = new MockResp(data, init);
-          r._data = data;
-          return r;
-        },
-      }
-    ),
-  };
-});
-
 // ─── Helpers ──────────────────────────────────────────────────────────
 
 import { prisma } from "@/lib/db";
@@ -71,10 +34,10 @@ const mockProjectShare = prisma.projectShare as {
 };
 
 function makeRequest(body: Record<string, unknown>) {
-  const { NextRequest } = require("next/server");
   return new NextRequest("http://localhost/api/projects/proj-1/share", {
+    method: "POST",
     body: JSON.stringify(body),
-    headers: { "x-user-id": "user-1" },
+    headers: { "x-user-id": "user-1", "content-type": "application/json" },
   });
 }
 

--- a/src/__tests__/share-route-p2002.test.ts
+++ b/src/__tests__/share-route-p2002.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Prisma } from "@prisma/client";
+
+// ─── Mocks ────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    projectShare: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  getCurrentUserId: vi.fn(() => "user-1"),
+  verifyProjectAccess: vi.fn(() =>
+    Promise.resolve({ authorized: true, project: { id: "proj-1", userId: "user-1" }, role: "OWNER" })
+  ),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("next/server", () => {
+  class MockResp {
+    status: number;
+    _data: unknown;
+    constructor(body: unknown, init?: { status?: number }) {
+      this._data = body;
+      this.status = init?.status || 200;
+    }
+    async json() { return this._data; }
+  }
+  return {
+    NextRequest: class {
+      private _body: unknown;
+      headers: Map<string, string>;
+      nextUrl: { searchParams: URLSearchParams };
+      constructor(url: string, init?: { body?: string; headers?: Record<string, string> }) {
+        this._body = init?.body ? JSON.parse(init.body) : null;
+        this.headers = new Map(Object.entries(init?.headers ?? {}));
+        this.nextUrl = { searchParams: new URL(url, "http://localhost").searchParams };
+      }
+      get(key: string) { return this.headers.get(key) ?? null; }
+      async json() { return this._body; }
+    },
+    NextResponse: Object.assign(
+      function (body: unknown, init?: { status?: number }) {
+        return new MockResp(body, init);
+      } as object,
+      {
+        json: (data: unknown, init?: { status?: number }) => {
+          const r = new MockResp(data, init);
+          r._data = data;
+          return r;
+        },
+      }
+    ),
+  };
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+import { prisma } from "@/lib/db";
+
+const mockProjectShare = prisma.projectShare as {
+  findUnique: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+};
+
+function makeRequest(body: Record<string, unknown>) {
+  const { NextRequest } = require("next/server");
+  return new NextRequest("http://localhost/api/projects/proj-1/share", {
+    body: JSON.stringify(body),
+    headers: { "x-user-id": "user-1" },
+  });
+}
+
+const routeCtx = { params: Promise.resolve({ id: "proj-1" }) };
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("POST /api/projects/[id]/share — P2002 race condition", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProjectShare.findUnique.mockResolvedValue(null);
+  });
+
+  it("returns 409 when concurrent create hits unique constraint (P2002)", async () => {
+    const { POST } = await import("@/app/api/projects/[id]/share/route");
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`projectId`,`email`)",
+      { code: "P2002", clientVersion: "5.0.0", meta: {} }
+    );
+    mockProjectShare.create.mockRejectedValue(p2002);
+
+    const res = await POST(makeRequest({ email: "race@example.com" }) as never, routeCtx);
+
+    expect((res as any).status).toBe(409);
+    const body = await (res as any).json();
+    expect(body.error).toMatch(/already/i);
+  });
+
+  it("returns 500 for non-P2002 database errors", async () => {
+    const { POST } = await import("@/app/api/projects/[id]/share/route");
+    mockProjectShare.create.mockRejectedValue(new Error("DB connection lost"));
+
+    const res = await POST(makeRequest({ email: "other@example.com" }) as never, routeCtx);
+
+    expect((res as any).status).toBe(500);
+    const body = await (res as any).json();
+    expect(body.error).toMatch(/internal server error/i);
+  });
+});

--- a/src/app/api/projects/[id]/share/route.ts
+++ b/src/app/api/projects/[id]/share/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db";
 import { getCurrentUserId, verifyProjectAccess } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
@@ -72,6 +73,15 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
 
     return NextResponse.json(share, { status: 201 });
   } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "Already shared with this email" },
+        { status: 409 }
+      );
+    }
     logger.error("POST /api/projects/[id]/share error", error);
     return NextResponse.json(
       { error: "Internal server error" },


### PR DESCRIPTION
## Summary

- Adds `import { Prisma } from "@prisma/client"` to the share route
- Catches `PrismaClientKnownRequestError` with `code === "P2002"` in the POST handler's catch block, returning 409 instead of falling through to the generic 500
- Adds a unit test (`src/__tests__/share-route-p2002.test.ts`) covering the P2002 → 409 path and confirming non-P2002 errors still return 500

## Test plan

- [ ] `docker compose exec app npm run test:run` — all existing sharing tests pass, new P2002 unit tests pass
- [ ] POST with new email → 201
- [ ] POST with duplicate email (sequential) → 409 (existing guard)
- [ ] POST concurrent race (simulated by mocking create to throw P2002) → 409 (new fix)
- [ ] POST with generic DB error → 500 (unchanged)

Fixes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)