### PR TITLE
fix: copy sql-tokenizer.mjs into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY --from=builder /app/.skills ./.skills
 
 # Migration runner + migration SQL files
 COPY --from=builder /app/scripts/migrate.mjs ./scripts/migrate.mjs
+COPY --from=builder /app/scripts/sql-tokenizer.mjs ./scripts/sql-tokenizer.mjs
 COPY --from=builder /app/prisma/migrations ./prisma/migrations
 
 USER nextjs

--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -130,7 +130,8 @@ export async function POST(request: NextRequest) {
   }
 
   const clientId = crypto.randomUUID();
-  const clientName = (typeof body.client_name === "string" ? body.client_name : "Unknown Client").slice(0, 80);
+  const rawName = typeof body.client_name === "string" ? body.client_name : "Unknown Client";
+  const clientName = rawName.slice(0, 80);
   const grantTypes = Array.isArray(body.grant_types)
     ? (body.grant_types as string[])
     : ["authorization_code", "refresh_token"];


### PR DESCRIPTION
## Summary

- `scripts/sql-tokenizer.mjs` was introduced in #643 as a runtime import of `scripts/migrate.mjs`, but the Dockerfile was never updated to copy it into the production image
- Every deploy since `a13b403` crashed immediately: `node scripts/migrate.mjs` threw `Cannot find module './sql-tokenizer.mjs'`, exiting non-zero before `node server.js` could run
- Fix: add one `COPY` line for `sql-tokenizer.mjs` alongside `migrate.mjs` in the Dockerfile runner stage

## Test plan

- [ ] CI passes (lint, type-check, tests, build)
- [ ] Staging deploy succeeds — `curl https://word-coach-annie-staging.up.railway.app/api/health` returns `{"status":"ok",...}`
- [ ] Staging E2E smoke tests pass and production deploy proceeds

Fixes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)