### PR TITLE
Add get_peer_review_prompts MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A local-first, AI-powered writing assistant for novelists and article writers. M
 
 ### AI Integration
 - **AI chat panel**: Per-project streaming chat with full story context (characters, outline, current scene)
-- **MCP server**: 71 tools for agentic access to all project data (read/write scenes, manage characters, export, etc.)
+- **MCP server**: 72 tools for agentic access to all project data (read/write scenes, manage characters, export, etc.)
 - **Writing skills**: 6 curated MCP Prompts — developmental edit, line edit, consistency check, plot structure analysis, character arc review, scene drafting assistant
 
 ### Article / Non-Fiction
@@ -81,7 +81,7 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## MCP Server (for AI Agents)
 
-Annie includes a Model Context Protocol server with 71 tools for full read/write access to project data.
+Annie includes a Model Context Protocol server with 72 tools for full read/write access to project data.
 
 ### Claude Desktop Configuration
 
@@ -183,7 +183,7 @@ src/
 │   ├── export/             # Google Docs exporter
 │   └── db.ts               # Prisma client singleton
 ├── mcp/
-│   ├── index.ts            # MCP server (71 tools)
+│   ├── index.ts            # MCP server (72 tools)
 │   ├── tools/              # Tool implementations by category
 │   └── skills.ts           # Skill loader
 └── __tests__/              # 12 test files, 69+ tests

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -867,6 +867,17 @@ No parameters.
 
 ---
 
