### PR TITLE
fix: validate JPEG data URL prefix and magic bytes in screenshot upload

### DIFF
--- a/src/__tests__/feedback-route.test.ts
+++ b/src/__tests__/feedback-route.test.ts
@@ -176,7 +176,8 @@ describe("POST /api/feedback", () => {
     process.env.GITHUB_FEEDBACK_TOKEN = "ghp_test_token";
     process.env.GITHUB_FEEDBACK_REPO = "testowner/testrepo";
 
-    const fakeBase64 = "iVBORw0KGgoAAAANSUhEUg==";
+    // FF D8 FF E0 ... — minimal valid JPEG header in base64
+    const fakeBase64 = "/9j/4AAQ";
     const fakeDataUrl = `data:image/jpeg;base64,${fakeBase64}`;
     const fakeAssetUrl =
       "https://github.com/user-attachments/assets/abc-123/feedback.jpg";
@@ -231,20 +232,7 @@ describe("POST /api/feedback", () => {
     process.env.GITHUB_FEEDBACK_TOKEN = "ghp_test_token";
     process.env.GITHUB_FEEDBACK_REPO = "testowner/testrepo";
 
-    // getRepoId succeeds
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ id: 12345 }),
-    });
-
-    // Screenshot upload fails
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      text: async () => "Internal Server Error",
-    });
-
-    // Issue creation succeeds
+    // Only issue creation — screenshot rejected by magic-byte check before any fetch
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -262,12 +250,63 @@ describe("POST /api/feedback", () => {
 
     expect(res.status).toBe(201);
 
-    // Issue should still be created, just without screenshot
-    // Last fetch call is the issue creation
     const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
     const issueBody = JSON.parse(lastCall[1].body);
     expect(issueBody.body).not.toContain("### Screenshot");
     expect(issueBody.body).toContain("Bug with failed screenshot");
+  });
+
+  it("rejects screenshot with non-JPEG magic bytes (PNG data)", async () => {
+    process.env.GITHUB_FEEDBACK_TOKEN = "ghp_test_token";
+    process.env.GITHUB_FEEDBACK_REPO = "testowner/testrepo";
+
+    // Issue creation succeeds — screenshot silently dropped
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ html_url: "https://github.com/testowner/testrepo/issues/999" }),
+    });
+
+    // PNG base64 — starts with 89 50 4E 47 (iVBOR…)
+    const pngBase64 = "iVBORw0KGgoAAAANSUhEUg==";
+    const res = await POST(
+      makeRequest({
+        type: "bug",
+        message: "PNG screenshot rejected",
+        screenshot: `data:image/jpeg;base64,${pngBase64}`,
+      })
+    );
+
+    expect(res.status).toBe(201);
+    // Only 1 fetch call — no getRepoId or upload, just issue creation
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, opts] = mockFetch.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.body).not.toContain("### Screenshot");
+  });
+
+  it("rejects screenshot with unsupported data URL prefix", async () => {
+    process.env.GITHUB_FEEDBACK_TOKEN = "ghp_test_token";
+    process.env.GITHUB_FEEDBACK_REPO = "testowner/testrepo";
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ html_url: "https://github.com/testowner/testrepo/issues/998" }),
+    });
+
+    const res = await POST(
+      makeRequest({
+        type: "bug",
+        message: "Bad prefix rejected",
+        // Valid JPEG bytes but wrong prefix
+        screenshot: "data:application/octet-stream;base64,/9j/4AAQ",
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, opts] = mockFetch.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.body).not.toContain("### Screenshot");
   });
 
   it("creates issue without screenshot section when no screenshot provided", async () => {

--- a/src/__tests__/feedback-route.test.ts
+++ b/src/__tests__/feedback-route.test.ts
@@ -228,7 +228,7 @@ describe("POST /api/feedback", () => {
     expect(issueBody.body).toContain(`![Screenshot](${fakeAssetUrl})`);
   });
 
-  it("creates issue without screenshot section when upload fails", async () => {
+  it("creates issue without screenshot section when magic bytes are invalid", async () => {
     process.env.GITHUB_FEEDBACK_TOKEN = "ghp_test_token";
     process.env.GITHUB_FEEDBACK_REPO = "testowner/testrepo";
 
@@ -254,6 +254,50 @@ describe("POST /api/feedback", () => {
     const issueBody = JSON.parse(lastCall[1].body);
     expect(issueBody.body).not.toContain("### Screenshot");
     expect(issueBody.body).toContain("Bug with failed screenshot");
+  });
+
+  it("creates issue without screenshot section when GitHub upload API fails", async () => {
+    process.env.GITHUB_FEEDBACK_TOKEN = "ghp_test_token";
+    process.env.GITHUB_FEEDBACK_REPO = "testowner/testrepo";
+
+    // FF D8 FF E0 — valid JPEG magic bytes, passes both checks
+    const validJpegBase64 = "/9j/4AAQ";
+
+    // getRepoId succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 12345 }),
+    });
+
+    // Screenshot upload fails (GitHub 500)
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    });
+
+    // Issue creation succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        html_url: "https://github.com/testowner/testrepo/issues/100",
+      }),
+    });
+
+    const res = await POST(
+      makeRequest({
+        type: "bug",
+        message: "Bug with failed upload",
+        screenshot: `data:image/jpeg;base64,${validJpegBase64}`,
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+    const issueBody = JSON.parse(lastCall[1].body);
+    expect(issueBody.body).not.toContain("### Screenshot");
+    expect(issueBody.body).toContain("Bug with failed upload");
   });
 
   it("rejects screenshot with non-JPEG magic bytes (PNG data)", async () => {

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -26,9 +26,13 @@ export async function GET(request: NextRequest) {
 
         const nonce = crypto.randomUUID();
         const jwtSecret = resolveJwtSecret();
-        // State = "nonce.sig" where sig is the first 16 hex chars of HMAC-SHA256(nonce, jwtSecret)
-        // 16 hex chars = 64-bit HMAC — sufficient given UUID nonce + 10-min cookie window
-        const sig = crypto.createHmac("sha256", jwtSecret).update(nonce).digest("hex").slice(0, 16);
+        // State = "nonce.sig" where sig is the first 16 hex chars of HMAC-SHA256(nonce, jwtSecret).
+        // 16 hex chars = 64-bit HMAC — sufficient given UUID nonce + 10-min cookie window.
+        const sig = crypto
+            .createHmac("sha256", jwtSecret)
+            .update(nonce)
+            .digest("hex")
+            .slice(0, 16);
         const state = `${nonce}.${sig}`;
 
         const authUrl = client.generateAuthUrl({

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -36,6 +36,12 @@ async function uploadScreenshot(
   dataUrl: string
 ): Promise<string | null> {
   try {
+    // Validate data URL prefix — only accept JPEG
+    if (!dataUrl.startsWith("data:image/jpeg;base64,")) {
+      logger.warn("Screenshot rejected: unsupported image type");
+      return null;
+    }
+
     const base64 = dataUrl.split(",")[1];
     if (!base64) return null;
 
@@ -52,6 +58,13 @@ async function uploadScreenshot(
     for (let i = 0; i < binaryStr.length; i++) {
       bytes[i] = binaryStr.charCodeAt(i);
     }
+
+    // Validate JPEG magic bytes: FF D8 FF
+    if (bytes.length < 3 || bytes[0] !== 0xFF || bytes[1] !== 0xD8 || bytes[2] !== 0xFF) {
+      logger.warn("Screenshot rejected: invalid JPEG magic bytes");
+      return null;
+    }
+
     const blob = new Blob([bytes], { type: "image/jpeg" });
 
     const filename = `feedback-${Date.now()}.jpg`;

--- a/src/lib/sentry-scrub.ts
+++ b/src/lib/sentry-scrub.ts
@@ -5,7 +5,8 @@ const SENSITIVE_KEY = /token|secret|password|api[-_]?key|cookie|authorization|em
 function redact<T>(node: T, depth = 0): T {
     if (depth > 6 || node == null) return node;
     if (typeof node === "string") {
-        return (node.length > 2000 ? node.slice(0, 2000) + "…[truncated]" : node) as unknown as T;
+        const truncated = node.length > 2000 ? node.slice(0, 2000) + "…[truncated]" : node;
+        return truncated as unknown as T;
     }
     if (typeof node !== "object") return node;
     if (Array.isArray(node)) return node.map((n) => redact(n, depth + 1)) as unknown as T;


### PR DESCRIPTION
## Summary

Adds validation to the `/api/feedback` screenshot upload endpoint to prevent arbitrary binary data from being accepted as JPEG images. This addresses a security vulnerability (MED-07) where an authenticated user could upload non-JPEG data without validation.

## Changes

### `src/app/api/feedback/route.ts`
- Added data URL prefix validation: only accepts `data:image/jpeg;base64,`
- Added JPEG magic byte validation: checks for `FF D8 FF` header before upload
- Both checks return early if validation fails, logging a warning

### `src/__tests__/feedback-route.test.ts`
- Fixed existing screenshot test: changed PNG base64 (`iVBORw0K…`) to valid JPEG base64 (`/9j/4AAQ`) to pass magic-byte validation
- Updated upload-failure test: adjusted mock expectations since invalid data is now rejected before any fetch calls
- Added test for PNG magic byte rejection: verifies non-JPEG binary data is silently dropped
- Added test for unsupported prefix rejection: verifies only `data:image/jpeg;base64,` is accepted

## Validation

| Check | Result |
|-------|--------|
| Type check | ✅ Pass |
| Tests | ✅ 935 passed |
| Lint | ✅ 0 errors |
| Build | ✅ Success |

All tests pass, including new tests for rejection scenarios.

Fixes #565