### PR TITLE
fix: remove PII from public GitHub feedback issues

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -574,6 +574,8 @@ Submit feedback (creates a GitHub issue if `GITHUB_FEEDBACK_TOKEN` is configured
 
 **Body**: `{ type: "bug|feature|other", message: string, email?: string, context?: { url?, userAgent?, screenSize? } }`
 
+> **Privacy**: `email` is accepted for interface compatibility but is never embedded in the public GitHub issue body. The `url` is reduced to pathname-only (query params and hash are stripped) before embedding.
+
 ---
 
 ## AI Inline

--- a/src/__tests__/feedback-route.test.ts
+++ b/src/__tests__/feedback-route.test.ts
@@ -114,17 +114,21 @@ describe("POST /api/feedback", () => {
       json: async () => ({ html_url: "https://github.com/testowner/testrepo/issues/42" }),
     });
 
-    await POST(makeRequest({
+    const res = await POST(makeRequest({
       type: "bug",
       message: "Something broke",
       email: "private@example.com",
-      context: { url: "http://localhost:3000/project/abc?token=secret", userAgent: "TestBrowser/1.0" },
+      context: { url: "http://localhost:3000/project/abc?token=secret#myFragment", userAgent: "TestBrowser/1.0" },
     }));
+    expect(res.status).toBe(201);
 
     const [, options] = mockFetch.mock.calls[0];
     const body = JSON.parse(options.body);
     expect(body.body).not.toContain("private@example.com");
+    // Email must NOT appear in the public issue body
     expect(body.body).not.toContain("secret");
+    // URL should be pathname-only — query params and hash stripped
+    expect(body.body).not.toContain("myFragment");
     expect(body.body).toContain("/project/abc");
   });
 
@@ -290,5 +294,28 @@ describe("POST /api/feedback", () => {
     const [, issueOpts] = mockFetch.mock.calls[0];
     const issueBody = JSON.parse(issueOpts.body);
     expect(issueBody.body).not.toContain("### Screenshot");
+  });
+
+  it("omits Page line when context URL is a relative path (unparseable by URL constructor)", async () => {
+    process.env.GITHUB_FEEDBACK_TOKEN = "ghp_test_token";
+    process.env.GITHUB_FEEDBACK_REPO = "testowner/testrepo";
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ html_url: "https://github.com/testowner/testrepo/issues/55" }),
+    });
+
+    const res = await POST(makeRequest({
+      type: "bug",
+      message: "Relative URL test",
+      context: { url: "/project/abc" }, // relative — new URL() will throw, catch returns undefined
+    }));
+
+    expect(res.status).toBe(201);
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    // Page line should be omitted gracefully — no crash on invalid URL
+    expect(body.body).not.toContain("**Page:**");
+    expect(body.body).toContain("Relative URL test");
   });
 });

