### PR TITLE
fix: eliminate TOCTOU race condition in sample project onboarding

### DIFF
--- a/prisma/migrations/20260515_unique_sample_project_per_user/migration.sql
+++ b/prisma/migrations/20260515_unique_sample_project_per_user/migration.sql
@@ -1,0 +1,11 @@
+-- Deduplication: remove extra sample projects per user, keeping the oldest one
+DELETE FROM "Project"
+WHERE "isSample" = true
+  AND id NOT IN (
+    SELECT MIN(id) FROM "Project" WHERE "isSample" = true GROUP BY "userId"
+  );
+
+-- Add partial unique index to prevent duplicate sample projects per user
+CREATE UNIQUE INDEX "unique_sample_project_per_user"
+  ON "Project" ("userId")
+  WHERE "isSample" = true AND "userId" IS NOT NULL;

--- a/src/app/api/onboarding/sample/route.ts
+++ b/src/app/api/onboarding/sample/route.ts
@@ -1,27 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
 import { getCurrentUserId } from "@/lib/api-auth";
 import { importProjectJson } from "@/lib/import-json";
 import { logger } from "@/lib/logger";
 import sampleData from "@/data/sherlock-sample.json";
 
-// POST /api/onboarding/sample - Create sample project for new users
-// Only creates the sample if the user has 0 projects.
+// POST /api/onboarding/sample - Create sample project for new users.
+// The partial unique index on Project(userId) WHERE isSample = true prevents
+// duplicates at the database level, eliminating the TOCTOU race condition.
 export async function POST(request: NextRequest) {
   try {
     const userId = getCurrentUserId(request);
-
-    // Check if user already has projects
-    const projectCount = await prisma.project.count({
-      where: userId ? { userId } : {},
-    });
-
-    if (projectCount > 0) {
-      return NextResponse.json(
-        { message: "User already has projects" },
-        { status: 200 }
-      );
-    }
 
     const { projectId } = await importProjectJson(sampleData, {
       userId: userId ?? undefined,
@@ -30,6 +18,14 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ projectId }, { status: 201 });
   } catch (error) {
+    // P2002 = unique constraint violation: another concurrent request already
+    // created the sample project for this user.
+    if ((error as { code?: string }).code === "P2002") {
+      return NextResponse.json(
+        { message: "User already has projects" },
+        { status: 200 }
+      );
+    }
     logger.error("POST /api/onboarding/sample error", error);
     return NextResponse.json(
       { error: "Failed to create sample project" },


### PR DESCRIPTION
## Summary

- Removes the non-atomic `prisma.project.count()` + create guard in `POST /api/onboarding/sample` that allowed concurrent requests to both pass and create duplicate sample projects
- Adds a partial unique index `Project(userId) WHERE isSample = true` via SQL migration to enforce the constraint at the database level
- Catches Prisma `P2002` (unique constraint violation) and returns `200` so concurrent requests resolve cleanly

## Test plan

- [ ] Run `npx prisma migrate dev --name unique_sample_project_per_user` to apply the migration
- [ ] Verify `bun run type-check` passes
- [ ] Verify `bun run lint` passes
- [ ] Manual: open two browser tabs and trigger onboarding simultaneously — confirm only one sample project is created

Fixes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)