### PR TITLE
feat: add insert_beat MCP tool

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -248,6 +248,20 @@ words (typos, punctuation, wording fixes) rather than replacing them with AI-gen
 
 ---
 
+#### `insert_beat`
+Insert a new beat block at a specific position in a scene. Because the payload contains
+only beat text (no CONTENT blocks), Annie's prose-writing guard never fires — prefer this
+tool over `write_scene_content` when adding structural waypoints without touching prose.
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `nodeId` | string | The scene node ID |
+| `afterParagraphIndex` | number | Insert beat after this block index (0-based, from `read_scene_content` blocks array — includes both CONTENT and BEAT blocks). Use `-1` to prepend before all existing blocks. |
+| `beatContent` | string | The beat text to insert (structural waypoint — not prose) |
+| `sceneContentHash` | string? | Optional scene-level `contentHash` from `read_scene_content` for stale detection |
+
+---
+
 #### `get_scene_versions`
 List version history of a scene (timestamps and word counts).
 

--- a/src/__tests__/structure-controller.test.ts
+++ b/src/__tests__/structure-controller.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { StructureController } from "@/lib/controllers/structure";
 import { ProjectsController } from "@/lib/controllers/projects";
+import { insertBeat } from "@/mcp/tools/structure";
 
 describe("StructureController", () => {
     describe("parseSceneContent", () => {
@@ -320,6 +321,75 @@ describe("StructureController", () => {
                 const withoutText = open.find((a) => a.content === "Without text");
                 expect(withoutText).toBeDefined();
                 expect(withoutText!.selectedText).toBeNull();
+            });
+        });
+
+        describe("insertBeat", () => {
+            it("inserts beat after given index", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(
+                    scene.id,
+                    "<p>Before</p><!-- beat: Existing --><p>After</p>"
+                );
+
+                const result = await insertBeat(scene.id, 0, "New beat");
+                expect(result.nodeId).toBe(scene.id);
+
+                const read = await StructureController.readSceneContent(scene.id);
+                expect(read.blocks).toHaveLength(4);
+                expect(read.blocks[0]).toEqual({ type: "CONTENT", content: "<p>Before</p>" });
+                expect(read.blocks[1]).toEqual({ type: "BEAT", content: "New beat" });
+                expect(read.blocks[2]).toEqual({ type: "BEAT", content: "Existing" });
+                expect(read.blocks[3]).toEqual({ type: "CONTENT", content: "<p>After</p>" });
+            });
+
+            it("inserts beat at index -1 (before all blocks)", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(scene.id, "<p>Existing</p>");
+
+                await insertBeat(scene.id, -1, "First beat");
+
+                const read = await StructureController.readSceneContent(scene.id);
+                expect(read.blocks).toHaveLength(2);
+                expect(read.blocks[0]).toEqual({ type: "BEAT", content: "First beat" });
+                expect(read.blocks[1]).toEqual({ type: "CONTENT", content: "<p>Existing</p>" });
+            });
+
+            it("throws if afterParagraphIndex is out of range", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(scene.id, "<p>Only</p>");
+
+                await expect(insertBeat(scene.id, 99, "Bad")).rejects.toThrow("out of range");
+                await expect(insertBeat(scene.id, -2, "Bad")).rejects.toThrow("out of range");
+            });
+
+            it("shifts existing blocks correctly", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContentFromBlocks(scene.id, [
+                    { type: "CONTENT", content: "<p>A</p>" },
+                    { type: "BEAT", content: "Existing beat" },
+                    { type: "CONTENT", content: "<p>C</p>" },
+                ]);
+
+                await insertBeat(scene.id, 1, "Between beat and C");
+
+                const read = await StructureController.readSceneContent(scene.id);
+                expect(read.blocks).toHaveLength(4);
+                expect(read.blocks[0]).toEqual({ type: "CONTENT", content: "<p>A</p>" });
+                expect(read.blocks[1]).toEqual({ type: "BEAT", content: "Existing beat" });
+                expect(read.blocks[2]).toEqual({ type: "BEAT", content: "Between beat and C" });
+                expect(read.blocks[3]).toEqual({ type: "CONTENT", content: "<p>C</p>" });
+            });
+
+            it("returns scene metadata", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(scene.id, "<p>Hello</p>");
+
+                const result = await insertBeat(scene.id, 0, "A beat");
+                expect(result.nodeId).toBe(scene.id);
+                expect(result.versionId).toBeDefined();
+                expect(result.wordCount).toBeDefined();
+                expect(result.createdAt).toBeDefined();
             });
         });
 

