### PR TITLE
fix: handle curl timeout in staging smoke workflow

### DIFF
--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -34,7 +34,7 @@ jobs:
           # Check if auth already works — skip reconfiguration if so
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
             -H "Authorization: Bearer $API_TOKEN" \
-            https://word-coach-annie-staging.up.railway.app/api/projects?limit=1)
+            https://word-coach-annie-staging.up.railway.app/api/projects?limit=1) || STATUS="000"
           if [ "$STATUS" = "200" ]; then
             echo "✓ API token auth already works on staging — no reconfiguration needed"
             exit 0
@@ -70,7 +70,7 @@ jobs:
           echo "Polling staging health every ${INTERVAL}s (up to ${MAX_ATTEMPTS} attempts / 10 min)..."
           for i in $(seq 1 $MAX_ATTEMPTS); do
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
-              https://word-coach-annie-staging.up.railway.app/api/health)
+              https://word-coach-annie-staging.up.railway.app/api/health) || STATUS="000"
             if [ "$STATUS" = "200" ]; then
               echo "✓ Staging health check passed after $((i * INTERVAL))s"
               break
@@ -87,7 +87,7 @@ jobs:
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
             -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" \
-            https://word-coach-annie-staging.up.railway.app/api/projects?limit=1)
+            https://word-coach-annie-staging.up.railway.app/api/projects?limit=1) || STATUS="000"
           if [ "$STATUS" != "200" ]; then
             echo "::error::API token auth still failing after deploy (HTTP $STATUS)"
             echo "::error::Check that API_TOKEN in Railway staging matches the GitHub secret"

--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -130,8 +130,7 @@ export async function POST(request: NextRequest) {
   }
 
   const clientId = crypto.randomUUID();
-  const rawClientName = typeof body.client_name === "string" ? body.client_name : "Unknown Client";
-  const clientName = rawClientName.slice(0, 80);
+  const clientName = (typeof body.client_name === "string" ? body.client_name : "Unknown Client").slice(0, 80);
   const grantTypes = Array.isArray(body.grant_types)
     ? (body.grant_types as string[])
     : ["authorization_code", "refresh_token"];


### PR DESCRIPTION
## Summary

The staging pipeline fails when curl times out (exit code 28) because `bash -e` kills the script before the retry/fallback logic can run.

## Problem

Three curl commands in `.github/workflows/staging-smoke.yml` that check HTTP status codes have a `--max-time 15` timeout but no error handling. When curl times out:
1. Curl exits with code 28
2. `bash -e` propagates this as a step failure
3. Retry/fallback logic is never reached, causing the entire workflow to fail

## Solution

Add `|| STATUS="000"` to the three curl commands (lines 37, 73, 90) to capture timeout errors as a sentinel value that the downstream `if` checks handle correctly. This mirrors the existing pattern used by the production health check at line 238.

## Changes

- **Line 37**: Add fallback to initial auth check curl
- **Line 73**: Add fallback to health poll loop curl  
- **Line 90**: Add fallback to post-deploy auth check curl

All three changes follow the same pattern: `curl ... || STATUS="000"`

## Validation

- ✅ YAML syntax validated
- ✅ TypeScript check passed
- ✅ Lint passed (0 new errors)
- ✅ Next.js build succeeded

Fixes #645