### PR TITLE
fix: allow /oauth/authorize as post-login redirect for MCP OAuth flow

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -154,6 +154,7 @@ const ALLOWED_REDIRECT_PATTERNS = [
     /^\/project\/[a-zA-Z0-9_-]+(\/.*)?$/,
     /^\/read\/[a-zA-Z0-9_-]+(\/.*)?$/,
     /^\/universe(\/[a-zA-Z0-9_-]+(\/.*)?)?$/,
+    /^\/oauth\/authorize$/,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Add \`/oauth/authorize\` to \`ALLOWED_REDIRECT_PATTERNS\` in \`src/lib/auth.ts\`

## Root cause
When an unauthenticated MCP client triggers the OAuth consent flow, the middleware redirects to \`/login?from=/oauth/authorize?...\`. The login page passes this \`from\` value to \`/api/auth/google?from=...\`, which calls \`isAllowedRedirect()\` before setting the \`oauth_redirect\` cookie. Since \`/oauth/authorize\` was not in the allowlist, the cookie was never set, and after Google login the callback redirected to \`/\` instead of back to the consent screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)