### PR TITLE
fix: stop returning raw error.message in API route catch blocks

### DIFF
--- a/src/__tests__/annotations-route.test.ts
+++ b/src/__tests__/annotations-route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-auth", () => ({
+  getCurrentUserId: vi.fn(() => "user-1"),
+  verifyProjectReadAccessByNode: vi.fn(async () => ({ authorized: true })),
+  verifyProjectWriteAccessByNode: vi.fn(async () => ({ authorized: true })),
+}));
+
+vi.mock("@/lib/controllers/structure", () => ({
+  ANNOTATION_ERRORS: { CONTENT_REQUIRED: "Content is required" },
+  StructureController: {
+    addAnnotation: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/lib/sanitize-server", () => ({
+  sanitizeInput: vi.fn((s: string) => s),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    annotation: {
+      findMany: vi.fn(async () => []),
+    },
+  },
+}));
+
+import { StructureController, ANNOTATION_ERRORS } from "@/lib/controllers/structure";
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/nodes/node-1/annotations", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockParams(nodeId: string) {
+  return { params: Promise.resolve({ id: nodeId }) };
+}
+
+describe("POST /api/nodes/[id]/annotations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 with 'Content is required' when that validation error is thrown", async () => {
+    vi.mocked(StructureController.addAnnotation).mockRejectedValue(
+      new Error(ANNOTATION_ERRORS.CONTENT_REQUIRED)
+    );
+    const { POST } = await import("@/app/api/nodes/[id]/annotations/route");
+    const res = await POST(makePostRequest({ content: "" }), mockParams("node-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Content is required");
+  });
+
+  it("returns 500 with generic message for unexpected errors without leaking details", async () => {
+    vi.mocked(StructureController.addAnnotation).mockRejectedValue(
+      new Error("FATAL: relation \"annotations\" does not exist")
+    );
+    const { POST } = await import("@/app/api/nodes/[id]/annotations/route");
+    const res = await POST(makePostRequest({ content: "some note" }), mockParams("node-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe("Internal server error");
+    expect(body.error).not.toContain("relation");
+    expect(body.error).not.toContain("annotations");
+  });
+
+  it("does not leak internal error messages for non-Error throws", async () => {
+    vi.mocked(StructureController.addAnnotation).mockRejectedValue("raw string error");
+    const { POST } = await import("@/app/api/nodes/[id]/annotations/route");
+    const res = await POST(makePostRequest({ content: "note" }), mockParams("node-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe("Internal server error");
+  });
+});

--- a/src/__tests__/nodes-route.test.ts
+++ b/src/__tests__/nodes-route.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-auth", () => ({
+  getCurrentUserId: vi.fn(() => "user-1"),
+  verifyProjectReadAccess: vi.fn(async () => ({ authorized: true })),
+  verifyProjectWriteAccess: vi.fn(async () => ({ authorized: true })),
+}));
+
+vi.mock("@/lib/controllers/structure", () => ({
+  StructureController: {
+    getOutline: vi.fn(async () => []),
+    createNode: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { StructureController } from "@/lib/controllers/structure";
+
+// A valid body that passes NodeCreateSchema validation
+const validBody = { type: "CHAPTER", title: "Test Chapter" };
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/projects/proj-1/nodes", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockParams(projectId: string) {
+  return { params: Promise.resolve({ id: projectId }) };
+}
+
+describe("POST /api/projects/[id]/nodes - error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 with generic message for invalid type error without leaking enum values", async () => {
+    vi.mocked(StructureController.createNode).mockRejectedValue(
+      new Error("type must be one of: chapter, scene, beat")
+    );
+    const { POST } = await import("@/app/api/projects/[id]/nodes/route");
+    const res = await POST(makePostRequest(validBody), mockParams("proj-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid node type or status");
+    expect(body.error).not.toContain("chapter");
+    expect(body.error).not.toContain("scene");
+  });
+
+  it("returns 400 for status must be error without leaking internal values", async () => {
+    vi.mocked(StructureController.createNode).mockRejectedValue(
+      new Error("status must be one of: draft, published")
+    );
+    const { POST } = await import("@/app/api/projects/[id]/nodes/route");
+    const res = await POST(makePostRequest(validBody), mockParams("proj-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid node type or status");
+    expect(body.error).not.toContain("draft");
+  });
+
+  it("returns 400 for parent not found error", async () => {
+    vi.mocked(StructureController.createNode).mockRejectedValue(
+      new Error("Parent node not found")
+    );
+    const { POST } = await import("@/app/api/projects/[id]/nodes/route");
+    const res = await POST(makePostRequest(validBody), mockParams("proj-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Parent node not found");
+  });
+
+  it("returns 404 for project not found error", async () => {
+    vi.mocked(StructureController.createNode).mockRejectedValue(
+      new Error("Project not found")
+    );
+    const { POST } = await import("@/app/api/projects/[id]/nodes/route");
+    const res = await POST(makePostRequest(validBody), mockParams("missing-proj"));
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("Project not found");
+  });
+
+  it("returns 500 for unexpected errors without leaking internal details", async () => {
+    vi.mocked(StructureController.createNode).mockRejectedValue(
+      new Error("connection timeout to db-host-internal:5432")
+    );
+    const { POST } = await import("@/app/api/projects/[id]/nodes/route");
+    const res = await POST(makePostRequest(validBody), mockParams("proj-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe("Internal server error");
+    expect(body.error).not.toContain("db-host-internal");
+    expect(body.error).not.toContain("5432");
+  });
+});

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -30,9 +30,8 @@ export async function GET(request: NextRequest) {
     // Verify CSRF state parameter (cookie equality + HMAC signature)
     const stateParam = request.nextUrl.searchParams.get("state");
     const stateCookie = request.cookies.get("oauth_state")?.value;
-    const baseUrl = env.GOOGLE_REDIRECT_URI
-        ? new URL(env.GOOGLE_REDIRECT_URI).origin
-        : request.nextUrl.origin;
+    const redirectUri = env.GOOGLE_REDIRECT_URI;
+    const baseUrl = redirectUri ? new URL(redirectUri).origin : request.nextUrl.origin;
     if (!stateParam || !stateCookie || stateParam !== stateCookie) {
         return NextResponse.redirect(
             new URL("/login?error=invalid_state", baseUrl)
@@ -62,7 +61,6 @@ export async function GET(request: NextRequest) {
 
     const clientId = env.GOOGLE_CLIENT_ID;
     const clientSecret = env.GOOGLE_CLIENT_SECRET;
-    const redirectUri = env.GOOGLE_REDIRECT_URI;
 
     if (!clientId || !clientSecret || !redirectUri) {
         return NextResponse.json(

--- a/src/app/api/integrations/google-docs/export/route.ts
+++ b/src/app/api/integrations/google-docs/export/route.ts
@@ -33,7 +33,6 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(result);
     } catch (error) {
         logger.error('POST /api/integrations/google-docs/export error', error);
-        const message = error instanceof Error ? error.message : 'Export failed';
-        return NextResponse.json({ error: message }, { status: 500 });
+        return NextResponse.json({ error: 'Export failed' }, { status: 500 });
     }
 }

--- a/src/app/api/nodes/[id]/annotations/route.ts
+++ b/src/app/api/nodes/[id]/annotations/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { StructureController } from "@/lib/controllers/structure";
+import { ANNOTATION_ERRORS, StructureController } from "@/lib/controllers/structure";
 import { getCurrentUserId, verifyProjectReadAccessByNode, verifyProjectWriteAccessByNode } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 import { sanitizeInput } from "@/lib/sanitize-server";
@@ -55,9 +55,9 @@ export async function POST(
         return NextResponse.json(annotation, { status: 201 });
     } catch (error) {
         logger.error("Failed to create annotation", error);
-        const isContentRequired = error instanceof Error && error.message === "Content is required";
+        const isContentRequired = error instanceof Error && error.message === ANNOTATION_ERRORS.CONTENT_REQUIRED;
         return NextResponse.json(
-            { error: isContentRequired ? "Content is required" : "Internal server error" },
+            { error: isContentRequired ? ANNOTATION_ERRORS.CONTENT_REQUIRED : "Internal server error" },
             { status: isContentRequired ? 400 : 500 }
         );
     }

--- a/src/app/api/nodes/[id]/annotations/route.ts
+++ b/src/app/api/nodes/[id]/annotations/route.ts
@@ -55,10 +55,10 @@ export async function POST(
         return NextResponse.json(annotation, { status: 201 });
     } catch (error) {
         logger.error("Failed to create annotation", error);
-        const message = error instanceof Error ? error.message : "Internal server error";
+        const isContentRequired = error instanceof Error && error.message === "Content is required";
         return NextResponse.json(
-            { error: message },
-            { status: message === "Content is required" ? 400 : 500 }
+            { error: isContentRequired ? "Content is required" : "Internal server error" },
+            { status: isContentRequired ? 400 : 500 }
         );
     }
 }

--- a/src/app/api/projects/[id]/copy-world-object/route.ts
+++ b/src/app/api/projects/[id]/copy-world-object/route.ts
@@ -44,7 +44,7 @@ export async function POST(
     } catch (error) {
         logger.error("Failed to copy world object to project", error);
         return NextResponse.json(
-            { error: error instanceof Error ? error.message : "Internal server error" },
+            { error: "Internal server error" },
             { status: 500 }
         );
     }

--- a/src/app/api/projects/[id]/nodes/route.ts
+++ b/src/app/api/projects/[id]/nodes/route.ts
@@ -75,8 +75,11 @@ export async function POST(
     if (message.includes("Project not found")) {
       return NextResponse.json({ error: "Project not found" }, { status: 404 });
     }
-    if (message.includes("type must be") || message.includes("status must be") || message.includes("Parent node not found")) {
-      return NextResponse.json({ error: message }, { status: 400 });
+    if (message.includes("type must be") || message.includes("status must be")) {
+      return NextResponse.json({ error: "Invalid node type or status" }, { status: 400 });
+    }
+    if (message.includes("Parent node not found")) {
+      return NextResponse.json({ error: "Parent node not found" }, { status: 400 });
     }
     return NextResponse.json(
       { error: "Internal server error" },

--- a/src/app/api/universes/transfer-object/route.ts
+++ b/src/app/api/universes/transfer-object/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest) {
     } catch (error) {
         logger.error("Failed to transfer story object", error);
         return NextResponse.json(
-            { error: error instanceof Error ? error.message : "Internal server error" },
+            { error: "Internal server error" },
             { status: 500 }
         );
     }

--- a/src/lib/controllers/structure.ts
+++ b/src/lib/controllers/structure.ts
@@ -3,6 +3,10 @@ import { autoSnapshot } from "../../mcp/snapshot";
 import type { SceneBlock } from "@/lib/types";
 import { logger } from "@/lib/logger";
 
+export const ANNOTATION_ERRORS = {
+    CONTENT_REQUIRED: "Content is required",
+} as const;
+
 export interface OutlineNode {
     id: string;
     type: string;
@@ -339,7 +343,7 @@ export class StructureController {
     }
 
     static async addAnnotation(nodeId: string, content: string, range: string = "", selectedText: string | null = null) {
-        if (!content) throw new Error("Content is required");
+        if (!content) throw new Error(ANNOTATION_ERRORS.CONTENT_REQUIRED);
 
         // Explicit ID provided as a workaround for Prisma client not applying @default(cuid())
         // in this context; crypto.randomUUID() is cryptographically secure and globally unique.


### PR DESCRIPTION
## Summary

This fix addresses a security vulnerability where five API routes were exposing raw `error.message` values from Prisma and other internal libraries directly to HTTP clients. These messages can leak sensitive schema details like table names, column names, and constraint information.

## Changes

**Affected Routes:**
1. `src/app/api/universes/transfer-object/route.ts` — Always return "Internal server error"
2. `src/app/api/projects/[id]/copy-world-object/route.ts` — Always return "Internal server error"
3. `src/app/api/integrations/google-docs/export/route.ts` — Always return "Export failed"
4. `src/app/api/nodes/[id]/annotations/route.ts` — Only surface the safe domain error "Content is required" on 400; all other errors return "Internal server error"
5. `src/app/api/projects/[id]/nodes/route.ts` — Replace raw validation messages with safe hardcoded strings ("Invalid node type or status", "Parent node not found", "Project not found")

## Validation

- ✅ Type check passes (0 errors)
- ✅ Lint passes (0 new errors, 141 pre-existing warnings)
- ✅ Build succeeds
- ✅ All route handlers now follow the safe error pattern already used in other routes

Fixes #566