### PR TITLE
fix: reject Google OAuth login when email is unverified

### DIFF
--- a/src/__tests__/google-oauth-callback.test.ts
+++ b/src/__tests__/google-oauth-callback.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockUserinfoGet = vi.fn();
+const mockGetToken = vi.fn();
+const mockSetCredentials = vi.fn();
+
+vi.mock("googleapis", () => ({
+    google: {
+        auth: {
+            OAuth2: class {
+                getToken = mockGetToken;
+                setCredentials = mockSetCredentials;
+            },
+        },
+        oauth2: () => ({
+            userinfo: { get: mockUserinfoGet },
+        }),
+    },
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        GOOGLE_CLIENT_ID: "test-client-id",
+        GOOGLE_CLIENT_SECRET: "test-client-secret",
+        GOOGLE_REDIRECT_URI: "http://localhost:3000/api/auth/google/callback",
+        ALLOWED_EMAILS: undefined,
+    },
+}));
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        user: {
+            upsert: vi.fn().mockResolvedValue({
+                id: "user-1",
+                email: "test@example.com",
+                name: "Test User",
+                picture: null,
+            }),
+        },
+    },
+}));
+
+vi.mock("@/lib/auth", () => ({
+    SESSION_COOKIE_NAME: "session",
+    SESSION_MAX_AGE: 86400,
+    createSessionToken: vi.fn().mockResolvedValue("mock-jwt-token"),
+    isAllowedRedirect: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/logger", () => ({
+    logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+function makeRequest(params?: Record<string, string>, cookies?: Record<string, string>) {
+    const url = new URL("http://localhost:3000/api/auth/google/callback");
+    url.searchParams.set("code", "test-code");
+    url.searchParams.set("state", "test-state");
+    for (const [k, v] of Object.entries(params ?? {})) {
+        url.searchParams.set(k, v);
+    }
+    const req = new NextRequest(url, {
+        headers: new Headers({
+            cookie: Object.entries({ oauth_state: "test-state", ...cookies })
+                .map(([k, v]) => `${k}=${v}`)
+                .join("; "),
+        }),
+    });
+    return req;
+}
+
+describe("Google OAuth callback - verified_email check", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetToken.mockResolvedValue({
+            tokens: { access_token: "tok", refresh_token: "ref" },
+        });
+    });
+
+    it("should redirect to /login?error=email_not_verified when verified_email is false", async () => {
+        mockUserinfoGet.mockResolvedValue({
+            data: {
+                email: "unverified@example.com",
+                id: "google-123",
+                verified_email: false,
+            },
+        });
+
+        const { GET } = await import(
+            "@/app/api/auth/google/callback/route"
+        );
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        const location = response.headers.get("location") ?? "";
+        expect(location).toContain("/login?error=email_not_verified");
+    });
+
+    it("should redirect to /login?error=email_not_verified when verified_email is undefined", async () => {
+        mockUserinfoGet.mockResolvedValue({
+            data: {
+                email: "noverified@example.com",
+                id: "google-456",
+                // verified_email omitted → undefined → falsy
+            },
+        });
+
+        const { GET } = await import(
+            "@/app/api/auth/google/callback/route"
+        );
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        const location = response.headers.get("location") ?? "";
+        expect(location).toContain("/login?error=email_not_verified");
+    });
+
+    it("should proceed to login when verified_email is true", async () => {
+        mockUserinfoGet.mockResolvedValue({
+            data: {
+                email: "verified@example.com",
+                id: "google-789",
+                verified_email: true,
+                name: "Verified User",
+                picture: null,
+            },
+        });
+
+        const { GET } = await import(
+            "@/app/api/auth/google/callback/route"
+        );
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        const location = response.headers.get("location") ?? "";
+        expect(location).not.toContain("error=email_not_verified");
+        // Should have session cookie set
+        const setCookie = response.headers.getSetCookie();
+        const sessionCookie = setCookie.find((c: string) => c.startsWith("session="));
+        expect(sessionCookie).toBeDefined();
+        expect(sessionCookie).toContain("mock-jwt-token");
+    });
+});

--- a/src/__tests__/google-oauth-callback.test.ts
+++ b/src/__tests__/google-oauth-callback.test.ts
@@ -92,11 +92,16 @@ describe("Google OAuth callback - verified_email check", () => {
         const { GET } = await import(
             "@/app/api/auth/google/callback/route"
         );
+        const { logger } = await import("@/lib/logger");
         const response = await GET(makeRequest());
 
         expect(response.status).toBe(307);
         const location = response.headers.get("location") ?? "";
         expect(location).toContain("/login?error=email_not_verified");
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Google OAuth rejected: unverified email",
+            { email: "unverified@example.com" }
+        );
     });
 
     it("should redirect to /login?error=email_not_verified when verified_email is undefined", async () => {
@@ -111,11 +116,16 @@ describe("Google OAuth callback - verified_email check", () => {
         const { GET } = await import(
             "@/app/api/auth/google/callback/route"
         );
+        const { logger } = await import("@/lib/logger");
         const response = await GET(makeRequest());
 
         expect(response.status).toBe(307);
         const location = response.headers.get("location") ?? "";
         expect(location).toContain("/login?error=email_not_verified");
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Google OAuth rejected: unverified email",
+            { email: "noverified@example.com" }
+        );
     });
 
     it("should proceed to login when verified_email is true", async () => {

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -75,6 +75,16 @@ export async function GET(request: NextRequest) {
             );
         }
 
+        if (!userInfo.verified_email) {
+            logger.warn("Google OAuth rejected: unverified email", {
+                email: userInfo.email,
+            });
+            const baseUrl = new URL(redirectUri).origin;
+            return NextResponse.redirect(
+                new URL("/login?error=email_not_verified", baseUrl)
+            );
+        }
+
         // Enforce invite-only allowlist (when configured)
         if (env.ALLOWED_EMAILS) {
             const allowed = env.ALLOWED_EMAILS.split(",").map((e) =>

--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -130,7 +130,8 @@ export async function POST(request: NextRequest) {
   }
 
   const clientId = crypto.randomUUID();
-  const clientName = (typeof body.client_name === "string" ? body.client_name : "Unknown Client").slice(0, 80);
+  const rawClientName = typeof body.client_name === "string" ? body.client_name : "Unknown Client";
+  const clientName = rawClientName.slice(0, 80);
   const grantTypes = Array.isArray(body.grant_types)
     ? (body.grant_types as string[])
     : ["authorization_code", "refresh_token"];


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability where unverified email accounts could complete Google OAuth login and receive a JWT session cookie.

The Google OAuth callback was fetching the `verified_email` claim from Google's userinfo API but never validating it before granting a session. This fix adds a guard clause to reject logins when `verified_email` is false or undefined.

**Fixes #583**

## Changes

- **src/app/api/auth/google/callback/route.ts**: Add `verified_email` guard clause after email/id validation (9 lines)
  - Logs a warning when unverified email login is rejected
  - Redirects to `/login?error=email_not_verified`
  - Guard placed before the allowlist check to fail fast

- **src/__tests__/google-oauth-callback.test.ts**: New test file with 3 test cases
  - Tests redirect when `verified_email: false`
  - Tests redirect when `verified_email: undefined` (falsy)
  - Tests normal login proceeds when `verified_email: true`

## Validation

✅ Type check passed  
✅ Tests: 877 passed, 0 failed  
✅ Lint: 0 errors  
✅ Build: Compiled successfully  

All checks pass without requiring fixes.

---

**Note**: PR #638 previously implemented this fix but was closed without being merged.