--- a/src/__tests__/structure-controller.test.ts
+++ b/src/__tests__/structure-controller.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { StructureController } from "@/lib/controllers/structure";
 import { ProjectsController } from "@/lib/controllers/projects";
 import { insertBeat } from "@/mcp/tools/structure";
+import { computeContentHash, StaleWriteError } from "@/mcp/content-hash";
 
 describe("StructureController", () => {
     describe("parseSceneContent", () => {
@@ -390,6 +391,23 @@ describe("StructureController", () => {
                 expect(result.versionId).toBeDefined();
                 expect(result.wordCount).toBeDefined();
                 expect(result.createdAt).toBeDefined();
+            });
+
+            it("rejects insert when sceneContentHash is stale", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(scene.id, "<p>Hello</p>");
+
+                const staleHash = computeContentHash("stale-content");
+                await expect(insertBeat(scene.id, 0, "New beat", staleHash)).rejects.toThrow(StaleWriteError);
+            });
+
+            it("accepts insert when sceneContentHash matches current content", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(scene.id, "<p>Hello</p>");
+
+                const current = await StructureController.readSceneContent(scene.id);
+                const hash = computeContentHash(current.content);
+                await expect(insertBeat(scene.id, 0, "New beat", hash)).resolves.toBeDefined();
             });
         });
 

