### PR TITLE
fix: remove Host-header injection in Google OAuth redirect_uri

### DIFF
--- a/src/app/api/auth/google-docs/callback/route.ts
+++ b/src/app/api/auth/google-docs/callback/route.ts
@@ -10,7 +10,10 @@ import { logger } from "@/lib/logger";
  */
 export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
-    const origin = new URL(env.GOOGLE_REDIRECT_URI || request.url).origin;
+    if (!env.GOOGLE_REDIRECT_URI) {
+        return NextResponse.json({ error: "Google OAuth not configured" }, { status: 501 });
+    }
+    const origin = new URL(env.GOOGLE_REDIRECT_URI).origin;
 
     const code = searchParams.get("code");
     const state = searchParams.get("state");

--- a/src/app/api/auth/google-docs/callback/route.ts
+++ b/src/app/api/auth/google-docs/callback/route.ts
@@ -9,10 +9,10 @@ import { logger } from "@/lib/logger";
  * Exchanges auth code for tokens, stores GoogleCredential, redirects to /settings.
  */
 export async function GET(request: NextRequest) {
-    const { searchParams } = new URL(request.url);
-    if (!env.GOOGLE_REDIRECT_URI) {
+    if (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET || !env.GOOGLE_REDIRECT_URI) {
         return NextResponse.json({ error: "Google OAuth not configured" }, { status: 501 });
     }
+    const { searchParams } = new URL(request.url);
     const origin = new URL(env.GOOGLE_REDIRECT_URI).origin;
 
     const code = searchParams.get("code");

--- a/src/app/api/auth/google-docs/route.ts
+++ b/src/app/api/auth/google-docs/route.ts
@@ -8,8 +8,8 @@ import crypto from "crypto";
  * GET /api/auth/google-docs — Redirect to Google OAuth for Docs/Drive scopes.
  * Separate from /api/auth/google (login) — this grants document access only.
  */
-export async function GET(request: NextRequest) {
-    if (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET) {
+export async function GET(_request: NextRequest) {
+    if (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET || !env.GOOGLE_REDIRECT_URI) {
         return NextResponse.json(
             { error: "Google OAuth not configured" },
             { status: 501 }
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
     }
 
     try {
-        const baseUrl = new URL(env.GOOGLE_REDIRECT_URI || request.url).origin;
+        const baseUrl = new URL(env.GOOGLE_REDIRECT_URI).origin;
         const redirectUri = `${baseUrl}/api/auth/google-docs/callback`;
 
         const state = crypto.randomUUID();

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -31,7 +31,17 @@ export async function GET(request: NextRequest) {
     const stateParam = request.nextUrl.searchParams.get("state");
     const stateCookie = request.cookies.get("oauth_state")?.value;
     const redirectUri = env.GOOGLE_REDIRECT_URI;
-    const baseUrl = redirectUri ? new URL(redirectUri).origin : request.nextUrl.origin;
+    const clientId = env.GOOGLE_CLIENT_ID;
+    const clientSecret = env.GOOGLE_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret || !redirectUri) {
+        return NextResponse.json(
+            { error: "Google OAuth not configured" },
+            { status: 501 }
+        );
+    }
+
+    const baseUrl = new URL(redirectUri).origin;
     if (!stateParam || !stateCookie || stateParam !== stateCookie) {
         return NextResponse.redirect(
             new URL("/login?error=invalid_state", baseUrl)
@@ -56,16 +66,6 @@ export async function GET(request: NextRequest) {
         logger.warn("OAuth HMAC state verification failed — possible CSRF or replay attempt");
         return NextResponse.redirect(
             new URL("/login?error=invalid_state", baseUrl)
-        );
-    }
-
-    const clientId = env.GOOGLE_CLIENT_ID;
-    const clientSecret = env.GOOGLE_CLIENT_SECRET;
-
-    if (!clientId || !clientSecret || !redirectUri) {
-        return NextResponse.json(
-            { error: "Google OAuth not configured" },
-            { status: 501 }
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a Host-header injection vulnerability in Google OAuth redirect_uri construction that could enable OAuth hijacking attacks.

## Problem

Three OAuth route files were constructing `redirectUri` and `baseUrl` by falling back to untrusted `request.url` / `request.nextUrl.origin` values when `GOOGLE_REDIRECT_URI` environment variable was not set. Since these values derive from the HTTP `Host` header, an attacker could spoof the header to:

1. Redirect the OAuth flow to an attacker-controlled domain
2. Manipulate error-redirect paths on callback routes

## Solution

Removed Host-header fallbacks and added early configuration guards in three files:

- **`src/app/api/auth/google-docs/route.ts`**: Added `GOOGLE_REDIRECT_URI` to the existence guard, changed `_request` parameter to unused (satisfies lint), removed `|| request.url` fallback
- **`src/app/api/auth/google-docs/callback/route.ts`**: Added early guard returning 501 before `origin` is computed, removed `|| request.url` fallback
- **`src/app/api/auth/google/callback/route.ts`**: Moved config guard before `baseUrl` computation, removed `request.nextUrl.origin` fallback

All three routes now fail explicitly (501 error) if `GOOGLE_REDIRECT_URI` is not configured, rather than silently accepting attacker-controlled Host headers.

## Changes

| File | Action | Details |
|------|--------|---------|
| `src/app/api/auth/google-docs/route.ts` | UPDATE | +2 lines, -2 lines |
| `src/app/api/auth/google-docs/callback/route.ts` | UPDATE | +4 lines, -1 line |
| `src/app/api/auth/google/callback/route.ts` | UPDATE | +12 lines, -12 lines |

## Validation

- ✅ Type check: No errors
- ✅ Lint: 0 new errors
- ✅ Build: Successful
- ⚠️ Tests: Blocked by environment (require TEST_DATABASE_URL)

## Issue

Fixes #564