### PR TITLE
fix(pwa): bypass service worker cache for OAuth and auth routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -115,6 +115,13 @@ const pwaConfig = withPWA({
     skipWaiting: true,
     clientsClaim: true,
     runtimeCaching: [
+      // Never cache OAuth or auth routes — the SW must not intercept redirects
+      // in the OAuth flow or serve stale responses for login/consent pages.
+      {
+        urlPattern: ({ url }: { url: URL }) =>
+          url.pathname.startsWith("/oauth/") || url.pathname.startsWith("/api/auth/"),
+        handler: "NetworkOnly" as const,
+      },
       // Cache Google Fonts stylesheets
       {
         urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,


### PR DESCRIPTION
## Summary

- The default `runtimeCaching` from `@ducanh2912/next-pwa` includes a `pages` entry (NetworkFirst) that matches all same-origin paths not starting with `/api/`
- This means `/oauth/authorize`, `/oauth/token`, `/oauth/register`, and similar routes are intercepted by the service worker
- When the SW fetches `/oauth/authorize?...` while the user is unauthenticated, it follows the 302→/login redirect transparently and can cache the login HTML under the `/oauth/authorize` key
- On repeat visits, the SW can serve this stale login-page response from cache, bypassing the actual session check and breaking the OAuth consent flow
- Also affects RSC prefetch caching for `/api/auth/` routes
- Fix: prepend a `NetworkOnly` rule at the top of `runtimeCaching` for all `/oauth/` and `/api/auth/` paths

## Test plan

- [ ] Attempt MCP connection from Claude — OAuth flow should complete without hitting cached stale responses
- [ ] Verify existing Annie session works (direct browser visit to annie.interstellarai.net still works normally)
- [ ] Verify PWA offline mode still works for app pages unrelated to OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)