### PR TITLE
fix: insert_beat uses paragraph-level targeting with CONTENT block split

### DIFF
--- a/src/__tests__/mcp-tools.test.ts
+++ b/src/__tests__/mcp-tools.test.ts
@@ -88,6 +88,18 @@ describe("MCP Structure Tools", () => {
         expect(result.paragraphs[0].contentHash).toHaveLength(64);
     });
 
+    it("readSceneContent paragraphs splits multi-paragraph CONTENT blocks", async () => {
+        const scene = await structureTools.createNode({ projectId, type: "SCENE", title: "S1" });
+        const { contentHash } = await structureTools.readSceneContent(scene.id);
+        await structureTools.writeSceneContent(scene.id, "<p>P1</p><p>P2</p><!-- beat: B1 --><p>P3</p>", contentHash);
+        const result = await structureTools.readSceneContent(scene.id);
+        expect(result.paragraphs).toHaveLength(4);
+        expect(result.paragraphs[0]).toMatchObject({ index: 0, type: "CONTENT", content: "<p>P1</p>" });
+        expect(result.paragraphs[1]).toMatchObject({ index: 1, type: "CONTENT", content: "<p>P2</p>" });
+        expect(result.paragraphs[2]).toMatchObject({ index: 2, type: "BEAT", content: "B1" });
+        expect(result.paragraphs[3]).toMatchObject({ index: 3, type: "CONTENT", content: "<p>P3</p>" });
+    });
+
     it("updateParagraph patches a single paragraph by index", async () => {
         const scene = await structureTools.createNode({ projectId, type: "SCENE", title: "S1" });
         const { contentHash } = await structureTools.readSceneContent(scene.id);

--- a/src/__tests__/mcp-tools.test.ts
+++ b/src/__tests__/mcp-tools.test.ts
@@ -117,6 +117,45 @@ describe("MCP Structure Tools", () => {
         expect(updated.paragraphs[2].content).toBe("<p>More text</p>");
     });
 
+    it("updateParagraph patches middle paragraph inside a multi-paragraph CONTENT block", async () => {
+        const scene = await structureTools.createNode({ projectId, type: "SCENE", title: "S1" });
+        const { contentHash } = await structureTools.readSceneContent(scene.id);
+        await structureTools.writeSceneContent(scene.id, "<p>P1</p><p>P2</p><p>P3</p>", contentHash);
+        const read = await structureTools.readSceneContent(scene.id);
+        const para = read.paragraphs[1];
+        await structureTools.updateParagraph(scene.id, 1, "<p>Updated P2</p>", para.contentHash);
+        const updated = await structureTools.readSceneContent(scene.id);
+        expect(updated.paragraphs).toHaveLength(3);
+        expect(updated.paragraphs[0].content).toBe("<p>P1</p>");
+        expect(updated.paragraphs[1].content).toBe("<p>Updated P2</p>");
+        expect(updated.paragraphs[2].content).toBe("<p>P3</p>");
+    });
+
+    it("updateParagraph patches first paragraph inside a multi-paragraph CONTENT block", async () => {
+        const scene = await structureTools.createNode({ projectId, type: "SCENE", title: "S1" });
+        const { contentHash } = await structureTools.readSceneContent(scene.id);
+        await structureTools.writeSceneContent(scene.id, "<p>A</p><p>B</p>", contentHash);
+        const read = await structureTools.readSceneContent(scene.id);
+        await structureTools.updateParagraph(scene.id, 0, "<p>Updated A</p>", read.paragraphs[0].contentHash);
+        const updated = await structureTools.readSceneContent(scene.id);
+        expect(updated.paragraphs[0].content).toBe("<p>Updated A</p>");
+        expect(updated.paragraphs[1].content).toBe("<p>B</p>");
+    });
+
+    it("readSceneContent paragraphs correctly splits CONTENT block with attributed <p> tags", async () => {
+        const scene = await structureTools.createNode({ projectId, type: "SCENE", title: "S1" });
+        const { contentHash } = await structureTools.readSceneContent(scene.id);
+        await structureTools.writeSceneContent(
+            scene.id,
+            '<p class="indent">First</p><p data-id="2">Second</p>',
+            contentHash,
+        );
+        const result = await structureTools.readSceneContent(scene.id);
+        expect(result.paragraphs).toHaveLength(2);
+        expect(result.paragraphs[0].content).toBe('<p class="indent">First</p>');
+        expect(result.paragraphs[1].content).toBe('<p data-id="2">Second</p>');
+    });
+
     it("updateParagraph rejects stale paragraphContentHash", async () => {
         const scene = await structureTools.createNode({ projectId, type: "SCENE", title: "S1" });
         const { contentHash } = await structureTools.readSceneContent(scene.id);

--- a/src/__tests__/structure-controller.test.ts
+++ b/src/__tests__/structure-controller.test.ts
@@ -409,6 +409,52 @@ describe("StructureController", () => {
                 const hash = computeContentHash(current.content);
                 await expect(insertBeat(scene.id, 0, "New beat", hash)).resolves.toBeDefined();
             });
+
+            it("splits single CONTENT block when inserting after first paragraph", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(scene.id, "<p>P1</p><p>P2</p><p>P3</p>");
+
+                await insertBeat(scene.id, 0, "After P1");
+
+                const read = await StructureController.readSceneContent(scene.id);
+                expect(read.blocks).toHaveLength(3);
+                expect(read.blocks[0]).toEqual({ type: "CONTENT", content: "<p>P1</p>" });
+                expect(read.blocks[1]).toEqual({ type: "BEAT", content: "After P1" });
+                expect(read.blocks[2]).toEqual({ type: "CONTENT", content: "<p>P2</p><p>P3</p>" });
+            });
+
+            it("splits single CONTENT block when inserting after middle paragraph", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(scene.id, "<p>P1</p><p>P2</p><p>P3</p>");
+
+                await insertBeat(scene.id, 1, "After P2");
+
+                const read = await StructureController.readSceneContent(scene.id);
+                expect(read.blocks).toHaveLength(3);
+                expect(read.blocks[0]).toEqual({ type: "CONTENT", content: "<p>P1</p><p>P2</p>" });
+                expect(read.blocks[1]).toEqual({ type: "BEAT", content: "After P2" });
+                expect(read.blocks[2]).toEqual({ type: "CONTENT", content: "<p>P3</p>" });
+            });
+
+            it("does not create empty CONTENT block when inserting after last paragraph", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(scene.id, "<p>P1</p><p>P2</p><p>P3</p>");
+
+                await insertBeat(scene.id, 2, "After last");
+
+                const read = await StructureController.readSceneContent(scene.id);
+                expect(read.blocks).toHaveLength(2);
+                expect(read.blocks[0]).toEqual({ type: "CONTENT", content: "<p>P1</p><p>P2</p><p>P3</p>" });
+                expect(read.blocks[1]).toEqual({ type: "BEAT", content: "After last" });
+            });
+
+            it("out-of-range uses total paragraph count not block count", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(scene.id, "<p>A</p><p>B</p><p>C</p>");
+
+                await expect(insertBeat(scene.id, 3, "Bad")).rejects.toThrow("out of range");
+                await expect(insertBeat(scene.id, -2, "Bad")).rejects.toThrow("out of range");
+            });
         });
 
         describe("writeSceneContentFromBlocks", () => {

--- a/src/__tests__/structure-controller.test.ts
+++ b/src/__tests__/structure-controller.test.ts
@@ -448,6 +448,32 @@ describe("StructureController", () => {
                 expect(read.blocks[1]).toEqual({ type: "BEAT", content: "After last" });
             });
 
+            it("treats non-<p> CONTENT block as a single atomic paragraph", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContentFromBlocks(scene.id, [
+                    { type: "CONTENT", content: "raw text without p tags" },
+                ]);
+                await insertBeat(scene.id, 0, "After raw");
+                const read = await StructureController.readSceneContent(scene.id);
+                expect(read.blocks).toHaveLength(2);
+                expect(read.blocks[0]).toEqual({ type: "CONTENT", content: "raw text without p tags" });
+                expect(read.blocks[1]).toEqual({ type: "BEAT", content: "After raw" });
+            });
+
+            it("splits block containing attributed <p> tags correctly", async () => {
+                const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
+                await StructureController.writeSceneContent(
+                    scene.id,
+                    '<p class="a">First</p><p class="b">Second</p>',
+                );
+                await insertBeat(scene.id, 0, "Mid beat");
+                const read = await StructureController.readSceneContent(scene.id);
+                expect(read.blocks).toHaveLength(3);
+                expect(read.blocks[0]).toEqual({ type: "CONTENT", content: '<p class="a">First</p>' });
+                expect(read.blocks[1]).toEqual({ type: "BEAT", content: "Mid beat" });
+                expect(read.blocks[2]).toEqual({ type: "CONTENT", content: '<p class="b">Second</p>' });
+            });
+
             it("out-of-range uses total paragraph count not block count", async () => {
                 const scene = await StructureController.createNode({ projectId, type: "SCENE", title: "S1" });
                 await StructureController.writeSceneContent(scene.id, "<p>A</p><p>B</p><p>C</p>");

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -404,7 +404,7 @@ server.tool(
             .number()
             .int()
             .describe(
-                "Insert the beat after this block index (from read_scene_content paragraphs array — includes both CONTENT and BEAT blocks). Use -1 to insert before all existing blocks.",
+                "Scene-level paragraph index (from read_scene_content paragraphs array). Each <p> element and each BEAT block is one paragraph. Use -1 to insert before all paragraphs, 0 to insert after the first paragraph, etc. When the target falls inside a CONTENT block, the block is split automatically.",
             ),
         beatContent: z.string().describe("The beat text to insert (structural waypoint — not prose)"),
         sceneContentHash: z

--- a/src/mcp/tools/structure.ts
+++ b/src/mcp/tools/structure.ts
@@ -83,6 +83,8 @@ type FlatParagraph = {
     content: string;
 };
 
+// [\s\S]*? instead of .*? so <p> elements with embedded newlines are matched in full.
+// Only use with match() — the /g flag makes lastIndex stateful, so exec() in a loop would fail across call sites.
 const P_TAG_RE = /<p(?:\s[^>]*)?>[\s\S]*?<\/p>/gi;
 
 function flattenBlocksToParagraphs(
@@ -111,6 +113,13 @@ function flattenBlocksToParagraphs(
     return result;
 }
 
+/**
+ * Splits `blockContent` after the paragraph at the given 0-based position.
+ * Returns [left, right] where left includes paragraphs 0..afterNthParagraph
+ * and right contains the remainder. right is "" when splitting after the last paragraph.
+ *
+ * @param afterNthParagraph - 0-based index of the paragraph to split after
+ */
 function splitAtParagraph(blockContent: string, afterNthParagraph: number): [string, string] {
     let count = 0;
     const re = /<\/p>/gi;
@@ -169,12 +178,18 @@ export async function updateParagraph(
         blocks[entry.blockIndex] = { type: "BEAT", content };
     } else {
         const blockContent = blocks[entry.blockIndex].content;
+        // Count how many <p> elements are in this block
         const matches = blockContent.match(P_TAG_RE);
         if (!matches || matches.length <= 1) {
             blocks[entry.blockIndex] = { type: "CONTENT", content };
         } else {
-            matches[entry.positionWithinBlock] = content;
-            blocks[entry.blockIndex] = { type: "CONTENT", content: matches.join("") };
+            // Use positional splits to replace only the target paragraph, preserving
+            // any inter-<p> content (e.g. whitespace) that match().join("") would drop.
+            const pos = entry.positionWithinBlock;
+            const before = pos === 0 ? "" : splitAtParagraph(blockContent, pos - 1)[0];
+            const restFromTarget = pos === 0 ? blockContent : splitAtParagraph(blockContent, pos - 1)[1];
+            const [, after] = splitAtParagraph(restFromTarget, 0);
+            blocks[entry.blockIndex] = { type: "CONTENT", content: before + content + after };
         }
     }
     const result = await StructureController.writeSceneContentFromBlocks(nodeId, blocks);
@@ -206,7 +221,7 @@ export async function insertBeat(
         blocks.splice(0, 0, { type: "BEAT", content: beatContent });
     } else {
         const entry = flat[afterParagraphIndex];
-        // Count how many <p> tags are in this block
+        // Count how many <p> elements are in this block
         const blockContent = blocks[entry.blockIndex].content;
         const matches = blockContent.match(P_TAG_RE);
         const isLastPInBlock = entry.type === "BEAT" || !matches || entry.positionWithinBlock === matches.length - 1;

--- a/src/mcp/tools/structure.ts
+++ b/src/mcp/tools/structure.ts
@@ -186,9 +186,8 @@ export async function updateParagraph(
             // Use positional splits to replace only the target paragraph, preserving
             // any inter-<p> content (e.g. whitespace) that match().join("") would drop.
             const pos = entry.positionWithinBlock;
-            const before = pos === 0 ? "" : splitAtParagraph(blockContent, pos - 1)[0];
-            const restFromTarget = pos === 0 ? blockContent : splitAtParagraph(blockContent, pos - 1)[1];
-            const [, after] = splitAtParagraph(restFromTarget, 0);
+            const [before, rest] = pos === 0 ? ["", blockContent] : splitAtParagraph(blockContent, pos - 1);
+            const [, after] = splitAtParagraph(rest, 0);
             blocks[entry.blockIndex] = { type: "CONTENT", content: before + content + after };
         }
     }

--- a/src/mcp/tools/structure.ts
+++ b/src/mcp/tools/structure.ts
@@ -75,16 +75,67 @@ export async function deleteNode(nodeId: string) {
     return result;
 }
 
+type FlatParagraph = {
+    globalIndex: number;
+    blockIndex: number;
+    positionWithinBlock: number;
+    type: "CONTENT" | "BEAT";
+    content: string;
+};
+
+const P_TAG_RE = /<p(?:\s[^>]*)?>[\s\S]*?<\/p>/gi;
+
+function flattenBlocksToParagraphs(
+    blocks: { type: "CONTENT" | "BEAT"; content: string }[],
+): FlatParagraph[] {
+    const result: FlatParagraph[] = [];
+    let globalIndex = 0;
+    for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
+        const block = blocks[blockIndex];
+        if (block.type === "BEAT") {
+            result.push({ globalIndex, blockIndex, positionWithinBlock: 0, type: "BEAT", content: block.content });
+            globalIndex++;
+        } else {
+            const matches = block.content.match(P_TAG_RE);
+            if (!matches || matches.length === 0) {
+                result.push({ globalIndex, blockIndex, positionWithinBlock: 0, type: "CONTENT", content: block.content });
+                globalIndex++;
+            } else {
+                for (let i = 0; i < matches.length; i++) {
+                    result.push({ globalIndex, blockIndex, positionWithinBlock: i, type: "CONTENT", content: matches[i] });
+                    globalIndex++;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+function splitAtParagraph(blockContent: string, afterNthParagraph: number): [string, string] {
+    let count = 0;
+    const re = /<\/p>/gi;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(blockContent)) !== null) {
+        count++;
+        if (count === afterNthParagraph + 1) {
+            const splitPos = match.index + match[0].length;
+            return [blockContent.slice(0, splitPos), blockContent.slice(splitPos)];
+        }
+    }
+    return [blockContent, ""];
+}
+
 export async function readSceneContent(nodeId: string) {
     const raw = await mcpCache.getOrSet(
         `sceneContent:${nodeId}`,
         () => StructureController.readSceneContent(nodeId),
     );
-    const paragraphs = raw.blocks.map((block, index) => ({
-        index,
-        type: block.type,
-        content: block.content,
-        contentHash: computeContentHash(String(index), block.type, block.content),
+    const flat = flattenBlocksToParagraphs(raw.blocks);
+    const paragraphs = flat.map((entry) => ({
+        index: entry.globalIndex,
+        type: entry.type,
+        content: entry.content,
+        contentHash: computeContentHash(String(entry.globalIndex), entry.type, entry.content),
     }));
     return {
         ...raw,
@@ -105,15 +156,27 @@ export async function updateParagraph(
         verifyContentHash(sceneContentHash, computeContentHash(current.content), "read_scene_content");
     }
     const blocks = current.blocks;
-    if (index < 0 || index >= blocks.length) {
-        throw new Error(`Paragraph index ${index} out of range (0–${blocks.length - 1})`);
+    const flat = flattenBlocksToParagraphs(blocks);
+    if (index < 0 || index >= flat.length) {
+        throw new Error(`Paragraph index ${index} out of range (0–${flat.length - 1})`);
     }
-    const block = blocks[index];
+    const entry = flat[index];
     if (paragraphContentHash !== undefined) {
-        const expected = computeContentHash(String(index), block.type, block.content);
+        const expected = computeContentHash(String(index), entry.type, entry.content);
         verifyContentHash(paragraphContentHash, expected, "read_scene_content");
     }
-    blocks[index] = { type: block.type, content };
+    if (entry.type === "BEAT") {
+        blocks[entry.blockIndex] = { type: "BEAT", content };
+    } else {
+        const blockContent = blocks[entry.blockIndex].content;
+        const matches = blockContent.match(P_TAG_RE);
+        if (!matches || matches.length <= 1) {
+            blocks[entry.blockIndex] = { type: "CONTENT", content };
+        } else {
+            matches[entry.positionWithinBlock] = content;
+            blocks[entry.blockIndex] = { type: "CONTENT", content: matches.join("") };
+        }
+    }
     const result = await StructureController.writeSceneContentFromBlocks(nodeId, blocks);
     mcpCache.delete(`sceneContent:${nodeId}`);
     invalidateStructureCaches();
@@ -131,14 +194,39 @@ export async function insertBeat(
         verifyContentHash(sceneContentHash, computeContentHash(current.content), "read_scene_content");
     }
     const blocks = current.blocks;
+    const flat = flattenBlocksToParagraphs(blocks);
+    const totalParagraphs = flat.length;
     // afterParagraphIndex of -1 means "insert at the very beginning"
-    if (afterParagraphIndex < -1 || afterParagraphIndex >= blocks.length) {
+    if (afterParagraphIndex < -1 || afterParagraphIndex >= totalParagraphs) {
         throw new Error(
-            `afterParagraphIndex ${afterParagraphIndex} out of range (-1–${blocks.length - 1})`
+            `afterParagraphIndex ${afterParagraphIndex} out of range (-1–${totalParagraphs - 1})`
         );
     }
-    const insertAt = afterParagraphIndex + 1;
-    blocks.splice(insertAt, 0, { type: "BEAT", content: beatContent });
+    if (afterParagraphIndex === -1) {
+        blocks.splice(0, 0, { type: "BEAT", content: beatContent });
+    } else {
+        const entry = flat[afterParagraphIndex];
+        // Count how many <p> tags are in this block
+        const blockContent = blocks[entry.blockIndex].content;
+        const matches = blockContent.match(P_TAG_RE);
+        const isLastPInBlock = entry.type === "BEAT" || !matches || entry.positionWithinBlock === matches.length - 1;
+
+        if (isLastPInBlock) {
+            // Insert beat after this block (no split needed)
+            blocks.splice(entry.blockIndex + 1, 0, { type: "BEAT", content: beatContent });
+        } else {
+            // Split the CONTENT block at the paragraph boundary
+            const [left, right] = splitAtParagraph(blockContent, entry.positionWithinBlock);
+            const replacement: { type: "CONTENT" | "BEAT"; content: string }[] = [
+                { type: "CONTENT", content: left },
+                { type: "BEAT", content: beatContent },
+            ];
+            if (right.trim() !== "") {
+                replacement.push({ type: "CONTENT", content: right });
+            }
+            blocks.splice(entry.blockIndex, 1, ...replacement);
+        }
+    }
     const result = await StructureController.writeSceneContentFromBlocks(nodeId, blocks);
     mcpCache.delete(`sceneContent:${nodeId}`);
     invalidateStructureCaches();


### PR DESCRIPTION
## Summary

Extends `insert_beat` MCP tool to support paragraph-level targeting within CONTENT blocks by automatically splitting blocks at paragraph boundaries. Agents can now insert beats precisely after any paragraph in scenes written as a single CONTENT block — the common case.

## Problem

A scene stored as one CONTENT block `<p>P1</p><p>P2</p><p>P3</p>` has only **one** entry in `blocks[]`. Calling `insertBeat(sceneId, 1, "Beat")` threw an "out of range" error because the tool treated indices as block-level array indices, not scene-level paragraph indices. Agents could not insert beats inside single-block scenes at all.

## Solution

Introduced a `flattenBlocksToParagraphs` helper that expands CONTENT blocks into individual `<p>` items and preserves BEAT blocks as atomic items. Updated three MCP tools to use this consistent index space:

1. **`readSceneContent.paragraphs`** — Now returns one entry per `<p>` element or BEAT block, enabling agents to look up correct indices
2. **`insertBeat`** — Accepts scene-level paragraph indices; when target falls inside a CONTENT block, splits the block at the paragraph boundary
3. **`updateParagraph`** — Uses the same flat index space for consistency

## Changes

| File | Changes |
|------|---------|
| `src/mcp/tools/structure.ts` | Added `flattenBlocksToParagraphs` helper; updated `readSceneContent`, `insertBeat`, and `updateParagraph` functions |
| `src/mcp/index.ts` | Updated `insert_beat` MCP description to clarify paragraph-level indexing and block splitting behavior |
| `src/__tests__/structure-controller.test.ts` | Added 4 new test cases covering split scenarios and range validation |
| `src/__tests__/mcp-tools.test.ts` | Added test case for flat paragraph view with multi-paragraph CONTENT blocks |

## Example

**Before**: Scene with `<p>P1</p><p>P2</p><p>P3</p>` (1 block)
```
readSceneContent → paragraphs: [{ index:0, type:"CONTENT", content:"<p>P1</p><p>P2</p><p>P3</p>" }]
insertBeat(sceneId, 1, "Beat") → Error: "out of range"
```

**After**: Same scene
```
readSceneContent → paragraphs: [
  { index:0, type:"CONTENT", content:"<p>P1</p>" },
  { index:1, type:"CONTENT", content:"<p>P2</p>" },
  { index:2, type:"CONTENT", content:"<p>P3</p>" }
]
insertBeat(sceneId, 1, "Beat") → blocks become [CONTENT("<p>P1</p><p>P2</p>"), BEAT("Beat"), CONTENT("<p>P3</p>")]
```

## Validation

✅ Type check: No errors
✅ Lint: 0 errors (141 pre-existing warnings)
✅ Tests: 1056 passed across 90 test files
✅ Build: Production build successful

Fixes #733