### PR TITLE
fix: remove PWA service worker caching of authenticated API routes (MED-17)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -115,23 +115,6 @@ const pwaConfig = withPWA({
     skipWaiting: true,
     clientsClaim: true,
     runtimeCaching: [
-      // Network-first for API routes: fresh data when online, cached when offline
-      {
-        urlPattern: /^\/api\/.*$/i,
-        handler: "NetworkFirst",
-        method: "GET",
-        options: {
-          cacheName: "api-cache",
-          expiration: {
-            maxEntries: 64,
-            maxAgeSeconds: 24 * 60 * 60,
-          },
-          cacheableResponse: {
-            statuses: [0, 200],
-          },
-          networkTimeoutSeconds: 5,
-        },
-      },
       // Cache Google Fonts stylesheets
       {
         urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
@@ -163,7 +146,9 @@ const pwaConfig = withPWA({
         },
       },
       // Include the default caches (static assets, images, etc.)
-      ...runtimeCaching,
+      // Filter out the built-in `apis` entry — authenticated API responses
+      // must not be cached on shared devices (MED-17).
+      ...runtimeCaching.filter((entry) => entry.options?.cacheName !== "apis"),
     ],
   },
 })(nextConfig);

--- a/next.config.ts
+++ b/next.config.ts
@@ -148,6 +148,8 @@ const pwaConfig = withPWA({
       // Include the default caches (static assets, images, etc.)
       // Filter out the built-in `apis` entry — authenticated API responses
       // must not be cached on shared devices (MED-17).
+      // NOTE: "apis" is the cacheName used by @ducanh2912/next-pwa ≥10.x.
+      // Verify this string if upgrading the package.
       ...runtimeCaching.filter((entry) => entry.options?.cacheName !== "apis"),
     ],
   },


### PR DESCRIPTION
## Summary

- Removes the explicit `NetworkFirst` cache rule for all `/api/*` GET requests (24h TTL, `next.config.ts:117-134`)
- Filters the built-in `apis` cache entry from the `@ducanh2912/next-pwa` default `runtimeCaching` spread, which covered the same routes
- Offline API calls now fall through to the `/_offline` document fallback instead of serving potentially stale, wrong-user data

## Security Impact

**Before**: Authenticated API responses (e.g. `/api/projects`, `/api/auth/me`) could be served from a 24h cache to a different user on a shared device.
**After**: API responses are never cached by the service worker.

Note: Previous PR #663 addressed this but was closed without merging. This PR applies the same fix.

## Test plan

- [ ] `bun run type-check` — no errors
- [ ] `bun run lint` — 0 errors
- [ ] `bun test` — all tests pass
- [ ] `bun run build` — verify `grep -c "api-cache" public/sw.js` returns 0
- [ ] Manual: go offline in DevTools → navigate to authenticated page → confirm `/_offline` fallback renders (not stale data)

Fixes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)