### PR TITLE
Add editorial intent to update_paragraph

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -232,6 +232,22 @@ Write new content to a scene. Provide `content` (HTML) or `blocks` (structured b
 
 ---
 
+#### `update_paragraph`
+Patch a single paragraph or beat within a scene by its index. Requires `paragraphContentHash`
+to prevent stale overwrites. Use `intent: "editorial"` when correcting the author's existing
+words (typos, punctuation, wording fixes) rather than replacing them with AI-generated prose.
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `nodeId` | string | The scene node ID |
+| `index` | number | The paragraph index from the paragraphs array |
+| `content` | string | New content for this paragraph (must match existing type: CONTENT or BEAT) |
+| `paragraphContentHash` | string | The `contentHash` from `paragraphs[index]` in `read_scene_content` |
+| `sceneContentHash` | string? | Optional scene-level hash for additional stale protection |
+| `intent` | `"editorial"` \| `"creative"` | Optional. `"editorial"` signals the author's words are being corrected — prose-writing guard does not apply. Omit or use `"creative"` for standard behavior. |
+
+---
+
 #### `get_scene_versions`
 List version history of a scene (timestamps and word counts).
 

--- a/src/__tests__/mcp-guardrails.test.ts
+++ b/src/__tests__/mcp-guardrails.test.ts
@@ -144,6 +144,12 @@ describe("update_paragraph intent field", () => {
     it("CLAUDE_COLLABORATION_INSTRUCTIONS should mention intent: 'editorial' for editorial corrections", () => {
         expect(CLAUDE_COLLABORATION_INSTRUCTIONS).toContain('intent: "editorial"');
     });
+
+    it("update_paragraph handler should not destructure intent (semantic signal only)", () => {
+        const handlerArgsMatch = updateParagraphSection.match(/async \(\{([^}]+)\}\)/);
+        expect(handlerArgsMatch).not.toBeNull();
+        expect(handlerArgsMatch![1]).not.toContain("intent");
+    });
 });
 
 describe("get_initial_instructions tool registration", () => {

--- a/src/__tests__/mcp-guardrails.test.ts
+++ b/src/__tests__/mcp-guardrails.test.ts
@@ -120,6 +120,32 @@ describe("CLAUDE_COLLABORATION_INSTRUCTIONS content", () => {
     });
 });
 
