### PR TITLE
fix: remove authMethod field from /api/auth/me response

### DIFF
--- a/e2e/feedback.spec.ts
+++ b/e2e/feedback.spec.ts
@@ -4,7 +4,6 @@ import { test, expect, Page } from '@playwright/test'
 
 const MOCK_AUTH_USER = {
   authenticated: true,
-  authMethod: 'google',
   user: {
     userId: 'test-user-1',
     email: 'tester@example.com',

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -21,7 +21,6 @@ export async function GET(request: NextRequest) {
     if (session) {
         return NextResponse.json({
             authenticated: true,
-            authMethod: "google",
             user: {
                 userId: session.userId,
                 email: session.email,
@@ -38,7 +37,6 @@ export async function GET(request: NextRequest) {
         if (cookie === expected) {
             return NextResponse.json({
                 authenticated: true,
-                authMethod: "api_token",
                 user: null,
             });
         }

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -11,7 +11,6 @@ export interface AuthUser {
 
 export interface AuthState {
     authenticated: boolean;
-    authMethod: "google" | "api_token" | null;
     user: AuthUser | null;
     loading: boolean;
     logout: () => Promise<void>;
@@ -20,7 +19,6 @@ export interface AuthState {
 
 export function useAuth(): AuthState {
     const [authenticated, setAuthenticated] = useState(false);
-    const [authMethod, setAuthMethod] = useState<"google" | "api_token" | null>(null);
     const [user, setUser] = useState<AuthUser | null>(null);
     const [loading, setLoading] = useState(true);
 
@@ -30,16 +28,13 @@ export function useAuth(): AuthState {
             if (res.ok) {
                 const data = await res.json();
                 setAuthenticated(data.authenticated);
-                setAuthMethod(data.authMethod || null);
                 setUser(data.user || null);
             } else {
                 setAuthenticated(false);
-                setAuthMethod(null);
                 setUser(null);
             }
         } catch {
             setAuthenticated(false);
-            setAuthMethod(null);
             setUser(null);
         } finally {
             setLoading(false);
@@ -49,7 +44,6 @@ export function useAuth(): AuthState {
     const logout = useCallback(async () => {
         await fetch("/api/auth/logout", { method: "POST" });
         setAuthenticated(false);
-        setAuthMethod(null);
         setUser(null);
         window.location.href = "/login";
     }, []);
@@ -58,5 +52,5 @@ export function useAuth(): AuthState {
         refresh();
     }, [refresh]);
 
-    return { authenticated, authMethod, user, loading, logout, refresh };
+    return { authenticated, user, loading, logout, refresh };
 }


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where the `/api/auth/me` endpoint unconditionally discloses the authentication method (`"google"` or `"api_token"`), leaking information about access patterns.

## Changes

- **`src/app/api/auth/me/route.ts`**: Removed `authMethod` field from both Google OAuth and API token response paths
- **`src/hooks/use-auth.ts`**: Removed `authMethod` field from `AuthState` interface and hook state; eliminated all `setAuthMethod` calls
- **`e2e/feedback.spec.ts`**: Updated mock auth response to match new shape without `authMethod`

## Investigation Findings

| Metric | Details |
|--------|---------|
| **Severity** | MEDIUM—leaks authentication method to any authenticated caller, no credentials exposed |
| **Root Cause** | Field was added during OAuth implementation but never consumed by frontend; provides zero UI value |
| **Impact** | 3 files modified, no architectural changes required |
| **Consumers** | Only `useAuth()` hook used in `user-menu.tsx`; already doesn't reference `authMethod` |

## Validation

✅ Type check: No errors  
✅ Lint: 0 errors (141 pre-existing warnings)  
✅ Build: Successfully compiled  
⚠️ Tests: Skipped (pre-existing infrastructure constraint—`TEST_DATABASE_URL` not configured)

All checks passed. No files modified during validation.

Fixes #567