### PR TITLE
Fix: handle StaleWriteError in all MCP write tool handlers

### DIFF
--- a/src/__tests__/mcp-guardrails.test.ts
+++ b/src/__tests__/mcp-guardrails.test.ts
@@ -181,6 +181,36 @@ describe("cross_reference_story_bible has no human approval gate", () => {
     });
 });
 
+describe("StaleWriteError handler-level wrapping", () => {
+    const handlers = [
+        "update_project",
+        "update_node",
+        "write_scene_content",
+        "update_story_object",
+        "update_universe",
+        "update_world_object",
+        "update_timeline_entry",
+    ];
+
+    for (const handler of handlers) {
+        it(`${handler} catch block returns isError: true`, () => {
+            const start = mcpSource.indexOf(`"${handler}"`);
+            const section = mcpSource.slice(start, start + 2500);
+            expect(section).toContain("isError: true");
+            expect(section).toContain("logger.error");
+        });
+    }
+
+    it("write_scene_content throws missing-arg error inside try block (returns isError)", () => {
+        const start = mcpSource.indexOf('"write_scene_content"');
+        const section = mcpSource.slice(start, start + 2000);
+        const throwIdx = section.indexOf('throw new Error("Either');
+        const catchIdx = section.indexOf("} catch (e)");
+        expect(throwIdx).toBeGreaterThan(-1);
+        expect(catchIdx).toBeGreaterThan(throwIdx);
+    });
+});
+
 describe("review persona prompts", () => {
     it("buildReviewPrompt helper should include ANNIE_HARD_RULE and export_manuscript", () => {
         const helperStart = mcpSource.indexOf("function buildReviewPrompt");

--- a/src/__tests__/mcp-guardrails.test.ts
+++ b/src/__tests__/mcp-guardrails.test.ts
@@ -25,39 +25,28 @@ describe("Annie Hard Rule Enforcement", () => {
     });
 
     describe("write_scene_content allows CONTENT blocks (author in control)", () => {
+        const writeSceneSection = mcpSource.slice(
+            mcpSource.indexOf('"write_scene_content"'),
+            mcpSource.indexOf('"write_scene_content"') + 2000
+        );
+
         it("should NOT contain a hard guard that checks for CONTENT blocks", () => {
-            const writeSceneSection = mcpSource.slice(
-                mcpSource.indexOf('"write_scene_content"'),
-                mcpSource.indexOf('"write_scene_content"') + 2000
-            );
             expect(writeSceneSection).not.toContain('blocks.some(b => b.type === "CONTENT")');
         });
 
         it("should NOT return Annie's refusal message for CONTENT blocks", () => {
-            const writeSceneSection = mcpSource.slice(
-                mcpSource.indexOf('"write_scene_content"'),
-                mcpSource.indexOf('"write_scene_content"') + 2000
-            );
             expect(writeSceneSection).not.toContain("Oh no no no. That part is yours.");
         });
 
         it("should call writeSceneContentFromBlocks directly without a CONTENT guard", () => {
-            const writeSceneSection = mcpSource.slice(
-                mcpSource.indexOf('"write_scene_content"'),
-                mcpSource.indexOf('"write_scene_content"') + 2000
-            );
             expect(writeSceneSection).toContain("writeSceneContentFromBlocks");
             expect(writeSceneSection).not.toContain("if (hasContentBlock)");
         });
 
         it("should describe write_scene_content with BEAT-by-default, CONTENT-on-request semantics", () => {
-            const toolDescSection = mcpSource.slice(
-                mcpSource.indexOf('"write_scene_content"'),
-                mcpSource.indexOf('"write_scene_content"') + 500
-            );
-            expect(toolDescSection).toContain("BEAT blocks by default");
-            expect(toolDescSection).toContain("CONTENT blocks are permitted only when the author explicitly requests prose");
-            expect(toolDescSection).not.toContain("Annie should ONLY use 'blocks' with type BEAT — never produce CONTENT blocks");
+            expect(writeSceneSection).toContain("BEAT blocks by default");
+            expect(writeSceneSection).toContain("CONTENT blocks are permitted only when the author explicitly requests prose");
+            expect(writeSceneSection).not.toContain("Annie should ONLY use 'blocks' with type BEAT — never produce CONTENT blocks");
         });
     });
 });
@@ -66,31 +55,24 @@ describe("plan_beats prompt", () => {
     // Slice anchor: indexOf('"plan_beats"') finds the server.prompt("plan_beats", ...) declaration.
     // The string "plan_beats" only appears once in the file (as the prompt name), so this is safe.
     // Slice length of 3000 chars covers the full handler (~2000 chars); increase if handler grows.
+    const planBeatsSection = mcpSource.slice(
+        mcpSource.indexOf('"plan_beats"'),
+        mcpSource.indexOf('"plan_beats"') + 3000
+    );
+
     it("should register a plan_beats prompt", () => {
         expect(mcpSource).toContain('"plan_beats"');
     });
 
     it("should load the scene-drafting-assistant skill", () => {
-        const planBeatsSection = mcpSource.slice(
-            mcpSource.indexOf('"plan_beats"'),
-            mcpSource.indexOf('"plan_beats"') + 3000
-        );
         expect(planBeatsSection).toContain('loadSkill("scene-drafting-assistant")');
     });
 
     it("should prepend ANNIE_HARD_RULE in plan_beats prompt", () => {
-        const planBeatsSection = mcpSource.slice(
-            mcpSource.indexOf('"plan_beats"'),
-            mcpSource.indexOf('"plan_beats"') + 3000
-        );
         expect(planBeatsSection).toContain("ANNIE_HARD_RULE + contextHeader + skill.instructions");
     });
 
     it("should include scene status, chapter, and word count in context header", () => {
-        const planBeatsSection = mcpSource.slice(
-            mcpSource.indexOf('"plan_beats"'),
-            mcpSource.indexOf('"plan_beats"') + 3000
-        );
         expect(planBeatsSection).toContain("Status:");
         expect(planBeatsSection).toContain("Chapter:");
         expect(planBeatsSection).toContain("Word Count:");

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -218,8 +218,14 @@ server.tool(
         genre: z.string().optional().describe("New genre"),
     },
     async ({ projectId, contentHash, title, author, synopsis, genre }) => {
-        const result = await updateProject(projectId, { title, author, synopsis, genre }, contentHash);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+            const result = await updateProject(projectId, { title, author, synopsis, genre }, contentHash);
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch (e) {
+            logger.error("update_project: failed", e);
+            const message = e instanceof Error ? e.message : String(e);
+            return { content: [{ type: "text", text: `Error updating project: ${message}` }], isError: true };
+        }
     }
 );
 
@@ -319,8 +325,14 @@ server.tool(
         parentId: z.string().nullable().optional().describe("New parent node ID (null to make top-level)"),
     },
     async ({ nodeId, contentHash, ...data }) => {
-        const result = await updateNode(nodeId, data, contentHash);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+            const result = await updateNode(nodeId, data, contentHash);
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch (e) {
+            logger.error("update_node: failed", e);
+            const message = e instanceof Error ? e.message : String(e);
+            return { content: [{ type: "text", text: `Error updating node: ${message}` }], isError: true };
+        }
     }
 );
 
@@ -364,15 +376,21 @@ server.tool(
         })).optional().describe("Structured content blocks")
     },
     async ({ nodeId, contentHash, content, blocks }) => {
-        if (blocks) {
-            const result = await writeSceneContentFromBlocks(nodeId, blocks as { type: "CONTENT" | "BEAT"; content: string }[], contentHash);
-            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+            if (blocks) {
+                const result = await writeSceneContentFromBlocks(nodeId, blocks as { type: "CONTENT" | "BEAT"; content: string }[], contentHash);
+                return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+            }
+            if (content !== undefined) {
+                const result = await writeSceneContent(nodeId, content, contentHash);
+                return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+            }
+            throw new Error("Either 'content' or 'blocks' must be provided");
+        } catch (e) {
+            logger.error("write_scene_content: failed", e);
+            const message = e instanceof Error ? e.message : String(e);
+            return { content: [{ type: "text", text: `Error writing scene content: ${message}` }], isError: true };
         }
-        if (content !== undefined) {
-            const result = await writeSceneContent(nodeId, content, contentHash);
-            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-        }
-        throw new Error("Either 'content' or 'blocks' must be provided");
     }
 );
 
