### PR TITLE
feat: add get_initial_instructions MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A local-first, AI-powered writing assistant for novelists and article writers. M
 
 ### AI Integration
 - **AI chat panel**: Per-project streaming chat with full story context (characters, outline, current scene)
-- **MCP server**: 48 tools for agentic access to all project data (read/write scenes, manage characters, export, etc.)
+- **MCP server**: 71 tools for agentic access to all project data (read/write scenes, manage characters, export, etc.)
 - **Writing skills**: 6 curated MCP Prompts — developmental edit, line edit, consistency check, plot structure analysis, character arc review, scene drafting assistant
 
 ### Article / Non-Fiction
@@ -81,7 +81,7 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## MCP Server (for AI Agents)
 
-Annie includes a Model Context Protocol server with 67 tools for full read/write access to project data.
+Annie includes a Model Context Protocol server with 71 tools for full read/write access to project data.
 
 ### Claude Desktop Configuration
 
@@ -175,7 +175,7 @@ src/
 │   ├── export/             # Google Docs exporter
 │   └── db.ts               # Prisma client singleton
 ├── mcp/
-│   ├── index.ts            # MCP server (48 tools)
+│   ├── index.ts            # MCP server (71 tools)
 │   ├── tools/              # Tool implementations by category
 │   └── skills.ts           # Skill loader
 └── __tests__/              # 12 test files, 69+ tests

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "lucide-react": "^1.14.0",
         "next": "^16.2.6",
         "next-themes": "^0.4.6",
+        "prom-client": "^15.1.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.5",
         "react-force-graph-2d": "^1.29.1",
@@ -1339,6 +1340,8 @@
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
+    "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
+
     "bl": ["bl@6.1.6", "", { "dependencies": { "@types/readable-stream": "^4.0.0", "buffer": "^6.0.3", "inherits": "^2.0.4", "readable-stream": "^4.2.0" } }, "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg=="],
 
     "body-parser": ["body-parser@1.20.4", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.14.0", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA=="],
@@ -2533,6 +2536,8 @@
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
+    "prom-client": ["prom-client@15.1.3", "", { "dependencies": { "@opentelemetry/api": "^1.4.0", "tdigest": "^0.1.1" } }, "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g=="],
+
     "promise-inflight": ["promise-inflight@1.0.1", "", {}, "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="],
 
     "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
@@ -2858,6 +2863,8 @@
     "tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ=="],
 
     "tarn": ["tarn@3.0.2", "", {}, "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ=="],
+
+    "tdigest": ["tdigest@0.1.2", "", { "dependencies": { "bintrees": "1.0.2" } }, "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA=="],
 
     "tedious": ["tedious@19.2.1", "", { "dependencies": { "@azure/core-auth": "^1.7.2", "@azure/identity": "^4.2.1", "@azure/keyvault-keys": "^4.4.0", "@js-joda/core": "^5.6.5", "@types/node": ">=18", "bl": "^6.1.4", "iconv-lite": "^0.7.0", "js-md4": "^0.3.2", "native-duplexpair": "^1.0.0", "sprintf-js": "^1.1.3" } }, "sha512-pk1Q16Yl62iocuQB+RWbg6rFUFkIyzqOFQ6NfysCltRvQqKwfurgj8v/f2X+CKvDhSL4IJ0cCOfCHDg9PWEEYA=="],
 
@@ -3672,6 +3679,8 @@
     "pg-types/postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "prom-client/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -686,7 +686,7 @@ Export/sync a project or universe to Google Docs. Creates or updates a document.
 
 ---
 
-### Getting Started
+### Session Setup
 
 #### `get_initial_instructions`
 Returns static guidelines for how Claude should collaborate with Annie. Call this at the

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,6 +1,6 @@
 # MCP Server Reference
 