--- a/src/app/project/[id]/tasks/page.tsx
+++ b/src/app/project/[id]/tasks/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo, use } from "react";
+import { useEffect, useState, use } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, CheckSquare, ListTodo } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -132,7 +132,7 @@ export default function TasksPage({ params }: { params: Promise<{ id: string }> 
   }
 
   const taskCount = tasks.length;
-  const completedCount = useMemo(() => tasks.filter((t) => t.completed).length, [tasks]);
+  const completedCount = tasks.filter((t) => t.completed).length;
 
   return (
     <div className="flex flex-col h-screen bg-surface">

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -20,6 +20,7 @@ import {
     writeSceneContent,
     writeSceneContentFromBlocks,
     updateParagraph,
+    insertBeat,
     getSceneVersions,
     restoreSceneVersion,
     addAnnotation,
@@ -387,6 +388,29 @@ server.tool(
     },
     async ({ nodeId, index, content, paragraphContentHash, sceneContentHash }) => {
         const result = await updateParagraph(nodeId, index, content, paragraphContentHash, sceneContentHash);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+);
+
+server.tool(
+    "insert_beat",
+    "Insert a new beat block after a specified paragraph index in a scene. The payload contains only beat text — no CONTENT blocks — so Annie's prose-writing guard never fires.",
+    {
+        nodeId: z.string().describe("The scene node ID"),
+        afterParagraphIndex: z
+            .number()
+            .int()
+            .describe(
+                "Insert the beat after this paragraph index (from read_scene_content paragraphs array). Use -1 to insert before all existing blocks.",
+            ),
+        beatContent: z.string().describe("The beat text to insert (structural waypoint — not prose)"),
+        sceneContentHash: z
+            .string()
+            .optional()
+            .describe("Optional scene-level contentHash from read_scene_content for stale detection"),
+    },
+    async ({ nodeId, afterParagraphIndex, beatContent, sceneContentHash }) => {
+        const result = await insertBeat(nodeId, afterParagraphIndex, beatContent, sceneContentHash);
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     }
 );

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -392,16 +392,18 @@ server.tool(
     }
 );
 
+// Note: insert_beat bypasses the prose-writing guard because the payload is beat
+// text only — no CONTENT blocks are written, so the guard condition never fires.
 server.tool(
     "insert_beat",
-    "Insert a new beat block after a specified paragraph index in a scene. The payload contains only beat text — no CONTENT blocks — so Annie's prose-writing guard never fires.",
+    "Insert a new beat block after a specified paragraph index in a scene. Use this tool for structural waypoints (beats), not prose — it writes only a BEAT block, keeping Annie's structural-vs-prose separation intact.",
     {
         nodeId: z.string().describe("The scene node ID"),
         afterParagraphIndex: z
             .number()
             .int()
             .describe(
-                "Insert the beat after this paragraph index (from read_scene_content paragraphs array). Use -1 to insert before all existing blocks.",
+                "Insert the beat after this block index (from read_scene_content paragraphs array — includes both CONTENT and BEAT blocks). Use -1 to insert before all existing blocks.",
             ),
         beatContent: z.string().describe("The beat text to insert (structural waypoint — not prose)"),
         sceneContentHash: z

--- a/src/mcp/tools/structure.ts
+++ b/src/mcp/tools/structure.ts
@@ -120,6 +120,31 @@ export async function updateParagraph(
     return result;
 }
 
+export async function insertBeat(
+    nodeId: string,
+    afterParagraphIndex: number,
+    beatContent: string,
+    sceneContentHash?: string,
+) {
+    const current = await StructureController.readSceneContent(nodeId);
+    if (sceneContentHash !== undefined) {
+        verifyContentHash(sceneContentHash, computeContentHash(current.content), "read_scene_content");
+    }
+    const blocks = current.blocks;
+    // afterParagraphIndex of -1 means "insert at the very beginning"
+    if (afterParagraphIndex < -1 || afterParagraphIndex >= blocks.length) {
+        throw new Error(
+            `afterParagraphIndex ${afterParagraphIndex} out of range (-1–${blocks.length - 1})`
+        );
+    }
+    const insertAt = afterParagraphIndex + 1;
+    blocks.splice(insertAt, 0, { type: "BEAT", content: beatContent });
+    const result = await StructureController.writeSceneContentFromBlocks(nodeId, blocks);
+    mcpCache.delete(`sceneContent:${nodeId}`);
+    invalidateStructureCaches();
+    return result;
+}
+
 export async function writeSceneContent(nodeId: string, content: string, contentHash?: string) {
     if (contentHash !== undefined) {
         const current = await StructureController.readSceneContent(nodeId);


### PR DESCRIPTION
## Summary

Add `insert_beat` MCP tool to insert a new beat block after a specified paragraph index in a scene. This eliminates the need to resubmit full scene content when adding structural waypoints — beats can be inserted with just beat text, bypassing Annie's prose-writing guard.

## Changes

- **`src/mcp/tools/structure.ts`**: Add `insertBeat(nodeId, afterParagraphIndex, beatContent, sceneContentHash?)` function following `updateParagraph` pattern
- **`src/mcp/index.ts`**: Register `insert_beat` MCP tool with Zod schema and handler
- **`src/__tests__/structure-controller.test.ts`**: Add comprehensive tests for insert_beat behavior (5 test cases covering middle insert, prepend, boundary conditions, and error cases)

## Validation Results

✅ **Type check**: No errors (`npx tsc --noEmit`)
✅ **Tests**: 1044 passed, 0 failed (89 test files)
✅ **Lint**: 0 errors, 141 pre-existing warnings
✅ **Build**: Production build compiled successfully

## Key Behaviors

- Inserts BEAT block at position `afterParagraphIndex + 1`
- Accepts `-1` to prepend beat before all blocks
- Validates index is within valid range `-1` to `blocks.length - 1`
- Optional `sceneContentHash` parameter for stale-write detection
- Returns updated scene metadata (nodeId, versionId, wordCount, createdAt)

Fixes #711