--- a/src/__tests__/feedback-route.test.ts
+++ b/src/__tests__/feedback-route.test.ts
@@ -94,10 +94,38 @@ describe("POST /api/feedback", () => {
     const body = JSON.parse(options.body);
     expect(body.title).toContain("Bug:");
     expect(body.title).toContain("editor crashes");
-    expect(body.body).toContain("tester@example.com");
+    // Email must NOT appear in the public issue body
+    expect(body.body).not.toContain("tester@example.com");
+    // User-agent and screen size are kept for debugging utility
     expect(body.body).toContain("TestBrowser/1.0");
     expect(body.body).toContain("1920x1080");
+    // URL should be pathname-only
+    expect(body.body).toContain("/project/abc");
+    expect(body.body).not.toContain("http://localhost:3000");
     expect(body.labels).toContain("bug");
+  });
+
+  it("does not include reporter email in GitHub issue body", async () => {
+    process.env.GITHUB_FEEDBACK_TOKEN = "ghp_test_token";
+    process.env.GITHUB_FEEDBACK_REPO = "testowner/testrepo";
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ html_url: "https://github.com/testowner/testrepo/issues/42" }),
+    });
+
+    await POST(makeRequest({
+      type: "bug",
+      message: "Something broke",
+      email: "private@example.com",
+      context: { url: "http://localhost:3000/project/abc?token=secret", userAgent: "TestBrowser/1.0" },
+    }));
+
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.body).not.toContain("private@example.com");
+    expect(body.body).not.toContain("secret");
+    expect(body.body).toContain("/project/abc");
   });
 
   it("returns 502 when GitHub API fails", async () => {

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -152,14 +152,21 @@ export async function POST(request: NextRequest) {
 
   // Sanitize and escape user-provided fields before embedding in GitHub Markdown
   const safeMessage = sanitizeInput(body.message.trim());
-  const safeEmail = body.email ? escapeMarkdown(sanitizeInput(body.email)) : undefined;
-  const safeUrl = body.context?.url ? escapeMarkdown(body.context.url) : undefined;
+  // Extract only the pathname — drop origin, query params, and hash
+  const safeUrl = body.context?.url
+    ? (() => {
+        try {
+          return escapeMarkdown(new URL(body.context.url!).pathname);
+        } catch {
+          return undefined;
+        }
+      })()
+    : undefined;
   const safeUserAgent = body.context?.userAgent ? escapeMarkdown(body.context.userAgent) : undefined;
   const safeScreenSize = body.context?.screenSize ? escapeMarkdown(body.context.screenSize) : undefined;
 
   // Build issue body with app context
   const contextLines: string[] = [];
-  if (safeEmail) contextLines.push(`**Reporter:** ${safeEmail}`);
   if (safeUrl) contextLines.push(`**Page:** ${safeUrl}`);
   if (safeUserAgent)
     contextLines.push(`**Browser:** ${safeUserAgent}`);

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -156,7 +156,7 @@ export async function POST(request: NextRequest) {
   const safeUrl = body.context?.url
     ? (() => {
         try {
-          return escapeMarkdown(new URL(body.context.url!).pathname);
+          return escapeMarkdown(new URL(body.context.url).pathname);
         } catch {
           return undefined;
         }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -71,11 +71,8 @@ function applyRateLimit(
 
     // Allow E2E / CI environments to bypass rate limiting (not honoured in production)
     if (process.env.DISABLE_RATE_LIMIT === "true") {
-        if (process.env.NODE_ENV === "production") {
-            console.error("[middleware] DISABLE_RATE_LIMIT=true is ignored in production");
-        } else {
-            return null;
-        }
+        if (process.env.NODE_ENV !== "production") return null;
+        console.error("[middleware] DISABLE_RATE_LIMIT=true is ignored in production");
     }
 
     const method = request.method;


### PR DESCRIPTION
## Summary

Removes PII (email address and full page URL) from public GitHub feedback issues created by the `/api/feedback` endpoint.

The feedback route was automatically posting the reporter's email and full page URL (including query parameters and hash) to a public GitHub repository. Email is auto-populated from the user's auth session without explicit user consent, and URLs may contain sensitive parameters.

## Changes

- **`src/app/api/feedback/route.ts`**
  - Extract only the pathname from feedback URLs (drop origin, query params, hash)
  - Remove reporter email from GitHub issue body entirely
  - Wrap URL parsing in try/catch to handle invalid URLs gracefully

- **`src/__tests__/feedback-route.test.ts`**
  - Updated assertions to verify email is NOT in issue body
  - Added assertions to verify URL is pathname-only
  - Added dedicated test for PII redaction behavior

## Testing

All validation passed:
- ✅ Type check: 0 errors
- ✅ Lint: 0 errors (141 pre-existing warnings)
- ✅ Tests: 932 passed across 83 test files
- ✅ Build: Compiled successfully

## What's Preserved

User-agent and screen size remain in issue body—these are genuine debugging signals and not individually identifying.

Screenshot upload mechanism is unchanged. Users have explicit consent for that channel.

Fixes #569