### PR TITLE
fix(middleware): preserve query params in login redirect

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -211,7 +211,7 @@ export async function middleware(request: NextRequest) {
     }
 
     const loginUrl = new URL("/login", request.url);
-    loginUrl.searchParams.set("from", pathname);
+    loginUrl.searchParams.set("from", pathname + request.nextUrl.search);
     return NextResponse.redirect(loginUrl);
 }
 


### PR DESCRIPTION
## Summary

- Middleware was using only `pathname` when redirecting to `/login?from=...`, dropping all query parameters
- This broke the OAuth consent flow: after Google login, the callback redirected to `/oauth/authorize` (no params), which immediately failed and sent users back to login
- Fix: include `request.nextUrl.search` so the full path+query is preserved through the login round-trip

## Test plan

- [ ] Attempt to connect Annie MCP from Claude
- [ ] Verify login redirect includes full OAuth params (e.g. `?from=%2Foauth%2Fauthorize%3Fresponse_type%3Dcode%26...`)
- [ ] Verify after Google login, consent screen appears with correct OAuth params
- [ ] Verify approval completes the MCP auth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)