@@ -584,8 +602,14 @@ server.tool(
         tags: z.string().optional().describe("New comma-separated tags"),
     },
     async ({ objectId, contentHash, ...data }) => {
-        const result = await updateStoryObject(objectId, data, contentHash);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+            const result = await updateStoryObject(objectId, data, contentHash);
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch (e) {
+            logger.error("update_story_object: failed", e);
+            const message = e instanceof Error ? e.message : String(e);
+            return { content: [{ type: "text", text: `Error updating story object: ${message}` }], isError: true };
+        }
     }
 );
 
@@ -980,8 +1004,14 @@ server.tool(
         description: z.string().optional().describe("New description"),
     },
     async ({ universeId, contentHash, ...data }) => {
-        const result = await updateUniverse(universeId, data, contentHash);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+            const result = await updateUniverse(universeId, data, contentHash);
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch (e) {
+            logger.error("update_universe: failed", e);
+            const message = e instanceof Error ? e.message : String(e);
+            return { content: [{ type: "text", text: `Error updating universe: ${message}` }], isError: true };
+        }
     }
 );
 
@@ -1053,8 +1083,14 @@ server.tool(
         type: z.string().optional().describe("New type"),
     },
     async ({ objectId, contentHash, ...data }) => {
-        const result = await updateWorldObject(objectId, data, contentHash);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+            const result = await updateWorldObject(objectId, data, contentHash);
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch (e) {
+            logger.error("update_world_object: failed", e);
+            const message = e instanceof Error ? e.message : String(e);
+            return { content: [{ type: "text", text: `Error updating world object: ${message}` }], isError: true };
+        }
     }
 );
 
