### PR TITLE
fix: pin JWT algorithm and enforce issuer/audience claims

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -6,6 +6,7 @@ import {
     verifySessionToken,
     isAuthEnabled,
     isAllowedRedirect,
+    getJwtKey,
 } from "@/lib/auth";
 
 describe("auth utilities", () => {
@@ -93,16 +94,22 @@ describe("JWT session tokens", () => {
 
     it("rejects a valid HS256 token without issuer/audience claims", async () => {
         const { SignJWT } = await import("jose");
-        const encoder = new TextEncoder();
-        const key = await crypto.subtle.importKey(
-            "raw", encoder.encode("test-jwt-secret"),
-            { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
-        );
+        const key = await getJwtKey();
         const token = await new SignJWT({ userId: "user-1", email: "a@b.com", name: "A" })
             .setProtectedHeader({ alg: "HS256" })
             .setExpirationTime("1h")
             .sign(key);
         const result = await verifySessionToken(token);
+        expect(result).toBeNull();
+    });
+
+    it("rejects an MCP access token presented to session verifier", async () => {
+        const { createMcpToken, ACCESS_TOKEN_TTL } = await import("@/lib/oauth-tokens");
+        const mcpToken = await createMcpToken(
+            { userId: "user-1", email: "a@b.com", type: "mcp_access", clientId: "c1" },
+            ACCESS_TOKEN_TTL
+        );
+        const result = await verifySessionToken(mcpToken);
         expect(result).toBeNull();
     });
 

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -82,6 +82,30 @@ describe("JWT session tokens", () => {
         expect(result).toBeNull();
     });
 
+    it("rejects a token signed with wrong algorithm (none attack)", async () => {
+        const header = btoa(JSON.stringify({ alg: "none", typ: "JWT" }))
+            .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+        const body = btoa(JSON.stringify({ userId: "x", email: "x@x.com", name: "x" }))
+            .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+        const result = await verifySessionToken(`${header}.${body}.`);
+        expect(result).toBeNull();
+    });
+
+    it("rejects a valid HS256 token without issuer/audience claims", async () => {
+        const { SignJWT } = await import("jose");
+        const encoder = new TextEncoder();
+        const key = await crypto.subtle.importKey(
+            "raw", encoder.encode("test-jwt-secret"),
+            { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
+        );
+        const token = await new SignJWT({ userId: "user-1", email: "a@b.com", name: "A" })
+            .setProtectedHeader({ alg: "HS256" })
+            .setExpirationTime("1h")
+            .sign(key);
+        const result = await verifySessionToken(token);
+        expect(result).toBeNull();
+    });
+
     it("returns null for JWT missing required fields", async () => {
         // Create a JWT with jose directly without userId
         const { SignJWT } = await import("jose");

--- a/src/__tests__/oauth-tokens.test.ts
+++ b/src/__tests__/oauth-tokens.test.ts
@@ -104,6 +104,15 @@ describe("MCP OAuth Tokens", () => {
       expect(payload).toBeNull();
     });
 
+    it("rejects a session token presented to MCP verifier", async () => {
+      const { createSessionToken } = await import("@/lib/auth");
+      const sessionToken = await createSessionToken({
+        userId: "user-1", email: "a@b.com", name: "A",
+      });
+      const payload = await verifyMcpToken(sessionToken, "mcp_access");
+      expect(payload).toBeNull();
+    });
+
     it("rejects a token missing clientId claim (legacy token)", async () => {
       // Simulate a pre-fix token by signing directly without clientId.
       // Tokens issued before this PR will be rejected, enforcing the security fix.

--- a/src/__tests__/oauth-tokens.test.ts
+++ b/src/__tests__/oauth-tokens.test.ts
@@ -81,6 +81,29 @@ describe("MCP OAuth Tokens", () => {
       expect(payload).toBeNull();
     });
 
+    it("rejects a valid HS256 token without issuer/audience claims", async () => {
+      const key = await getJwtKey();
+      const token = await new SignJWT({
+        userId: "user-1", email: "a@b.com",
+        type: "mcp_access", clientId: "client-1",
+      })
+        .setProtectedHeader({ alg: "HS256" })
+        .setIssuedAt()
+        .setExpirationTime("1h")
+        .sign(key);
+      const payload = await verifyMcpToken(token, "mcp_access");
+      expect(payload).toBeNull();
+    });
+
+    it("rejects an access token presented as a refresh token audience", async () => {
+      const token = await createMcpToken(
+        { userId: "user-1", email: "a@b.com", type: "mcp_access", clientId: "c1" },
+        ACCESS_TOKEN_TTL
+      );
+      const payload = await verifyMcpToken(token, "mcp_refresh");
+      expect(payload).toBeNull();
+    });
+
     it("rejects a token missing clientId claim (legacy token)", async () => {
       // Simulate a pre-fix token by signing directly without clientId.
       // Tokens issued before this PR will be rejected, enforcing the security fix.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,9 @@ const SESSION_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 
 export { SESSION_COOKIE_NAME, SESSION_MAX_AGE };
 
+export const JWT_ISSUER = "word-coach-annie";
+export const JWT_AUDIENCE_SESSION = "word-coach-annie:session";
+
 /** JWT payload shape for Google OAuth sessions. */
 export interface SessionPayload {
     userId: string;
@@ -65,6 +68,8 @@ export async function createSessionToken(payload: SessionPayload): Promise<strin
     const key = await getJwtKey();
     return new SignJWT({ ...payload })
         .setProtectedHeader({ alg: "HS256" })
+        .setIssuer(JWT_ISSUER)
+        .setAudience(JWT_AUDIENCE_SESSION)
         .setIssuedAt()
         .setExpirationTime(`${SESSION_MAX_AGE}s`)
         .sign(key);
@@ -77,7 +82,11 @@ export async function createSessionToken(payload: SessionPayload): Promise<strin
 export async function verifySessionToken(token: string): Promise<SessionPayload | null> {
     try {
         const key = await getJwtKey();
-        const { payload } = await jwtVerify(token, key);
+        const { payload } = await jwtVerify(token, key, {
+            algorithms: ["HS256"],
+            issuer: JWT_ISSUER,
+            audience: JWT_AUDIENCE_SESSION,
+        });
         if (payload.userId && payload.email) {
             return {
                 userId: payload.userId as string,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,8 +7,9 @@
  *
  * When neither API_TOKEN nor GOOGLE_CLIENT_ID is set, auth is disabled (local dev).
  */
-import { SignJWT, jwtVerify } from "jose";
+import { SignJWT, jwtVerify, errors as JoseErrors } from "jose";
 import { env } from "@/lib/env";
+import { logger } from "@/lib/logger";
 
 const SESSION_COOKIE_NAME = "annie_session";
 const SESSION_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
@@ -63,6 +64,7 @@ export async function getJwtKey(): Promise<CryptoKey> {
 
 /**
  * Create a signed JWT for a user session.
+ * Sets iss=JWT_ISSUER and aud=JWT_AUDIENCE_SESSION; verifySessionToken enforces both.
  */
 export async function createSessionToken(payload: SessionPayload): Promise<string> {
     const key = await getJwtKey();
@@ -96,7 +98,13 @@ export async function verifySessionToken(token: string): Promise<SessionPayload 
             };
         }
         return null;
-    } catch {
+    } catch (err) {
+        // Expected: expired, tampered, wrong issuer/audience/algorithm — treat as invalid.
+        if (err instanceof JoseErrors.JOSEError) {
+            return null;
+        }
+        // Unexpected: infrastructure failure (missing key, crypto error).
+        logger.error("verifySessionToken: unexpected error during JWT verification", err);
         return null;
     }
 }

--- a/src/lib/oauth-tokens.ts
+++ b/src/lib/oauth-tokens.ts
@@ -5,7 +5,10 @@
  * Uses the same JWT signing key as session tokens (src/lib/auth.ts).
  */
 import { SignJWT, jwtVerify, errors as JoseErrors } from "jose";
-import { getJwtKey, safeEqual } from "@/lib/auth";
+import { getJwtKey, safeEqual, JWT_ISSUER } from "@/lib/auth";
+
+const JWT_AUDIENCE_MCP_ACCESS = "word-coach-annie:mcp_access";
+const JWT_AUDIENCE_MCP_REFRESH = "word-coach-annie:mcp_refresh";
 import { logger } from "@/lib/logger";
 
 // Access token: 1 hour
@@ -26,8 +29,13 @@ export async function createMcpToken(
   ttlSeconds: number
 ): Promise<string> {
   const key = await getJwtKey();
+  const audience = payload.type === "mcp_access"
+    ? JWT_AUDIENCE_MCP_ACCESS
+    : JWT_AUDIENCE_MCP_REFRESH;
   return new SignJWT({ ...payload })
     .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(JWT_ISSUER)
+    .setAudience(audience)
     .setIssuedAt()
     .setExpirationTime(`${ttlSeconds}s`)
     .sign(key);
@@ -40,7 +48,14 @@ export async function verifyMcpToken(
 ): Promise<{ userId: string; email: string; clientId: string } | null> {
   try {
     const key = await getJwtKey();
-    const { payload } = await jwtVerify(token, key);
+    const audience = expectedType === "mcp_access"
+      ? JWT_AUDIENCE_MCP_ACCESS
+      : JWT_AUDIENCE_MCP_REFRESH;
+    const { payload } = await jwtVerify(token, key, {
+      algorithms: ["HS256"],
+      issuer: JWT_ISSUER,
+      audience,
+    });
     if (
       payload.type !== expectedType ||
       !payload.userId ||

--- a/src/lib/oauth-tokens.ts
+++ b/src/lib/oauth-tokens.ts
@@ -6,10 +6,10 @@
  */
 import { SignJWT, jwtVerify, errors as JoseErrors } from "jose";
 import { getJwtKey, safeEqual, JWT_ISSUER } from "@/lib/auth";
+import { logger } from "@/lib/logger";
 
 const JWT_AUDIENCE_MCP_ACCESS = "word-coach-annie:mcp_access";
 const JWT_AUDIENCE_MCP_REFRESH = "word-coach-annie:mcp_refresh";
-import { logger } from "@/lib/logger";
 
 // Access token: 1 hour
 export const ACCESS_TOKEN_TTL = 60 * 60;
@@ -70,7 +70,8 @@ export async function verifyMcpToken(
       clientId: payload.clientId as string,
     };
   } catch (err) {
-    // Expected: token is expired, tampered, or has wrong type — treat as invalid.
+    // Expected: token is expired, tampered, has a wrong algorithm,
+    // mismatched issuer/audience, or other JOSE validation failure — treat as invalid.
     if (
       err instanceof JoseErrors.JWTExpired ||
       err instanceof JoseErrors.JWTInvalid ||

--- a/src/lib/oauth-tokens.ts
+++ b/src/lib/oauth-tokens.ts
@@ -70,19 +70,11 @@ export async function verifyMcpToken(
       clientId: payload.clientId as string,
     };
   } catch (err) {
-    // Expected: token is expired, tampered, has a wrong algorithm,
-    // mismatched issuer/audience, or other JOSE validation failure — treat as invalid.
-    if (
-      err instanceof JoseErrors.JWTExpired ||
-      err instanceof JoseErrors.JWTInvalid ||
-      err instanceof JoseErrors.JWSSignatureVerificationFailed ||
-      err instanceof JoseErrors.JOSEError
-    ) {
+    // Expected: expired, tampered, wrong algorithm, mismatched issuer/audience — treat as invalid.
+    if (err instanceof JoseErrors.JOSEError) {
       return null;
     }
     // Unexpected: infrastructure failure (missing key, crypto error).
-    // Log with full context so Sentry captures it, then return null so
-    // callers still return 400 rather than an unhandled 500.
     logger.error("verifyMcpToken: unexpected error during JWT verification", err);
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes a critical JWT validation vulnerability in session and MCP token verification. Both `verifySessionToken` and `verifyMcpToken` were accepting tokens with any algorithm and without validating issuer/audience claims, exposing the application to algorithm confusion attacks and cross-service token reuse.

## Changes

### Core Fixes
- **src/lib/auth.ts**: 
  - Added `JWT_ISSUER` and `JWT_AUDIENCE_SESSION` constants
  - Updated `createSessionToken` to set issuer and audience claims
  - Updated `verifySessionToken` to enforce algorithm pinning (HS256) and validate issuer/audience

- **src/lib/oauth-tokens.ts**:
  - Added MCP token audience constants (`JWT_AUDIENCE_MCP_ACCESS`, `JWT_AUDIENCE_MCP_REFRESH`)
  - Updated `createMcpToken` to set issuer and distinct audiences by token type
  - Updated `verifyMcpToken` to enforce algorithm pinning and validate issuer/audience per token type

### Test Coverage
- **src/__tests__/auth.test.ts**: Added tests to reject tokens with wrong algorithm or missing issuer/audience
- **src/__tests__/oauth-tokens.test.ts**: Added tests for missing claims and audience type mismatch validation

## Validation Results

✅ Type checking: 0 errors
✅ Linting: 0 errors (141 pre-existing warnings)
✅ Tests: 959 passed across 85 test files
✅ Build: Successful (43 static pages)

## Breaking Change Notice

⚠️ **Existing tokens will be invalidated**

All currently live session tokens and MCP tokens issued before this fix will be rejected because they lack the new `iss` and `aud` claims. This is an acceptable trade-off for a security fix:
- Users will be required to re-authenticate (new session token)
- OAuth clients will need to re-run the authorization flow (new MCP tokens)

This is a one-time impact following the deployment.

## Security Impact

- **Algorithm Confusion**: Pinning to HS256 prevents attackers from forcing `alg: "none"` or algorithm downgrade attacks
- **Issuer Validation**: Rejects JWTs from other services using the same secret
- **Audience Separation**: MCP access tokens cannot be reused as refresh tokens, and session tokens cannot be reused as MCP tokens

Fixes #560