### PR TITLE
fix(auth): use SameSite=Lax for session cookie to fix OAuth redirect loop

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -115,6 +115,13 @@ const pwaConfig = withPWA({
     skipWaiting: true,
     clientsClaim: true,
     runtimeCaching: [
+      // Never cache OAuth or auth routes — the SW must not intercept redirects
+      // in the OAuth flow or serve stale responses for login/consent pages.
+      {
+        urlPattern: ({ url }: { url: URL }) =>
+          url.pathname.startsWith("/oauth/") || url.pathname.startsWith("/api/auth/"),
+        handler: "NetworkOnly" as const,
+      },
       // Cache Google Fonts stylesheets
       {
         urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -164,7 +164,12 @@ export async function GET(request: NextRequest) {
         response.cookies.set(SESSION_COOKIE_NAME, jwt, {
             httpOnly: true,
             secure: process.env.NODE_ENV === "production",
-            sameSite: "strict",
+            // SameSite=Lax (not Strict) is required for OAuth flows: the redirect chain
+            // from Google back to /oauth/authorize inherits a cross-site context, so
+            // Strict cookies are silently dropped by the browser before reaching the
+            // middleware. Lax still blocks cross-site POST (CSRF vector); the session
+            // cookie is httpOnly so JS cannot read it regardless.
+            sameSite: "lax",
             maxAge: SESSION_MAX_AGE,
             path: "/",
         });


### PR DESCRIPTION
## Root cause

The Google OAuth callback sets the session cookie with `SameSite=Strict`, then immediately redirects the user to `/oauth/authorize?...`. The browser silently drops the cookie because the **entire redirect chain** (claude.ai → annie → Google → annie callback) is treated as having a cross-site initiator — even though the final callback→authorize hop is same-domain.

The middleware sees no session cookie on the `/oauth/authorize` request and redirects to `/login` again, creating an infinite loop.

## Fix

Change `sameSite: "strict"` → `"lax"` on the session cookie set by `/api/auth/google/callback`.

`SameSite=Lax` is the standard for OAuth Authorization Server session cookies (Google, GitHub, etc.) because it allows cookies to be sent on top-level cross-site GET navigations (the redirect chain case) while still blocking cross-site POST requests (the CSRF attack vector). The session cookie is `httpOnly` so JavaScript cannot read it regardless of the SameSite setting.

## Why not Strict everywhere?

`Strict` is kept for:
- `csrf_oauth` cookie in `/oauth/authorize` — CSRF token, correct to be Strict
- Session cookie set by `/api/auth/login` (API token flow) — that's a same-site POST, no redirect chain issue

## Test plan
- [ ] Connect Annie MCP from Claude → complete Google login → consent page appears (no login loop)
- [ ] Existing annie sessions still work (page loads without re-login)
- [ ] Logout clears session correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)