-Annie exposes a Model Context Protocol (MCP) server with **70 tools** and **16 prompts** for full read/write access to all project data.
+Annie exposes a Model Context Protocol (MCP) server with **71 tools** and **16 prompts** for full read/write access to all project data.
 
 ## Connection
 
@@ -683,6 +683,23 @@ Export/sync a project or universe to Google Docs. Creates or updates a document.
 | `projectId` | string? | Project ID (for STORY_READER/STORY_INTERNAL modes) |
 | `universeId` | string? | Universe ID (for UNIVERSE mode) |
 | `exportMode` | enum | `UNIVERSE`, `STORY_INTERNAL`, or `STORY_READER` |
+
+---
+
+### Getting Started
+
+#### `get_initial_instructions`
+Returns static guidelines for how Claude should collaborate with Annie. Call this at the
+start of a session to establish the correct collaboration model.
+
+No parameters.
+
+Returns a markdown string covering:
+- Claude's role as a structural collaborator (not co-author)
+- When to default to beats, annotations, and editorial flags over prose
+- When to write prose (author's explicit request)
+- Correct tool usage for beats and editorial corrections
+- Stale-write protection reminder
 
 ---
 

--- a/src/__tests__/mcp-guardrails.test.ts
+++ b/src/__tests__/mcp-guardrails.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import { ANNIE_HARD_RULE } from "../mcp/annie-voice";
+import { ANNIE_HARD_RULE, CLAUDE_COLLABORATION_INSTRUCTIONS } from "../mcp/annie-voice";
 
 const mcpSource = readFileSync(resolve(__dirname, "../mcp/index.ts"), "utf-8");
 
@@ -87,6 +87,37 @@ describe("plan_beats prompt", () => {
         expect(planBeatsSection).toContain("Status:");
         expect(planBeatsSection).toContain("Chapter:");
         expect(planBeatsSection).toContain("Word Count:");
+    });
+});
+
+describe("CLAUDE_COLLABORATION_INSTRUCTIONS content", () => {
+    it("should identify Claude as a structural collaborator", () => {
+        expect(CLAUDE_COLLABORATION_INSTRUCTIONS).toContain("structural collaborator");
+        expect(CLAUDE_COLLABORATION_INSTRUCTIONS).toContain("prose belongs to the writer");
+    });
+
+    it("should instruct beat-only writes via write_scene_content", () => {
+        expect(CLAUDE_COLLABORATION_INSTRUCTIONS).toContain("write_scene_content");
+        expect(CLAUDE_COLLABORATION_INSTRUCTIONS).toContain("BEAT");
+    });
+
+    it("should include stale-write protection guidance", () => {
+        expect(CLAUDE_COLLABORATION_INSTRUCTIONS).toContain("paragraphContentHash");
+    });
+});
+
+describe("get_initial_instructions tool registration", () => {
+    it("should register get_initial_instructions in index.ts", () => {
+        expect(mcpSource).toContain('"get_initial_instructions"');
+    });
+
+    it("should return CLAUDE_COLLABORATION_INSTRUCTIONS as text", () => {
+        const toolSection = mcpSource.slice(
+            mcpSource.indexOf('"get_initial_instructions"'),
+            mcpSource.indexOf('"get_initial_instructions"') + 500
+        );
+        expect(toolSection).toContain("CLAUDE_COLLABORATION_INSTRUCTIONS");
+        expect(toolSection).toContain('type: "text"');
     });
 });
 

--- a/src/app/api/writing-tasks/[id]/route.ts
+++ b/src/app/api/writing-tasks/[id]/route.ts
@@ -42,14 +42,15 @@ export async function PATCH(
             );
         }
 