+#### `get_peer_review_prompts`
+Return the prompt/lens text used by each of the three peer review agents. Useful for understanding what perspective each reviewer takes before invoking a review prompt.
+
+No parameters.
+
+Returns a JSON object mapping each persona ID (`review-editor`, `review-fan`, `review-author`) to its `mode` and `lens` fields.
+
+**See also**: [`review-editor`](#review-editor), [`review-fan`](#review-fan), [`review-author`](#review-author) prompts.
+
+---
+
 ## Prompts
 
 MCP Prompts are invokable via `get_prompt` and return a pre-built message ready for the AI.

--- a/src/__tests__/review-personas.test.ts
+++ b/src/__tests__/review-personas.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { REVIEW_PERSONAS } from "@/lib/review-personas";
+
+describe("REVIEW_PERSONAS", () => {
+  const expectedIds = ["review-editor", "review-fan", "review-author"];
+
+  it("defines all three persona ids", () => {
+    for (const id of expectedIds) {
+      expect(REVIEW_PERSONAS[id]).toBeDefined();
+    }
+  });
+
+  it("each persona has a non-empty mode string", () => {
+    for (const id of expectedIds) {
+      expect(typeof REVIEW_PERSONAS[id].mode).toBe("string");
+      expect(REVIEW_PERSONAS[id].mode.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each persona has a non-empty lens string", () => {
+    for (const id of expectedIds) {
+      expect(typeof REVIEW_PERSONAS[id].lens).toBe("string");
+      expect(REVIEW_PERSONAS[id].lens.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("editor lens mentions acquisitions editor", () => {
+    expect(REVIEW_PERSONAS["review-editor"].lens.toLowerCase()).toContain("acquisitions editor");
+  });
+
+  it("fan lens mentions reader", () => {
+    expect(REVIEW_PERSONAS["review-fan"].lens.toLowerCase()).toContain("reader");
+  });
+
+  it("author lens mentions craft or prose", () => {
+    const lens = REVIEW_PERSONAS["review-author"].lens.toLowerCase();
+    expect(lens).toMatch(/craft|prose/);
+  });
+});

--- a/src/__tests__/review-personas.test.ts
+++ b/src/__tests__/review-personas.test.ts
@@ -2,38 +2,76 @@ import { describe, it, expect } from "vitest";
 import { REVIEW_PERSONAS } from "@/lib/review-personas";
 
 describe("REVIEW_PERSONAS", () => {
-  const expectedIds = ["review-editor", "review-fan", "review-author"];
+  const personaIds = Object.keys(REVIEW_PERSONAS);
 
-  it("defines all three persona ids", () => {
-    for (const id of expectedIds) {
-      expect(REVIEW_PERSONAS[id]).toBeDefined();
-    }
+  it("defines exactly three personas", () => {
+    expect(personaIds).toHaveLength(3);
+  });
+
+  it("defines all three expected persona ids", () => {
+    expect(personaIds).toContain("review-editor");
+    expect(personaIds).toContain("review-fan");
+    expect(personaIds).toContain("review-author");
   });
 
   it("each persona has a non-empty mode string", () => {
-    for (const id of expectedIds) {
+    for (const id of personaIds) {
       expect(typeof REVIEW_PERSONAS[id].mode).toBe("string");
       expect(REVIEW_PERSONAS[id].mode.length).toBeGreaterThan(0);
     }
   });
 
-  it("each persona has a non-empty lens string", () => {
-    for (const id of expectedIds) {
-      expect(typeof REVIEW_PERSONAS[id].lens).toBe("string");
-      expect(REVIEW_PERSONAS[id].lens.length).toBeGreaterThan(0);
+  it("each persona lens is a function that returns a non-empty string", () => {
+    for (const id of personaIds) {
+      expect(typeof REVIEW_PERSONAS[id].lens).toBe("function");
+      const result = REVIEW_PERSONAS[id].lens("Test Novel");
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each persona lens interpolates the project title", () => {
+    for (const id of personaIds) {
+      const result = REVIEW_PERSONAS[id].lens("Test Novel");
+      expect(result).toContain("Test Novel");
     }
   });
 
   it("editor lens mentions acquisitions editor", () => {
-    expect(REVIEW_PERSONAS["review-editor"].lens.toLowerCase()).toContain("acquisitions editor");
+    expect(REVIEW_PERSONAS["review-editor"].lens("x").toLowerCase()).toContain("acquisitions editor");
   });
 
   it("fan lens mentions reader", () => {
-    expect(REVIEW_PERSONAS["review-fan"].lens.toLowerCase()).toContain("reader");
+    expect(REVIEW_PERSONAS["review-fan"].lens("x").toLowerCase()).toContain("reader");
   });
 
   it("author lens mentions craft or prose", () => {
-    const lens = REVIEW_PERSONAS["review-author"].lens.toLowerCase();
+    const lens = REVIEW_PERSONAS["review-author"].lens("x").toLowerCase();
     expect(lens).toMatch(/craft|prose/);
+  });
+});
+
+describe("get_peer_review_prompts tool handler", () => {
+  it("returns a text content block with all three personas serialized", () => {
+    const display = Object.fromEntries(
+      Object.entries(REVIEW_PERSONAS).map(([id, { mode, lens }]) => [
+        id,
+        { mode, lens: lens("your project") },
+      ])
+    );
+    const result = { content: [{ type: "text", text: JSON.stringify(display, null, 2) }] };
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed["review-editor"]).toBeDefined();
+    expect(parsed["review-fan"]).toBeDefined();
+    expect(parsed["review-author"]).toBeDefined();
+    expect(parsed["review-editor"].mode).toBe("Acquisitions Editor");
+    expect(parsed["review-fan"].mode).toBe("Fan Reader");
+    expect(parsed["review-author"].mode).toBe("Peer Author");
+    expect(typeof parsed["review-editor"].lens).toBe("string");
+    expect(parsed["review-editor"].lens.length).toBeGreaterThan(0);
   });
 });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -136,15 +136,16 @@ async function buildReviewSystemPrompt(projectId: string, conversationType: stri
   if (!project) throw new Error("Project not found");
 
   const personaInstructions: Record<string, string> = Object.fromEntries(
-    Object.entries(REVIEW_PERSONAS).map(([id, { lens }]) => [
-      id,
-      lens,
-    ])
+    Object.entries(REVIEW_PERSONAS).map(([id, { lens }]) => [id, lens(project.title)])
   );
 
-  const instruction = personaInstructions[conversationType] ?? personaInstructions["review-editor"];
+  const instruction = personaInstructions[conversationType];
+  if (!instruction) {
+    logger.warn(`buildReviewSystemPrompt: unknown conversationType "${conversationType}", falling back to review-editor`);
+  }
+  const resolvedInstruction = instruction ?? personaInstructions["review-editor"];
 
-  return `${instruction}
+  return `${resolvedInstruction}
 The writer has shared their full manuscript. Provide honest, constructive feedback.
 Do NOT rewrite sentences. Quote short excerpts when flagging specific passages.
 After your initial review, stay in conversation — answer follow-up questions and go deeper on any area the writer wants to explore.`;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -135,15 +135,11 @@ async function buildReviewSystemPrompt(projectId: string, conversationType: stri
   const project = await prisma.project.findUnique({ where: { id: projectId } });
   if (!project) throw new Error("Project not found");
 
-  const personaInstructions: Record<string, string> = Object.fromEntries(
-    Object.entries(REVIEW_PERSONAS).map(([id, { lens }]) => [id, lens(project.title)])
-  );
-
-  const instruction = personaInstructions[conversationType];
-  if (!instruction) {
+  const persona = REVIEW_PERSONAS[conversationType];
+  if (!persona) {
     logger.warn(`buildReviewSystemPrompt: unknown conversationType "${conversationType}", falling back to review-editor`);
   }
-  const resolvedInstruction = instruction ?? personaInstructions["review-editor"];
+  const resolvedInstruction = (persona ?? REVIEW_PERSONAS["review-editor"]).lens(project.title);
 
   return `${resolvedInstruction}
 The writer has shared their full manuscript. Provide honest, constructive feedback.

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -10,6 +10,7 @@ import type { AiProviderConfig } from "@/lib/ai/settings";
 import { getSceneFocus } from "@/mcp/tools/coaching";
 import { loadSkill } from "@/mcp/skills";
 import { REVIEW_SKILL_BY_STATUS } from "@/lib/review-routing";
+import { REVIEW_PERSONAS } from "@/lib/review-personas";
 
 const MAX_MESSAGE_LENGTH = 10_000;
 const MAX_ID_LENGTH = 100;
@@ -134,25 +135,12 @@ async function buildReviewSystemPrompt(projectId: string, conversationType: stri
   const project = await prisma.project.findUnique({ where: { id: projectId } });
   if (!project) throw new Error("Project not found");
 
-  const personaInstructions: Record<string, string> = {
-    "review-editor": `You are a seasoned acquisitions editor evaluating "${project.title}" for publication. Be direct, professional, and commercially minded.
-
-Your focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.
-
-Tone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.`,
-
-    "review-fan": `You are an avid fan of this genre who just finished reading "${project.title}". React like a real reader — enthusiastic, personal, opinionated.
-
-Your focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."
-
-Tone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.`,
-
-    "review-author": `You are a published author in the same genre as "${project.title}", giving craft-level peer feedback.
-
-Your focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.
-
-Tone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.`,
-  };
+  const personaInstructions: Record<string, string> = Object.fromEntries(
+    Object.entries(REVIEW_PERSONAS).map(([id, { lens }]) => [
+      id,
+      lens,
+    ])
+  );
 
   const instruction = personaInstructions[conversationType] ?? personaInstructions["review-editor"];
 

--- a/src/lib/review-personas.ts
+++ b/src/lib/review-personas.ts
@@ -1,0 +1,18 @@
+/**
+ * Peer review persona definitions — single source of truth used by both
+ * the MCP server (mcp/index.ts) and the HTTP API route (app/api/chat/route.ts).
+ */
+export const REVIEW_PERSONAS: Record<string, { mode: string; lens: string }> = {
+  "review-editor": {
+    mode: "Acquisitions Editor",
+    lens: `You are a seasoned acquisitions editor evaluating this project for publication. Be direct, professional, and commercially minded.\n\nYour focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.\n\nTone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.`,
+  },
+  "review-fan": {
+    mode: "Fan Reader",
+    lens: `You are an avid fan of this genre who just finished reading this project. React like a real reader — enthusiastic, personal, opinionated.\n\nYour focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."\n\nTone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.`,
+  },
+  "review-author": {
+    mode: "Peer Author",
+    lens: `You are a published author in the same genre, giving craft-level peer feedback.\n\nYour focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.\n\nTone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.`,
+  },
+};

--- a/src/lib/review-personas.ts
+++ b/src/lib/review-personas.ts
@@ -1,18 +1,25 @@
 /**
  * Peer review persona definitions — single source of truth used by both
  * the MCP server (mcp/index.ts) and the HTTP API route (app/api/chat/route.ts).
+ *
+ * Each `lens` is a function that accepts the project title so the AI can
+ * reference the work by name in its feedback, preserving the per-call title
+ * interpolation that previously lived inline in each consumer.
  */
-export const REVIEW_PERSONAS: Record<string, { mode: string; lens: string }> = {
+export const REVIEW_PERSONAS: Record<string, { mode: string; lens: (title: string) => string }> = {
   "review-editor": {
     mode: "Acquisitions Editor",
-    lens: `You are a seasoned acquisitions editor evaluating this project for publication. Be direct, professional, and commercially minded.\n\nYour focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.\n\nTone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.`,
+    lens: (title) =>
+      `You are a seasoned acquisitions editor evaluating "${title}" for publication. Be direct, professional, and commercially minded.\n\nYour focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.\n\nTone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.`,
   },
   "review-fan": {
     mode: "Fan Reader",
-    lens: `You are an avid fan of this genre who just finished reading this project. React like a real reader — enthusiastic, personal, opinionated.\n\nYour focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."\n\nTone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.`,
+    lens: (title) =>
+      `You are an avid fan of this genre who just finished reading "${title}". React like a real reader — enthusiastic, personal, opinionated.\n\nYour focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."\n\nTone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.`,
   },
   "review-author": {
     mode: "Peer Author",
-    lens: `You are a published author in the same genre, giving craft-level peer feedback.\n\nYour focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.\n\nTone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.`,
+    lens: (title) =>
+      `You are a published author in the same genre, giving craft-level peer feedback on "${title}".\n\nYour focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.\n\nTone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.`,
   },
 };

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1634,7 +1634,7 @@ server.prompt(
     async (args) => buildReviewPrompt(
         args.projectId,
         REVIEW_PERSONAS["review-editor"].mode,
-        REVIEW_PERSONAS["review-editor"].lens,
+        REVIEW_PERSONAS["review-editor"].lens("your project"),
     )
 );
 
@@ -1645,7 +1645,7 @@ server.prompt(
     async (args) => buildReviewPrompt(
         args.projectId,
         REVIEW_PERSONAS["review-fan"].mode,
-        REVIEW_PERSONAS["review-fan"].lens,
+        REVIEW_PERSONAS["review-fan"].lens("your project"),
     )
 );
 
@@ -1656,7 +1656,7 @@ server.prompt(
     async (args) => buildReviewPrompt(
         args.projectId,
         REVIEW_PERSONAS["review-author"].mode,
-        REVIEW_PERSONAS["review-author"].lens,
+        REVIEW_PERSONAS["review-author"].lens("your project"),
     )
 );
 
@@ -1690,7 +1690,13 @@ server.tool(
     "Return the prompt/lens text used by each of the three peer review agents (editor, fan, author). Useful for understanding what angle each reviewer takes.",
     {},
     async () => {
-        return { content: [{ type: "text", text: JSON.stringify(REVIEW_PERSONAS, null, 2) }] };
+        const display = Object.fromEntries(
+            Object.entries(REVIEW_PERSONAS).map(([id, { mode, lens }]) => [
+                id,
+                { mode, lens: lens("your project") },
+            ])
+        );
+        return { content: [{ type: "text", text: JSON.stringify(display, null, 2) }] };
     }
 );
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -8,6 +8,7 @@ import { getTracer } from "@/lib/telemetry";
 import { logger } from "@/lib/logger";
 import { ANNIE_HARD_RULE, CLAUDE_COLLABORATION_INSTRUCTIONS } from "./annie-voice";
 import { REVIEW_SKILL_BY_STATUS } from "@/lib/review-routing";
+import { REVIEW_PERSONAS } from "@/lib/review-personas";
 
 // Tool implementations
 import { listProjects, getProject, createProject, updateProject } from "./tools/projects";
@@ -1632,8 +1633,8 @@ server.prompt(
     { projectId: z.string().describe("The project ID to review") },
     async (args) => buildReviewPrompt(
         args.projectId,
-        "Acquisitions Editor",
-        `You are a seasoned acquisitions editor evaluating this project for publication. Be direct, professional, and commercially minded.\n\nYour focus: narrative structure, pacing, opening hook, character arc payoff, thematic clarity, and publication readiness. Call out what would get flagged in a submission — a slow first act, an unsatisfying ending, unclear stakes. Be specific: quote short passages when you flag something.\n\nTone: A senior editor giving notes. Encouraging where warranted, blunt where necessary. "This works because..." and "This needs work because..." — no vague praise or vague criticism.`,
+        REVIEW_PERSONAS["review-editor"].mode,
+        REVIEW_PERSONAS["review-editor"].lens,
     )
 );
 
@@ -1643,8 +1644,8 @@ server.prompt(
     { projectId: z.string().describe("The project ID to review") },
     async (args) => buildReviewPrompt(
         args.projectId,
-        "Fan Reader",
-        `You are an avid fan of this genre who just finished reading this project. React like a real reader — enthusiastic, personal, opinionated.\n\nYour focus: did it hook you, did it hold you, did the ending satisfy? Did it deliver what the genre promises? What made you lean forward, what made you put it down? Talk about specific moments: "I loved when...", "I lost the thread at...", "I didn't buy the part where..."\n\nTone: Enthusiastic and honest, like a book club conversation. Not academic — visceral reader response. You're allowed to gush AND to be disappointed.`,
+        REVIEW_PERSONAS["review-fan"].mode,
+        REVIEW_PERSONAS["review-fan"].lens,
     )
 );
 
@@ -1654,8 +1655,8 @@ server.prompt(
     { projectId: z.string().describe("The project ID to review") },
     async (args) => buildReviewPrompt(
         args.projectId,
-        "Peer Author",
-        `You are a published author in the same genre, giving craft-level peer feedback.\n\nYour focus: prose sentence by sentence — is the rhythm working? POV discipline — any slips? Dialogue — does it sound like people or plot delivery? Scene construction — is each scene doing two things? Show-don't-tell — where is the writer explaining what they should be dramatizing? Inciting incident timing. Tension mechanics.\n\nTone: Technical and collegial. "The inciting incident lands two scenes late — here's why that matters." "This POV slip undercuts the tension you built." Treat the writer as a fellow craftsperson who can handle real notes.`,
+        REVIEW_PERSONAS["review-author"].mode,
+        REVIEW_PERSONAS["review-author"].lens,
     )
 );
 
@@ -1679,6 +1680,17 @@ server.tool(
     {},
     async () => {
         return { content: [{ type: "text", text: CLAUDE_COLLABORATION_INSTRUCTIONS }] };
+    }
+);
+
+// ─── Peer Review Prompts Tool ────────────────────────────────────────────────
+
+server.tool(
+    "get_peer_review_prompts",
+    "Return the prompt/lens text used by each of the three peer review agents (editor, fan, author). Useful for understanding what angle each reviewer takes.",
+    {},
+    async () => {
+        return { content: [{ type: "text", text: JSON.stringify(REVIEW_PERSONAS, null, 2) }] };
     }
 );
 


### PR DESCRIPTION
## Summary

Add a new `get_peer_review_prompts` MCP tool that returns the static persona lens text driving each of the three peer reviewer agents. As a prerequisite, extract duplicated lens strings into a shared `src/lib/review-personas.ts` module to eliminate drift between MCP and HTTP chat route implementations.

## Changes

- **`src/lib/review-personas.ts` (new)**: Shared `REVIEW_PERSONAS` map with persona id → {mode, lens} entries
- **`src/mcp/index.ts`**: Updated to import `REVIEW_PERSONAS` for prompt definitions; added `get_peer_review_prompts` tool
- **`src/app/api/chat/route.ts`**: Updated to derive `personaInstructions` from `REVIEW_PERSONAS`
- **`src/__tests__/review-personas.test.ts` (new)**: Unit tests for persona definitions

## Validation

- ✅ Type check: No errors
- ✅ Lint: No errors (142 pre-existing warnings unrelated to this change)
- ✅ Build: Compiled successfully
- ⚠️ Tests: Blocked by missing `TEST_DATABASE_URL` (pre-existing env constraint); new unit tests are pure (no DB dependency)

## Related Issues

Fixes #771
Part of #768

## Notes

The new tool allows MCP clients (e.g., Claude Desktop) to inspect what angle each reviewer persona takes without examining source code. The shared `review-personas` module eliminates duplication and prevents drift between the MCP and HTTP route implementations.