@@ -1100,8 +1136,14 @@ server.tool(
         orderIndex: z.number().optional().describe("New order index"),
     },
     async ({ entryId, contentHash, ...data }) => {
-        const result = await updateTimelineEntry(entryId, data, contentHash);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+            const result = await updateTimelineEntry(entryId, data, contentHash);
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch (e) {
+            logger.error("update_timeline_entry: failed", e);
+            const message = e instanceof Error ? e.message : String(e);
+            return { content: [{ type: "text", text: `Error updating timeline entry: ${message}` }], isError: true };
+        }
     }
 );
 


### PR DESCRIPTION
## Summary

Fixes #760 by adding error handling to 7 MCP write tool handlers that were missing try-catch blocks. This prevents `StaleWriteError` from propagating uncaught through the MCP transport layer.

## Problem

When an agent calls a write tool (e.g., `write_scene_content`, `update_node`) with a stale `contentHash`, a `StaleWriteError` is thrown. However, 7 of the 9 write tools lack try-catch handlers, so the error propagates to the transport layer as an unhandled exception instead of being converted to an MCP tool error response (`isError: true`). The route handler then catches it and returns a generic HTTP 500, leaving agents with no actionable guidance for recovery.

## Solution

Added identical try-catch blocks to all 7 affected MCP handlers, mirroring the existing pattern already in use by `update_paragraph` and `insert_beat`. This ensures:

1. **Consistent error handling** — all write tools now return `{ isError: true, content: [...error message...] }` for stale writes
2. **Agent recovery** — agents receive the `Stale write rejected: call \`read_*_content\` to get fresh hash` message and can retry with correct hash
3. **Reduced noise** — Sentry will no longer log stale writes as 500 errors (they're expected concurrency behavior, not server crashes)

## Changes

**File: `src/mcp/index.ts`** (+62 lines, -20 lines)

Added try-catch blocks around these handlers:
- `update_project` (line 220)
- `update_node` (line 321)
- `write_scene_content` (line 366)
- `update_story_object` (line 586)
- `update_universe` (line 982)
- `update_world_object` (line 1055)
- `update_timeline_entry` (line 1102)

All blocks follow the proven pattern:
```typescript
try {
    const result = await handler(...);
    return { content: [...] };
} catch (e) {
    logger.error("handler_name: failed", e);
    const message = e instanceof Error ? e.message : String(e);
    return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
}
```

## Testing

| Check | Result |
|-------|--------|
| Type check (`npm run typecheck`) | ✅ Pass |
| Lint (`npm run lint`) | ✅ Pass (0 errors, 141 pre-existing warnings) |
| Build (`npm run build`) | ✅ Pass |
| Tests | ⚠️ Skipped (no local PostgreSQL — implementation mirrors already-tested `update_paragraph`/`insert_beat` pattern) |

The implementation mirrors the already-tested `update_paragraph` and `insert_beat` handlers. Existing tests cover the underlying function layer's `StaleWriteError` throw behavior.

## Validation

- ✅ Code compiles with no type errors
- ✅ No new linting violations introduced
- ✅ Build succeeds for all pages and server routes
- ✅ Follows established error handling pattern in codebase

Fixes #760