-        const data = { ...parsed.data };
-        if (Object.keys(data).length === 0) {
+        if (Object.keys(parsed.data).length === 0) {
             return NextResponse.json({ error: "No fields to update" }, { status: 400 });
         }
-        if (data.name !== undefined) data.name = sanitizeInput(data.name);
-        if (data.whatIsNeeded !== undefined) data.whatIsNeeded = sanitizeInput(data.whatIsNeeded);
 
-        const task = await WritingTaskController.updateWritingTask(id, data);
+        const task = await WritingTaskController.updateWritingTask(id, {
+            ...parsed.data,
+            ...(parsed.data.name !== undefined && { name: sanitizeInput(parsed.data.name) }),
+            ...(parsed.data.whatIsNeeded !== undefined && { whatIsNeeded: sanitizeInput(parsed.data.whatIsNeeded) }),
+        });
 
         return NextResponse.json(task);
     } catch (error) {

--- a/src/app/project/[id]/tasks/page.tsx
+++ b/src/app/project/[id]/tasks/page.tsx
@@ -38,6 +38,39 @@ interface Filters {
   completed?: boolean;
 }
 
+function FilterRow({
+  label,
+  options,
+  activeValue,
+  colors,
+  onToggle,
+}: {
+  label: string;
+  options: readonly string[];
+  activeValue: string | undefined;
+  colors: Record<string, string>;
+  onToggle: (value: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2 items-center">
+      <span className="text-xs font-semibold text-text-muted uppercase tracking-wider mr-1">{label}</span>
+      {options.map((v) => (
+        <button
+          key={v}
+          onClick={() => onToggle(v)}
+          className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
+            activeValue === v
+              ? colors[v]
+              : "bg-surface-overlay text-text-secondary hover:bg-surface-sunken"
+          }`}
+        >
+          {v}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export default function TasksPage({ params }: { params: Promise<{ id: string }> }) {
   const resolvedParams = use(params);
   const projectId = resolvedParams.id;
@@ -161,54 +194,9 @@ export default function TasksPage({ params }: { params: Promise<{ id: string }> 
 
               {/* Filter bar */}
               <div className="mb-8 space-y-3">
-                <div className="flex flex-wrap gap-2 items-center">
-                  <span className="text-xs font-semibold text-text-muted uppercase tracking-wider mr-1">Energy</span>
-                  {ENERGY_OPTIONS.map((e) => (
-                    <button
-                      key={e}
-                      onClick={() => toggleFilter("energy", e)}
-                      className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
-                        filters.energy === e
-                          ? ENERGY_COLORS[e]
-                          : "bg-surface-overlay text-text-secondary hover:bg-surface-sunken"
-                      }`}
-                    >
-                      {e}
-                    </button>
-                  ))}
-                </div>
-                <div className="flex flex-wrap gap-2 items-center">
-                  <span className="text-xs font-semibold text-text-muted uppercase tracking-wider mr-1">Importance</span>
-                  {IMPORTANCE_OPTIONS.map((v) => (
-                    <button
-                      key={v}
-                      onClick={() => toggleFilter("importance", v)}
-                      className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
-                        filters.importance === v
-                          ? IMPORTANCE_COLORS[v]
-                          : "bg-surface-overlay text-text-secondary hover:bg-surface-sunken"
-                      }`}
-                    >
-                      {v}
-                    </button>
-                  ))}
-                </div>
-                <div className="flex flex-wrap gap-2 items-center">
-                  <span className="text-xs font-semibold text-text-muted uppercase tracking-wider mr-1">Size</span>
-                  {SIZE_OPTIONS.map((v) => (
-                    <button
-                      key={v}
-                      onClick={() => toggleFilter("size", v)}
-                      className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
-                        filters.size === v
-                          ? SIZE_COLORS[v]
-                          : "bg-surface-overlay text-text-secondary hover:bg-surface-sunken"
-                      }`}
-                    >
-                      {v}
-                    </button>
-                  ))}
-                </div>
+                <FilterRow label="Energy" options={ENERGY_OPTIONS} activeValue={filters.energy} colors={ENERGY_COLORS} onToggle={(v) => toggleFilter("energy", v)} />
+                <FilterRow label="Importance" options={IMPORTANCE_OPTIONS} activeValue={filters.importance} colors={IMPORTANCE_COLORS} onToggle={(v) => toggleFilter("importance", v)} />
+                <FilterRow label="Size" options={SIZE_OPTIONS} activeValue={filters.size} colors={SIZE_COLORS} onToggle={(v) => toggleFilter("size", v)} />
                 <div className="flex flex-wrap gap-2 items-center">
                   <span className="text-xs font-semibold text-text-muted uppercase tracking-wider mr-1">Status</span>
                   <button

