### PR TITLE
fix: restore MCP OAuth dynamic client registration

### DIFF
--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -8,7 +8,6 @@ import {
   type ClientRegistration,
 } from "@/lib/oauth-store";
 import { getCurrentUserId } from "@/lib/api-auth";
-import { isAuthEnabled } from "@/lib/auth";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 
@@ -51,15 +50,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Require an authenticated session when auth is enabled
-  const authEnabled = isAuthEnabled();
-  const userId = authEnabled ? getCurrentUserId(request) : null;
-  if (authEnabled && !userId) {
-    return NextResponse.json(
-      { error: "invalid_client_metadata", error_description: "registration requires an authenticated session" },
-      { status: 401 }
-    );
-  }
+  const userId = getCurrentUserId(request);  // null when not logged in — tracked for audit only
 
   let body: Record<string, unknown>;
   try {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,6 +22,7 @@ const PUBLIC_PATHS = [
     "/privacy",
     "/terms",
     "/.well-known/oauth-authorization-server",
+    "/oauth/register",
     "/oauth/token",
     "/version.json",
 ];


### PR DESCRIPTION
## Summary

- The security fix in #558 broke MCP connectivity by requiring an authenticated session for dynamic client registration (`POST /oauth/register`)
- RFC 7591 dynamic client registration must happen **before** the user authenticates — the MCP SDK hits `/oauth/register` first, then starts the OAuth browser flow; if registration fails, the whole flow fails
- Registration itself is harmless since auth is still required to authorize the client; IP rate limiting (5 req/hr in-memory + DB-persisted 24h rolling window per IP) and a global client cap provide the necessary abuse protection

## Changes

- **`src/middleware.ts`**: Add `/oauth/register` back to `PUBLIC_PATHS` so the middleware passes the request through without redirecting to login
- **`src/app/oauth/register/route.ts`**: Remove the auth gate (`authEnabled && !userId → 401`); keep `userId` obtained from the session (null when not logged in) for audit logging only; remove now-unused `isAuthEnabled` import

## Test plan

- [ ] Connect Claude.ai or Claude Code to `https://annie.interstellarai.net/api/mcp` — OAuth flow should complete without a 401 on `/oauth/register`
- [ ] Confirm unauthenticated POST to `/oauth/register` returns 201 with `client_id`
- [ ] Confirm rate limiting still applies (6th registration attempt from same IP within an hour → 429)
- [ ] Confirm existing authenticated flows (browser session, API token, MCP access token) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)