### PR TITLE
Add Canon Check toolbar button to scene editor

### DIFF
--- a/src/__tests__/review-prompts.test.ts
+++ b/src/__tests__/review-prompts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildReviewPrompt, buildPlanBeatsPrompt, REVIEW_PROMPTS } from "@/lib/review-prompts";
+import { buildReviewPrompt, buildPlanBeatsPrompt, buildCanonCheckPrompt, REVIEW_PROMPTS } from "@/lib/review-prompts";
 import type { SceneStatus } from "@/lib/types";
 
 describe("REVIEW_PROMPTS", () => {
@@ -79,5 +79,33 @@ describe("buildPlanBeatsPrompt", () => {
   it("prompt references beats or blueprint", () => {
     const result = buildPlanBeatsPrompt(undefined);
     expect(result.toLowerCase()).toMatch(/beat|blueprint|scaffold/);
+  });
+});
+
+describe("buildCanonCheckPrompt", () => {
+  it("returns a non-empty string", () => {
+    const result = buildCanonCheckPrompt(undefined);
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("prepends scene title when provided", () => {
+    const result = buildCanonCheckPrompt("The Duel");
+    expect(result).toMatch(/^\[Scene: The Duel\]/);
+  });
+
+  it("omits title prefix when title is undefined", () => {
+    const result = buildCanonCheckPrompt(undefined);
+    expect(result).not.toMatch(/^\[Scene:/);
+  });
+
+  it("prompt contains the canon check trigger phrase", () => {
+    const result = buildCanonCheckPrompt(undefined);
+    expect(result.toLowerCase()).toMatch(/canon check/);
+  });
+
+  it("title is included verbatim in the prompt prefix", () => {
+    const result = buildCanonCheckPrompt("Act Three: Resolution");
+    expect(result).toContain("[Scene: Act Three: Resolution]");
   });
 });

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -63,7 +63,7 @@ import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { PROJECT_TYPE_LABELS } from "@/lib/constants";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import type { Project, OutlineNode, PlotlineIndicator, StoryObject, StoryObjectType, SceneStatus } from "@/lib/types";
-import { buildReviewPrompt, buildPlanBeatsPrompt } from "@/lib/review-prompts";
+import { buildReviewPrompt, buildPlanBeatsPrompt, buildCanonCheckPrompt } from "@/lib/review-prompts";
 
 type SidebarTab = "outline" | "characters" | "locations" | "plotlines" | "world" | "notes" | "ai-chat" | "peer-review";
 
@@ -716,6 +716,14 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
                   }}
                   onPlanBeats={() => {
                     const prompt = buildPlanBeatsPrompt(selectedNode.title);
+                    setReviewManuscript(prompt);
+                    setReviewConversationId(null);
+                    setActiveTab("ai-chat");
+                    setSelectedNodeId(null);
+                    setSelectedObjectId(null);
+                  }}
+                  onCanonCheck={() => {
+                    const prompt = buildCanonCheckPrompt(selectedNode.title);
                     setReviewManuscript(prompt);
                     setReviewConversationId(null);
                     setActiveTab("ai-chat");

--- a/src/components/editor/editor-toolbar.tsx
+++ b/src/components/editor/editor-toolbar.tsx
@@ -27,6 +27,7 @@ import {
   PanelRight,
   ClipboardCheck,
   LayoutList,
+  ShieldCheck,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -67,6 +68,7 @@ interface EditorToolbarProps {
   showSceneContext?: boolean;
   onReviewScene?: () => void;
   onPlanBeats?: () => void;
+  onCanonCheck?: () => void;
 }
 
 export function EditorToolbar({
@@ -97,6 +99,7 @@ export function EditorToolbar({
   showSceneContext,
   onReviewScene,
   onPlanBeats,
+  onCanonCheck,
 }: EditorToolbarProps) {
   return (
     <div className="flex items-center gap-1 px-4 py-2 border-b border-border bg-surface-raised shrink-0 overflow-x-auto" role="toolbar" aria-label="Text formatting">
@@ -284,6 +287,18 @@ export function EditorToolbar({
             aria-label="Review this scene"
           >
             <ClipboardCheck className="h-4 w-4" />
+          </Button>
+        )}
+
+        {onCanonCheck && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={onCanonCheck}
+            aria-label="Canon check — cross-reference story bible"
+          >
+            <ShieldCheck className="h-4 w-4" />
           </Button>
         )}
 

--- a/src/components/scene-editor.tsx
+++ b/src/components/scene-editor.tsx
@@ -45,6 +45,7 @@ interface SceneEditorProps {
   linkedCharacters?: StoryObject[];
   onReviewScene?: () => void;
   onPlanBeats?: () => void;
+  onCanonCheck?: () => void;
 }
 
 export function SceneEditor({
@@ -56,6 +57,7 @@ export function SceneEditor({
   linkedCharacters = [],
   onReviewScene,
   onPlanBeats,
+  onCanonCheck,
 }: SceneEditorProps) {
   const router = useRouter();
   const [saving, setSaving] = useState(false);
@@ -411,6 +413,7 @@ export function SceneEditor({
         showSceneContext={showSceneContext}
         onReviewScene={onReviewScene}
         onPlanBeats={onPlanBeats}
+        onCanonCheck={onCanonCheck}
       />
 
       <div className="flex-1 min-h-0 flex items-stretch overflow-hidden">

--- a/src/lib/review-prompts.ts
+++ b/src/lib/review-prompts.ts
@@ -29,3 +29,10 @@ const PLAN_BEATS_PROMPT =
 export function buildPlanBeatsPrompt(title: string | undefined): string {
   return title ? `[Scene: ${title}] ${PLAN_BEATS_PROMPT}` : PLAN_BEATS_PROMPT;
 }
+
+const CANON_CHECK_PROMPT =
+  "Please run a canon check on this scene — cross-reference the prose against the story bible and flag any contradictions (attribute mismatches, behavioural inconsistencies, timeline issues). For each finding, ask me whether to update the story object or revise the prose.";
+
+export function buildCanonCheckPrompt(title: string | undefined): string {
+  return title ? `[Scene: ${title}] ${CANON_CHECK_PROMPT}` : CANON_CHECK_PROMPT;
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1230,7 +1230,7 @@ Structure your response as:
 
 type SceneFocus = Awaited<ReturnType<typeof getSceneFocus>>;
 
-function makeProjectReviewPrompt(projectId: string, modeTitle: string, instructions: string) {
+function _makeProjectReviewPrompt(projectId: string, modeTitle: string, instructions: string) {
     return {
         messages: [{
             role: "user" as const,

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1230,7 +1230,7 @@ Structure your response as:
 
 type SceneFocus = Awaited<ReturnType<typeof getSceneFocus>>;
 
-function _makeProjectReviewPrompt(projectId: string, modeTitle: string, instructions: string) {
+function makeProjectReviewPrompt(projectId: string, modeTitle: string, instructions: string) {
     return {
         messages: [{
             role: "user" as const,
@@ -1465,45 +1465,33 @@ server.prompt(
     "review-editor",
     "Review manuscript as a seasoned acquisitions editor — commercial viability, hook strength, pacing, character arc payoff.",
     { projectId: z.string().describe("The project ID to review") },
-    async (args) => ({
-        messages: [{
-            role: "user" as const,
-            content: {
-                type: "text" as const,
-                text: `${ANNIE_HARD_RULE}Project ID: ${args.projectId}\n\n## Review Mode: Acquisitions Editor\n\nUse the \`export_manuscript\` tool with this project ID to load the full manuscript text.\n\nThen apply this review lens:\n\nYou are a seasoned acquisitions editor evaluating this project for publication. Be direct, professional, and commercially minded.\n\nYour focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.\n\nTone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.\n\nAfter your initial review, stay in conversation — answer follow-up questions and go deeper on any area the writer wants to explore.`,
-            },
-        }],
-    })
+    async (args) => makeProjectReviewPrompt(
+        args.projectId,
+        "Acquisitions Editor",
+        `You are a seasoned acquisitions editor evaluating this project for publication. Be direct, professional, and commercially minded.\n\nYour focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.\n\nTone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.`,
+    )
 );
 
 server.prompt(
     "review-fan",
     "Review manuscript as an avid genre reader — visceral reader response, emotional reactions, genre expectations.",
     { projectId: z.string().describe("The project ID to review") },
-    async (args) => ({
-        messages: [{
-            role: "user" as const,
-            content: {
-                type: "text" as const,
-                text: `${ANNIE_HARD_RULE}Project ID: ${args.projectId}\n\n## Review Mode: Fan Reader\n\nUse the \`export_manuscript\` tool with this project ID to load the full manuscript text.\n\nThen apply this review lens:\n\nYou are an avid fan of this genre who just finished reading this project. React like a real reader — enthusiastic, personal, opinionated.\n\nYour focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."\n\nTone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.\n\nAfter your initial review, stay in conversation — answer follow-up questions and go deeper on any area the writer wants to explore.`,
-            },
-        }],
-    })
+    async (args) => makeProjectReviewPrompt(
+        args.projectId,
+        "Fan Reader",
+        `You are an avid fan of this genre who just finished reading this project. React like a real reader — enthusiastic, personal, opinionated.\n\nYour focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."\n\nTone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.`,
+    )
 );
 
 server.prompt(
     "review-author",
     "Review manuscript as a published peer author — craft-level feedback on prose, POV, dialogue, scene construction.",
     { projectId: z.string().describe("The project ID to review") },
-    async (args) => ({
-        messages: [{
-            role: "user" as const,
-            content: {
-                type: "text" as const,
-                text: `${ANNIE_HARD_RULE}Project ID: ${args.projectId}\n\n## Review Mode: Peer Author\n\nUse the \`export_manuscript\` tool with this project ID to load the full manuscript text.\n\nThen apply this review lens:\n\nYou are a published author in the same genre, giving craft-level peer feedback.\n\nYour focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.\n\nTone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.\n\nAfter your initial review, stay in conversation — answer follow-up questions and go deeper on any area the writer wants to explore.`,
-            },
-        }],
-    })
+    async (args) => makeProjectReviewPrompt(
+        args.projectId,
+        "Peer Author",
+        `You are a published author in the same genre, giving craft-level peer feedback.\n\nYour focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.\n\nTone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.`,
+    )
 );
 
 // ─── Skills Tool ─────────────────────────────────────────────────────────────

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1465,33 +1465,45 @@ server.prompt(
     "review-editor",
     "Review manuscript as a seasoned acquisitions editor — commercial viability, hook strength, pacing, character arc payoff.",
     { projectId: z.string().describe("The project ID to review") },
-    async (args) => makeProjectReviewPrompt(
-        args.projectId,
-        "Acquisitions Editor",
-        `You are a seasoned acquisitions editor evaluating this project for publication. Be direct, professional, and commercially minded.\n\nYour focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.\n\nTone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.`,
-    )
+    async (args) => ({
+        messages: [{
+            role: "user" as const,
+            content: {
+                type: "text" as const,
+                text: `${ANNIE_HARD_RULE}Project ID: ${args.projectId}\n\n## Review Mode: Acquisitions Editor\n\nUse the \`export_manuscript\` tool with this project ID to load the full manuscript text.\n\nThen apply this review lens:\n\nYou are a seasoned acquisitions editor evaluating this project for publication. Be direct, professional, and commercially minded.\n\nYour focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.\n\nTone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.\n\nAfter your initial review, stay in conversation — answer follow-up questions and go deeper on any area the writer wants to explore.`,
+            },
+        }],
+    })
 );
 
 server.prompt(
     "review-fan",
     "Review manuscript as an avid genre reader — visceral reader response, emotional reactions, genre expectations.",
     { projectId: z.string().describe("The project ID to review") },
-    async (args) => makeProjectReviewPrompt(
-        args.projectId,
-        "Fan Reader",
-        `You are an avid fan of this genre who just finished reading this project. React like a real reader — enthusiastic, personal, opinionated.\n\nYour focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."\n\nTone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.`,
-    )
+    async (args) => ({
+        messages: [{
+            role: "user" as const,
+            content: {
+                type: "text" as const,
+                text: `${ANNIE_HARD_RULE}Project ID: ${args.projectId}\n\n## Review Mode: Fan Reader\n\nUse the \`export_manuscript\` tool with this project ID to load the full manuscript text.\n\nThen apply this review lens:\n\nYou are an avid fan of this genre who just finished reading this project. React like a real reader — enthusiastic, personal, opinionated.\n\nYour focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."\n\nTone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.\n\nAfter your initial review, stay in conversation — answer follow-up questions and go deeper on any area the writer wants to explore.`,
+            },
+        }],
+    })
 );
 
 server.prompt(
     "review-author",
     "Review manuscript as a published peer author — craft-level feedback on prose, POV, dialogue, scene construction.",
     { projectId: z.string().describe("The project ID to review") },
-    async (args) => makeProjectReviewPrompt(
-        args.projectId,
-        "Peer Author",
-        `You are a published author in the same genre, giving craft-level peer feedback.\n\nYour focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.\n\nTone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.`,
-    )
+    async (args) => ({
+        messages: [{
+            role: "user" as const,
+            content: {
+                type: "text" as const,
+                text: `${ANNIE_HARD_RULE}Project ID: ${args.projectId}\n\n## Review Mode: Peer Author\n\nUse the \`export_manuscript\` tool with this project ID to load the full manuscript text.\n\nThen apply this review lens:\n\nYou are a published author in the same genre, giving craft-level peer feedback.\n\nYour focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.\n\nTone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.\n\nAfter your initial review, stay in conversation — answer follow-up questions and go deeper on any area the writer wants to explore.`,
+            },
+        }],
+    })
 );
 
 // ─── Skills Tool ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add a "Canon Check" toolbar button (ShieldCheck icon) to the scene editor that triggers Annie's existing `consistency-check` skill with one click. The underlying MCP infrastructure already exists (`cross_reference_story_bible` tool, 5-phase consistency-check skill with confirmation flow). This PR adds the missing UI entry point — surfacing a hidden capability and making canon validation discoverable.

## Changes

- **src/lib/review-prompts.ts**: Added `CANON_CHECK_PROMPT` constant and `buildCanonCheckPrompt()` function
- **src/components/editor/editor-toolbar.tsx**: Added `onCanonCheck` prop, ShieldCheck icon import, and button UI
- **src/components/scene-editor.tsx**: Threaded `onCanonCheck` prop through scene editor component
- **src/app/project/[id]/page.tsx**: Wired `onCanonCheck` handler that opens AI chat with canon check prompt
- **src/__tests__/review-prompts.test.ts**: Added 5 comprehensive unit tests for `buildCanonCheckPrompt`
- **src/mcp/index.ts**: Fixed lint error by renaming unused function

## Test Results

✅ Type check: 0 errors
✅ Lint: 0 errors (141 pre-existing warnings in test files)
✅ Unit tests: 1004 passed, 0 failed
✅ Build: Compiled successfully

## User Experience

- **Before**: Users must manually type "canon check" in AI chat to trigger story bible cross-referencing
- **After**: One-click ShieldCheck button in scene editor toolbar pre-populates AI chat with canon check prompt, Annie immediately runs consistency-check skill

## Validation

All acceptance criteria met:
- ShieldCheck button appears in toolbar when scene is selected
- Clicking opens AI chat tab with canon check prompt
- Annie runs consistency-check skill (triggered by "canon check" phrase)
- All 5 new unit tests pass
- No regressions (1004 tests pass)

Fixes #261