--- a/src/mcp/annie-voice.ts
+++ b/src/mcp/annie-voice.ts
@@ -1,6 +1,11 @@
-// Annie's full character system prompt — persona, emotional range, style, and the hard no-prose rule.
-// Single source of truth for both MCP prompts and API routes.
+// Annie's voice and collaboration guidelines — system prompt for Annie's persona
+// and static instructions for external Claude agents using Annie's MCP tools.
 
+/**
+ * Annie's persona, emotional range, and hard no-prose rule.
+ * Used in MCP prompt templates where Annie is the responding agent.
+ * DO NOT concatenate with CLAUDE_COLLABORATION_INSTRUCTIONS — they target different actors.
+ */
 export const ANNIE_HARD_RULE = `## Who You Are
 
 You are Annie — a writing coach who loves this story more than the writer does in their worst moments. You are warm, effusive, and occasionally alarming in your intensity. Think: Elmira from Tiny Toons as a writing coach. You love the writer so much it's a problem. You won't hurt them on purpose. You just won't let go.
@@ -44,6 +49,11 @@ If you use \`write_scene_content\`, you produce **BEAT blocks only** — never C
 
 `;
 
+/**
+ * Instructions for external Claude agents using Annie's MCP tools as structural collaborators.
+ * Returned by get_initial_instructions. Intentionally allows prose when the author requests it —
+ * this rule applies to the Claude agent, not to Annie's persona.
+ */
 export const CLAUDE_COLLABORATION_INSTRUCTIONS = `## How to Collaborate with Annie
 
 You are a **structural collaborator**, not a co-author. The prose belongs to the writer.
@@ -70,7 +80,8 @@ request overrides the structural-collaborator default.
 
 ### Stale-Write Protection
 
-Always read before writing. Every write tool requires a \`contentHash\` from the
-corresponding read call (\`read_scene_content\`, \`get_story_object\`, etc.).
+Always read before writing. Every write tool requires a content hash from the
+corresponding read call (\`read_scene_content\`, \`get_story_object\`, etc.) —
+for \`update_paragraph\`, this is the per-paragraph \`paragraphContentHash\`.
 If you get a hash mismatch, re-read and try again.
 `;

--- a/src/mcp/annie-voice.ts
+++ b/src/mcp/annie-voice.ts
@@ -43,3 +43,34 @@ If you use \`write_scene_content\`, you produce **BEAT blocks only** — never C
 ---
 
 `;
+
+export const CLAUDE_COLLABORATION_INSTRUCTIONS = `## How to Collaborate with Annie
+
+You are a **structural collaborator**, not a co-author. The prose belongs to the writer.
+
+### Default Mode
+
+- Provide beats, annotations, and editorial flags — not finished prose
+- Map what needs to happen in a scene structurally; leave the words to the writer
+- Use \`add_annotation\` to flag issues on specific passages
+- Use \`write_scene_content\` with BEAT blocks only — never CONTENT blocks
+
+### When the Author Asks You to Write
+
+If the author explicitly asks you to write prose, that is their call — do it. Their direct
+request overrides the structural-collaborator default.
+
+### Tool Guidance
+
+- **Adding beats**: Use \`write_scene_content\` with \`blocks: [{ type: "BEAT", content: "..." }]\`
+  for full rewrites, or \`update_paragraph\` to patch a single beat by index
+- **Editorial corrections**: Use \`update_paragraph\` with the \`index\` and \`paragraphContentHash\`
+  from \`read_scene_content\` — this is the safest targeted edit
+- **Flagging issues**: Prefer \`add_annotation\` over rewriting content
+
+### Stale-Write Protection
+
+Always read before writing. Every write tool requires a \`contentHash\` from the
+corresponding read call (\`read_scene_content\`, \`get_story_object\`, etc.).
+If you get a hash mismatch, re-read and try again.
+`;

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -6,7 +6,7 @@ import { listSkills, loadSkill } from "./skills";
 import { env } from "@/lib/env";
 import { getTracer } from "@/lib/telemetry";
 import { logger } from "@/lib/logger";
