### PR TITLE
fix: replace CSP form-action wildcard with 'self' on OAuth pages

### DIFF
--- a/src/__tests__/oauth-authorize-route.test.ts
+++ b/src/__tests__/oauth-authorize-route.test.ts
@@ -154,6 +154,29 @@ describe("GET /oauth/authorize CSP headers", () => {
   });
 });
 
+describe("POST /oauth/authorize CSP headers", () => {
+  it("sets form-action 'self' (not wildcard) on code page", async () => {
+    const req = makePostRequest(
+      {
+        action: "approve",
+        csrf_token: "token-abc",
+        response_type: "code",
+        client_id: "c1",
+        redirect_uri: "http://localhost/callback",
+        code_challenge: "abc",
+        code_challenge_method: "S256",
+        state: "xyz",
+      },
+      "session=valid-session; csrf_oauth=token-abc",
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).not.toContain("form-action *");
+  });
+});
+
 describe("POST /oauth/authorize approve happy-path", () => {
   it("renders code page on approve when CSRF and session are valid (localhost redirect)", async () => {
     const req = makePostRequest(

--- a/src/__tests__/oauth-authorize-route.test.ts
+++ b/src/__tests__/oauth-authorize-route.test.ts
@@ -143,6 +143,17 @@ describe("GET /oauth/authorize CSRF token generation", () => {
   });
 });
 
+describe("GET /oauth/authorize CSP headers", () => {
+  it("sets form-action 'self' (not wildcard) on consent page", async () => {
+    const req = makeGetRequest();
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).not.toContain("form-action *");
+  });
+});
+
 describe("POST /oauth/authorize approve happy-path", () => {
   it("renders code page on approve when CSRF and session are valid (localhost redirect)", async () => {
     const req = makePostRequest(

--- a/src/app/oauth/authorize/route.ts
+++ b/src/app/oauth/authorize/route.ts
@@ -333,7 +333,7 @@ function renderCodePage(code: string, redirectUrl: string): NextResponse {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      "Content-Security-Policy": "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; form-action *",
+      "Content-Security-Policy": "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; form-action 'self'",
       "Cache-Control": "no-store",
     },
   });
@@ -437,7 +437,7 @@ function renderConsentPage(
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      "Content-Security-Policy": "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; form-action *",
+      "Content-Security-Policy": "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; form-action 'self'",
       "Cache-Control": "no-store",
     },
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -71,8 +71,11 @@ function applyRateLimit(
 
     // Allow E2E / CI environments to bypass rate limiting (not honoured in production)
     if (process.env.DISABLE_RATE_LIMIT === "true") {
-        if (process.env.NODE_ENV !== "production") return null;
-        console.error("[middleware] DISABLE_RATE_LIMIT=true is ignored in production");
+        if (process.env.NODE_ENV === "production") {
+            console.error("[middleware] DISABLE_RATE_LIMIT=true is ignored in production");
+        } else {
+            return null;
+        }
     }
 
     const method = request.method;


### PR DESCRIPTION
## Summary

This PR fixes a security misconfiguration where the OAuth consent and code pages were overriding the Content Security Policy (CSP) with a permissive `form-action *` directive, weakening the form-action protection established in the global policy.

**Issue**: Fixes #571

## Problem

Both `renderConsentPage()` and `renderCodePage()` in `src/app/oauth/authorize/route.ts` set an inline CSP header with `form-action *`, which overrides the stricter `form-action 'self'` defined in the global policy (`next.config.ts`). The wildcard allows form submissions to any URL, which is unnecessary since:

- The consent form only posts to `/oauth/authorize` (self-origin)
- The code page has no form elements
- The page is protected by `Cache-Control: no-store` to prevent service-worker caching

## Changes

| File | Action | Details |
|------|--------|---------|
| `src/app/oauth/authorize/route.ts` | Update | Replace `form-action *` with `form-action 'self'` in `renderCodePage()` (line 336) |
| `src/app/oauth/authorize/route.ts` | Update | Replace `form-action *` with `form-action 'self'` in `renderConsentPage()` (line 440) |
| `src/__tests__/oauth-authorize-route.test.ts` | Add | CSP header assertions to validate `form-action 'self'` is set |

## Validation

✅ Type check: No errors  
✅ Lint: 0 errors, 141 pre-existing warnings  
✅ Build: Next.js compiled successfully  
✅ Tests: New CSP header assertions pass

---

**Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>**