### PR TITLE
fix: replace naive SQL semicolon split with context-aware tokenizer

### DIFF
--- a/scripts/__tests__/migrate.test.ts
+++ b/scripts/__tests__/migrate.test.ts
@@ -1,5 +1,101 @@
 import { spawnSync } from 'child_process';
 import { join } from 'path';
+import { splitSqlStatements } from '../sql-tokenizer.mjs';
+
+describe('splitSqlStatements()', () => {
+  it('splits simple semicolon-separated statements', () => {
+    const sql = 'CREATE TABLE a (id INT); CREATE TABLE b (id INT);';
+    expect(splitSqlStatements(sql)).toEqual([
+      'CREATE TABLE a (id INT)',
+      'CREATE TABLE b (id INT)',
+    ]);
+  });
+
+  it('does NOT split on semicolons inside dollar-quoted blocks', () => {
+    const sql = `
+      CREATE FUNCTION foo() RETURNS void AS $$
+        BEGIN
+          RAISE NOTICE 'hello; world';
+        END;
+      $$ LANGUAGE plpgsql;
+    `;
+    const stmts = splitSqlStatements(sql);
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]).toContain('$$');
+  });
+
+  it('does NOT split on semicolons inside single-quoted strings', () => {
+    const sql = `INSERT INTO t (col) VALUES ('value;with;semis');`;
+    const stmts = splitSqlStatements(sql);
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]).toContain("'value;with;semis'");
+  });
+
+  it('handles escaped single quotes (repeated quote)', () => {
+    const sql = `INSERT INTO t (col) VALUES ('it''s fine; really');`;
+    const stmts = splitSqlStatements(sql);
+    expect(stmts).toHaveLength(1);
+  });
+
+  it('strips single-line comments', () => {
+    const sql = `-- this is a comment\nCREATE TABLE a (id INT);`;
+    const stmts = splitSqlStatements(sql);
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]).not.toContain('--');
+  });
+
+  it('strips block comments', () => {
+    const sql = `/* drop everything */ CREATE TABLE a (id INT);`;
+    const stmts = splitSqlStatements(sql);
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]).not.toContain('/*');
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(splitSqlStatements('')).toEqual([]);
+  });
+
+  it('returns empty array for whitespace-only input', () => {
+    expect(splitSqlStatements('   \n\t  ')).toEqual([]);
+  });
+
+  it('handles trailing content with no closing semicolon', () => {
+    const sql = 'SELECT 1;\nSELECT 2';
+    expect(splitSqlStatements(sql)).toEqual(['SELECT 1', 'SELECT 2']);
+  });
+
+  it('handles $1 parameter placeholders without treating them as dollar-quotes', () => {
+    // tagEnd === -1 when no second $ follows immediately after $1
+    const sql = `SELECT $1; SELECT $2;`;
+    const stmts = splitSqlStatements(sql);
+    expect(stmts).toHaveLength(2);
+  });
+
+  it('throws on unclosed block comment', () => {
+    const sql = `CREATE TABLE a (id INT); /* unclosed comment`;
+    expect(() => splitSqlStatements(sql)).toThrow('Unclosed block comment');
+  });
+
+  it('throws on unclosed single-quoted string', () => {
+    const sql = `INSERT INTO t VALUES ('unclosed`;
+    expect(() => splitSqlStatements(sql)).toThrow('Unclosed single-quoted string');
+  });
+
+  it('throws on unclosed dollar-quote tag', () => {
+    const sql = `CREATE FUNCTION foo() RETURNS void AS $$ BEGIN -- missing close`;
+    expect(() => splitSqlStatements(sql)).toThrow('Unclosed dollar-quote tag');
+  });
+
+  it('handles multiple statements with comments between them', () => {
+    const sql = `
+      CREATE TABLE a (id INT);
+      -- a comment between statements
+      CREATE TABLE b (id INT);
+      /* block comment */ CREATE TABLE c (id INT);
+    `;
+    expect(splitSqlStatements(sql)).toHaveLength(3);
+  });
+});
 
 describe('migrate.mjs — DATABASE_URL guard', () => {
   it('exits with code 0 and emits a warning when DATABASE_URL is not set', () => {

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -103,8 +103,7 @@ async function migrate() {
     // and single-quoted strings that may contain semicolons.
     const statements = splitSqlStatements(sql);
 
-    for (let i = 0; i < statements.length; i++) {
-      const stmt = statements[i];
+    for (const [i, stmt] of statements.entries()) {
       try {
         await prisma.$executeRawUnsafe(stmt);
       } catch (e) {

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -26,6 +26,62 @@ if (!connectionString) {
 const adapter = new PrismaPg({ connectionString });
 const prisma = new PrismaClient({ adapter });
 
+function splitSqlStatements(sql) {
+  const statements = [];
+  let current = '';
+  let i = 0;
+
+  while (i < sql.length) {
+    // Dollar-quote: $tag$ ... $tag$
+    if (sql[i] === '$') {
+      const tagEnd = sql.indexOf('$', i + 1);
+      if (tagEnd !== -1) {
+        const tag = sql.slice(i, tagEnd + 1);
+        const closeIdx = sql.indexOf(tag, tagEnd + 1);
+        if (closeIdx !== -1) {
+          current += sql.slice(i, closeIdx + tag.length);
+          i = closeIdx + tag.length;
+          continue;
+        }
+      }
+    }
+    // Single-quoted string
+    if (sql[i] === "'") {
+      current += sql[i++];
+      while (i < sql.length) {
+        if (sql[i] === "'" && sql[i + 1] === "'") { current += "''"; i += 2; }
+        else if (sql[i] === "'") { current += sql[i++]; break; }
+        else current += sql[i++];
+      }
+      continue;
+    }
+    // Single-line comment (strip)
+    if (sql[i] === '-' && sql[i + 1] === '-') {
+      while (i < sql.length && sql[i] !== '\n') i++;
+      continue;
+    }
+    // Block comment (strip)
+    if (sql[i] === '/' && sql[i + 1] === '*') {
+      i += 2;
+      while (i < sql.length && !(sql[i] === '*' && sql[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    // Statement separator
+    if (sql[i] === ';') {
+      const stmt = current.trim();
+      if (stmt.length > 0) statements.push(stmt);
+      current = '';
+      i++;
+      continue;
+    }
+    current += sql[i++];
+  }
+  const stmt = current.trim();
+  if (stmt.length > 0) statements.push(stmt);
+  return statements;
+}
+
 async function ensureMigrationsTable() {
   await prisma.$executeRawUnsafe(`
     CREATE TABLE IF NOT EXISTS "_prisma_migrations" (
@@ -96,11 +152,10 @@ async function migrate() {
     console.log(`  apply ${dir}`);
 
     // Split into individual statements for Prisma's $executeRawUnsafe
-    // which only supports single statements at a time
-    const statements = sql
-      .split(';')
-      .map((s) => s.replace(/--[^\n]*/g, '').trim())
-      .filter((s) => s.length > 0);
+    // which only supports single statements at a time.
+    // Uses a context-aware tokenizer to handle dollar-quoted strings ($$...$$)
+    // and single-quoted strings that may contain semicolons.
+    const statements = splitSqlStatements(sql);
 
     for (let i = 0; i < statements.length; i++) {
       const stmt = statements[i];

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -13,6 +13,7 @@ import { PrismaPg } from '@prisma/adapter-pg';
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { createHash, randomUUID } from 'crypto';
 import { join } from 'path';
+import { splitSqlStatements } from './sql-tokenizer.mjs';
 
 // Use DATABASE_URL (pooler) — our script splits SQL into single statements
 // which work fine through PgBouncer transaction mode.
@@ -25,62 +26,6 @@ if (!connectionString) {
 }
 const adapter = new PrismaPg({ connectionString });
 const prisma = new PrismaClient({ adapter });
-
-function splitSqlStatements(sql) {
-  const statements = [];
-  let current = '';
-  let i = 0;
-
-  while (i < sql.length) {
-    // Dollar-quote: $tag$ ... $tag$
-    if (sql[i] === '$') {
-      const tagEnd = sql.indexOf('$', i + 1);
-      if (tagEnd !== -1) {
-        const tag = sql.slice(i, tagEnd + 1);
-        const closeIdx = sql.indexOf(tag, tagEnd + 1);
-        if (closeIdx !== -1) {
-          current += sql.slice(i, closeIdx + tag.length);
-          i = closeIdx + tag.length;
-          continue;
-        }
-      }
-    }
-    // Single-quoted string
-    if (sql[i] === "'") {
-      current += sql[i++];
-      while (i < sql.length) {
-        if (sql[i] === "'" && sql[i + 1] === "'") { current += "''"; i += 2; }
-        else if (sql[i] === "'") { current += sql[i++]; break; }
-        else current += sql[i++];
-      }
-      continue;
-    }
-    // Single-line comment (strip)
-    if (sql[i] === '-' && sql[i + 1] === '-') {
-      while (i < sql.length && sql[i] !== '\n') i++;
-      continue;
-    }
-    // Block comment (strip)
-    if (sql[i] === '/' && sql[i + 1] === '*') {
-      i += 2;
-      while (i < sql.length && !(sql[i] === '*' && sql[i + 1] === '/')) i++;
-      i += 2;
-      continue;
-    }
-    // Statement separator
-    if (sql[i] === ';') {
-      const stmt = current.trim();
-      if (stmt.length > 0) statements.push(stmt);
-      current = '';
-      i++;
-      continue;
-    }
-    current += sql[i++];
-  }
-  const stmt = current.trim();
-  if (stmt.length > 0) statements.push(stmt);
-  return statements;
-}
 
 async function ensureMigrationsTable() {
   await prisma.$executeRawUnsafe(`
@@ -128,6 +73,7 @@ async function migrate() {
 
     const sqlPath = join(migrationsDir, dir, 'migration.sql');
     if (!existsSync(sqlPath)) {
+      console.warn(`  warn  ${dir} — no migration.sql found, skipping`);
       continue;
     }
 

--- a/scripts/sql-tokenizer.mjs
+++ b/scripts/sql-tokenizer.mjs
@@ -1,0 +1,91 @@
+/**
+ * Split a SQL string into individual statements.
+ *
+ * Handles:
+ *   - Dollar-quoted strings ($tag$...$tag$) — preserved across semicolons
+ *   - Single-quoted strings ('...') with escaped quotes ('')
+ *   - Single-line comments (--...) — stripped from output
+ *   - Block comments (/* ... *\/) — stripped from output
+ *
+ * Note: PostgreSQL E'...\'' escape strings are NOT handled — Prisma does not emit them.
+ *
+ * Throws if the SQL contains an unclosed block comment, unclosed single-quoted string,
+ * or an unclosed dollar-quote tag (indicating malformed SQL that would silently corrupt
+ * or partially apply a migration).
+ *
+ * @param {string} sql - Raw SQL file contents
+ * @returns {string[]} Non-empty, trimmed SQL statements (no trailing semicolon)
+ */
+export function splitSqlStatements(sql) {
+  const statements = [];
+  let current = '';
+  let i = 0;
+
+  while (i < sql.length) {
+    // Dollar-quote: $tag$ ... $tag$ where tag is empty ($$) or a valid identifier
+    if (sql[i] === '$') {
+      const tagEnd = sql.indexOf('$', i + 1);
+      if (tagEnd !== -1) {
+        const tag = sql.slice(i, tagEnd + 1);
+        // Only treat as dollar-quote if the tag content is a valid SQL identifier
+        // (empty for $$, or letters/digits/underscore only). This prevents $1 parameter
+        // placeholders from being mistaken for dollar-quote openers.
+        const tagContent = tag.slice(1, -1);
+        const isValidTag = tagContent === '' || /^[A-Za-z_][A-Za-z0-9_]*$/.test(tagContent);
+        if (isValidTag) {
+          const closeIdx = sql.indexOf(tag, tagEnd + 1);
+          if (closeIdx !== -1) {
+            current += sql.slice(i, closeIdx + tag.length);
+            i = closeIdx + tag.length;
+            continue;
+          }
+          throw new Error(`Unclosed dollar-quote tag "${tag}" in SQL starting at position ${i}`);
+        }
+      }
+    }
+    // Single-quoted string ('...' with standard SQL '' escaping only).
+    // Note: PostgreSQL E'...\'' escape strings are NOT handled — Prisma does not emit them.
+    if (sql[i] === "'") {
+      const strStart = i;
+      current += sql[i++];
+      let closed = false;
+      while (i < sql.length) {
+        if (sql[i] === "'" && sql[i + 1] === "'") { current += "''"; i += 2; }
+        else if (sql[i] === "'") { current += sql[i++]; closed = true; break; }
+        else current += sql[i++];
+      }
+      if (!closed) {
+        throw new Error(`Unclosed single-quoted string in SQL starting at position ${strStart}`);
+      }
+      continue;
+    }
+    // Single-line comment (strip)
+    if (sql[i] === '-' && sql[i + 1] === '-') {
+      while (i < sql.length && sql[i] !== '\n') i++;
+      continue;
+    }
+    // Block comment (strip)
+    if (sql[i] === '/' && sql[i + 1] === '*') {
+      const commentStart = i;
+      i += 2;
+      while (i < sql.length && !(sql[i] === '*' && sql[i + 1] === '/')) i++;
+      if (i >= sql.length) {
+        throw new Error(`Unclosed block comment in SQL starting at position ${commentStart}`);
+      }
+      i += 2;
+      continue;
+    }
+    // Statement separator
+    if (sql[i] === ';') {
+      const stmt = current.trim();
+      if (stmt.length > 0) statements.push(stmt);
+      current = '';
+      i++;
+      continue;
+    }
+    current += sql[i++];
+  }
+  const stmt = current.trim();
+  if (stmt.length > 0) statements.push(stmt);
+  return statements;
+}

--- a/scripts/sql-tokenizer.mjs
+++ b/scripts/sql-tokenizer.mjs
@@ -43,8 +43,7 @@ export function splitSqlStatements(sql) {
         }
       }
     }
-    // Single-quoted string ('...' with standard SQL '' escaping only).
-    // Note: PostgreSQL E'...\'' escape strings are NOT handled — Prisma does not emit them.
+    // Single-quoted string ('...' with standard SQL '' escaping only)
     if (sql[i] === "'") {
       const strStart = i;
       current += sql[i++];


### PR DESCRIPTION
## Summary

- Adds `splitSqlStatements()` to `scripts/migrate.mjs` — a context-aware SQL tokenizer
- Handles dollar-quoted strings (`$$...$$`, `$tag$...$tag$`), single-quoted strings, single-line comments, and block comments
- Replaces the naive `sql.split(';')` that would incorrectly fragment statements containing embedded semicolons

## Test plan

- [x] `node --check scripts/migrate.mjs` passes (syntax valid)
- [ ] Run existing migrations against a test DB — confirm no regressions
- [ ] Manually test with a migration containing `DO $$ BEGIN ... END $$;` with embedded semicolons

Fixes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)