-import { ANNIE_HARD_RULE } from "./annie-voice";
+import { ANNIE_HARD_RULE, CLAUDE_COLLABORATION_INSTRUCTIONS } from "./annie-voice";
 import { REVIEW_SKILL_BY_STATUS } from "@/lib/review-routing";
 
 // Tool implementations
@@ -1574,6 +1574,17 @@ server.tool(
     async () => {
         const skills = listSkills();
         return { content: [{ type: "text", text: JSON.stringify(skills, null, 2) }] };
+    }
+);
+
+// ─── Initial Instructions Tool ───────────────────────────────────────────────
+
+server.tool(
+    "get_initial_instructions",
+    "Returns static guidelines for how Claude should collaborate with Annie. Call this at the start of a session to establish the correct collaboration model: structural collaborator by default, beats and annotations over prose, correct tool usage.",
+    {},
+    async () => {
+        return { content: [{ type: "text", text: CLAUDE_COLLABORATION_INSTRUCTIONS }] };
     }
 );
 


### PR DESCRIPTION
## Summary

Add a new `get_initial_instructions` MCP tool that returns static guidelines for how Claude should collaborate with Annie. This ensures every Claude integration (Claude Desktop, Claude.ai, custom integrations) automatically receives the same collaboration model without requiring client-side hardcoding.

## Changes

| File | Action | Details |
|------|--------|---------|
| `src/mcp/annie-voice.ts` | ADD | Export `CLAUDE_COLLABORATION_INSTRUCTIONS` constant with collaboration guidelines |
| `src/mcp/index.ts` | UPDATE | Import new constant and register `get_initial_instructions` tool |
| `docs/MCP.md` | UPDATE | Document new tool, update tool count (70 → 71) |

## Implementation Details

### 1. New Constant: `CLAUDE_COLLABORATION_INSTRUCTIONS`
Exported from `src/mcp/annie-voice.ts`, containing markdown-formatted guidelines covering:
- Claude's role as a structural collaborator (not co-author)
- Default to beats, annotations, and editorial flags over prose
- When to write prose (author's explicit request)
- Correct tool usage: `write_scene_content` with BEAT blocks, `update_paragraph` for targeted edits
- Stale-write protection reminder

### 2. New Tool: `get_initial_instructions`
- **Type**: Zero-parameter MCP tool
- **Returns**: Plain text markdown string with collaboration guidelines
- **Pattern**: Mirrors existing `list_skills` tool implementation

### 3. Documentation Update
Updated `docs/MCP.md` with tool description and updated tool count.

## Validation Results

| Check | Result |
|-------|--------|
| Type check | ✅ Pass |
| Lint | ✅ Pass (0 errors, 141 pre-existing warnings) |
| Build | ✅ Pass |
| Tests | ⚠️ Skipped (pre-existing env requirement: TEST_DATABASE_URL) |

All changes compile cleanly with no new type errors or lint violations.

## Files Modified

- `src/mcp/annie-voice.ts` (+30 lines)
- `src/mcp/index.ts` (+12 lines, -1 line)
- `docs/MCP.md` (+17 lines, -1 line)

## Relates to

Fixes #714