+describe("update_paragraph intent field", () => {
+    const updateParagraphSection = mcpSource.slice(
+        mcpSource.indexOf('"update_paragraph"'),
+        mcpSource.indexOf('"update_paragraph"') + 1500
+    );
+
+    it("should include intent enum in the update_paragraph schema", () => {
+        expect(updateParagraphSection).toContain("intent");
+        expect(updateParagraphSection).toContain("editorial");
+        expect(updateParagraphSection).toContain("creative");
+    });
+
+    it("should describe the prose-writing guard exemption in the intent field description", () => {
+        expect(updateParagraphSection).toContain("prose-writing guard does not apply");
+    });
+
+    it("ANNIE_HARD_RULE should contain editorial intent exemption", () => {
+        expect(ANNIE_HARD_RULE).toContain("intent: 'editorial'");
+        expect(ANNIE_HARD_RULE).toContain("editorial intent");
+    });
+
+    it("CLAUDE_COLLABORATION_INSTRUCTIONS should mention intent: 'editorial' for editorial corrections", () => {
+        expect(CLAUDE_COLLABORATION_INSTRUCTIONS).toContain('intent: "editorial"');
+    });
+});
+
 describe("get_initial_instructions tool registration", () => {
     it("should register get_initial_instructions in index.ts", () => {
         expect(mcpSource).toContain('"get_initial_instructions"');

--- a/src/app/api/writing-tasks/[id]/route.ts
+++ b/src/app/api/writing-tasks/[id]/route.ts
@@ -46,11 +46,10 @@ export async function PATCH(
             return NextResponse.json({ error: "No fields to update" }, { status: 400 });
         }
 
-        const task = await WritingTaskController.updateWritingTask(id, {
-            ...parsed.data,
-            ...(parsed.data.name !== undefined && { name: sanitizeInput(parsed.data.name) }),
-            ...(parsed.data.whatIsNeeded !== undefined && { whatIsNeeded: sanitizeInput(parsed.data.whatIsNeeded) }),
-        });
+        const data = { ...parsed.data };
+        if (data.name !== undefined) data.name = sanitizeInput(data.name);
+        if (data.whatIsNeeded !== undefined) data.whatIsNeeded = sanitizeInput(data.whatIsNeeded);
+        const task = await WritingTaskController.updateWritingTask(id, data);
 
         return NextResponse.json(task);
     } catch (error) {

--- a/src/mcp/annie-voice.ts
+++ b/src/mcp/annie-voice.ts
@@ -45,6 +45,8 @@ You NEVER write narrative prose, finished passages, or CONTENT blocks. Your outp
 
 If you use \`write_scene_content\`, you produce **BEAT blocks only** — never CONTENT blocks. Beats are structural waypoints (what happens, what shifts, what the reader should feel), not finished prose.
 
+**Exception — editorial intent**: You may use \`update_paragraph\` with \`intent: 'editorial'\` to correct or rearrange the author's *existing* words (typos, punctuation, wording fixes). The words stay the author's — you are not writing prose, you are tending to it.
+
 ---
 
 `;
@@ -74,8 +76,9 @@ request overrides the structural-collaborator default.
 
 - **Adding beats**: Use \`write_scene_content\` with \`blocks: [{ type: "BEAT", content: "..." }]\`
   for full rewrites, or \`update_paragraph\` to patch a single beat by index
-- **Editorial corrections**: Use \`update_paragraph\` with the \`index\` and \`paragraphContentHash\`
-  from \`read_scene_content\` — this is the safest targeted edit
+- **Editorial corrections**: Use \`update_paragraph\` with \`intent: "editorial"\`, the \`index\`, and \`paragraphContentHash\`
+  from \`read_scene_content\` — this is the safest targeted edit. The \`intent: "editorial"\` flag signals
+  that you are correcting the author's existing words, not writing new prose.
 - **Flagging issues**: Prefer \`add_annotation\` over rewriting content
 
 ### Stale-Write Protection

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -376,13 +376,14 @@ server.tool(
 
 server.tool(
     "update_paragraph",
-    "Patch a single paragraph or beat within a scene by its index (from read_scene_content paragraphs array). Requires paragraphContentHash from the paragraph entry to prevent stale overwrites. Optionally also accepts sceneContentHash for scene-level stale detection.",
+    "Patch a single paragraph or beat within a scene by its index (from read_scene_content paragraphs array). Requires paragraphContentHash from the paragraph entry to prevent stale overwrites. Optionally also accepts sceneContentHash for scene-level stale detection. Set intent: 'editorial' when correcting or rearranging the author's existing words rather than replacing them with AI-generated prose.",
     {
         nodeId: z.string().describe("The scene node ID"),
         index: z.number().int().describe("The paragraph index from the paragraphs array"),
         content: z.string().describe("New content for this paragraph (must match the existing type — CONTENT or BEAT)"),
         paragraphContentHash: z.string().describe("The contentHash from the paragraphs[index] entry in read_scene_content"),
         sceneContentHash: z.string().optional().describe("Optional scene-level contentHash from read_scene_content for additional stale protection"),
+        intent: z.enum(["editorial", "creative"]).optional().describe("Intent signal: 'editorial' means the author's existing words are being corrected or rearranged (not replaced with AI-generated prose) — the prose-writing guard does not apply. When absent or 'creative', standard prose-writing rules apply."),
     },
     async ({ nodeId, index, content, paragraphContentHash, sceneContentHash }) => {
         const result = await updateParagraph(nodeId, index, content, paragraphContentHash, sceneContentHash);


### PR DESCRIPTION
## Summary

Add an optional `intent` field (`"editorial" | "creative"`) to the `update_paragraph` MCP tool so that agents can signal when they are correcting or rearranging the author's existing words (not generating new prose). Update Annie's hard-rule and Claude collaboration instructions to exempt `intent: 'editorial'` from the no-prose guard.

## Problem

`ANNIE_HARD_RULE` states "You NEVER write narrative prose, finished passages, or CONTENT blocks." This rule currently has no exception for editorial corrections to *existing* CONTENT blocks. When an agent uses `update_paragraph` to fix a typo or rearrange the author's own words, Annie's hard rule treats it the same as AI-generated prose — blocking the action. An `intent: 'editorial'` flag makes the distinction explicit at the protocol level.

## Changes

| File | Action | Details |
|------|--------|---------|
| `src/mcp/index.ts` | Update | Add `intent` enum field (`"editorial" | "creative"`) to `update_paragraph` schema |
| `src/mcp/annie-voice.ts` | Update | Update `ANNIE_HARD_RULE` to exempt `intent: 'editorial'` calls; update `CLAUDE_COLLABORATION_INSTRUCTIONS` to instruct agents to use `intent: 'editorial'` for editorial corrections |
| `src/__tests__/mcp-guardrails.test.ts` | Add | New guardrail tests verifying the intent field is present in the schema and the hard rule references it |

## Validation

- ✅ Type check: No errors
- ✅ Tests: 1038 passed, 0 failed
- ✅ Lint: 0 errors (141 pre-existing warnings unrelated to changes)
- ✅ Build: Compiled successfully

All tests pass. No type errors or lint issues introduced.

Fixes #712