### PR TITLE
Fix: strip PII from content report GitHub issues

### DIFF
--- a/src/__tests__/report-route.test.ts
+++ b/src/__tests__/report-route.test.ts
@@ -85,6 +85,7 @@ describe("POST /api/projects/[id]/report", () => {
   });
 
   it("does not include project author name in GitHub issue body", async () => {
+    mockFindUnique.mockResolvedValue({ id: "proj1", title: "My Story", author: "Jane Doe" });
     const res = await POST(
       makeRequest({ category: "copyright" }),
       { params: Promise.resolve({ id: "proj1" }) }
@@ -93,6 +94,7 @@ describe("POST /api/projects/[id]/report", () => {
     const [, options] = mockFetch.mock.calls[0];
     const body = JSON.parse(options.body);
     expect(body.body).not.toContain("Author:");
+    expect(body.body).not.toContain("Jane Doe");
   });
 
   it("strips query params and hash from URL in GitHub issue body", async () => {

--- a/src/__tests__/report-route.test.ts
+++ b/src/__tests__/report-route.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// --- Mocks ---
+
+const mockFindUnique = vi.fn();
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    project: { findUnique: (...args: unknown[]) => mockFindUnique(...args) },
+  },
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy({} as Record<string, string>, {
+    get: (_t, key: string) => (mockEnv as Record<string, string>)[key],
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const mockEnv: Record<string, string> = {};
+const mockFetch = vi.fn();
+
+import { POST } from "@/app/api/projects/[id]/report/route";
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockFindUnique.mockReset();
+  global.fetch = mockFetch as unknown as typeof fetch;
+  mockEnv.GITHUB_FEEDBACK_TOKEN = "ghp_test_token";
+  mockEnv.GITHUB_FEEDBACK_REPO = "testowner/testrepo";
+  mockFindUnique.mockResolvedValue({ id: "proj1", title: "My Story" });
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      html_url: "https://github.com/testowner/testrepo/issues/1",
+    }),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRequest(
+  body: object,
+  headers: Record<string, string> = {}
+): NextRequest {
+  return new NextRequest("http://localhost/api/projects/proj1/report", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+describe("POST /api/projects/[id]/report", () => {
+  it("does not include reporter email in GitHub issue body", async () => {
+    const res = await POST(
+      makeRequest(
+        { category: "harassment", details: "Bad content" },
+        { "x-user-email": "private@example.com" }
+      ),
+      { params: Promise.resolve({ id: "proj1" }) }
+    );
+    expect(res.status).toBe(201);
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.body).not.toContain("private@example.com");
+  });
+
+  it("does not include reporter user ID in GitHub issue body", async () => {
+    const res = await POST(
+      makeRequest(
+        { category: "other" },
+        { "x-user-id": "user-uuid-123" }
+      ),
+      { params: Promise.resolve({ id: "proj1" }) }
+    );
+    expect(res.status).toBe(201);
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.body).not.toContain("user-uuid-123");
+  });
+
+  it("does not include project author name in GitHub issue body", async () => {
+    const res = await POST(
+      makeRequest({ category: "copyright" }),
+      { params: Promise.resolve({ id: "proj1" }) }
+    );
+    expect(res.status).toBe(201);
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.body).not.toContain("Author:");
+  });
+
+  it("strips query params and hash from URL in GitHub issue body", async () => {
+    const res = await POST(
+      makeRequest({
+        category: "illegal",
+        url: "https://example.com/read/proj1?ref=email#section",
+      }),
+      { params: Promise.resolve({ id: "proj1" }) }
+    );
+    expect(res.status).toBe(201);
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.body).toContain("/read/proj1");
+    expect(body.body).not.toContain("ref=email");
+    expect(body.body).not.toContain("section");
+    expect(body.body).not.toContain("https://example.com");
+  });
+});

--- a/src/app/api/projects/[id]/report/route.ts
+++ b/src/app/api/projects/[id]/report/route.ts
@@ -36,7 +36,7 @@ export async function POST(
   // Verify the project exists (anyone can report, no auth required for read-accessible content)
   const project = await prisma.project.findUnique({
     where: { id: projectId },
-    select: { id: true, title: true, author: true },
+    select: { id: true, title: true },
   });
 
   if (!project) {
@@ -53,24 +53,17 @@ export async function POST(
     );
   }
 
-  // Get reporter identity if available
-  const reporterEmail = request.headers.get("x-user-email");
-  const reporterId = request.headers.get("x-user-id");
-
   // Build GitHub issue — escape all user-controlled fields to prevent markdown injection
   const categoryLabel = CATEGORY_LABELS[category] || escapeMarkdown(category);
   const safeTitle = escapeMarkdown(project.title ?? "");
-  const safeAuthor = project.author ? escapeMarkdown(project.author) : "";
   let safeUrl = "";
   if (url && typeof url === "string") {
     try {
       const u = new URL(url);
-      if (["http:", "https:"].includes(u.protocol)) safeUrl = escapeMarkdown(u.toString());
+      if (["http:", "https:"].includes(u.protocol)) safeUrl = escapeMarkdown(u.pathname);
     } catch { /* ignore invalid URLs */ }
   }
   const safeDetails = details?.trim() ? sanitizeInput(details.trim()).slice(0, 4000) : "";
-  const safeReporterEmail = reporterEmail ? escapeMarkdown(reporterEmail) : null;
-  const safeReporterId = reporterId ? escapeMarkdown(reporterId) : null;
 
   const title = `Content Report: ${categoryLabel} — "${safeTitle}"`;
 
@@ -79,10 +72,7 @@ export async function POST(
     "",
     `**Project:** ${safeTitle} (ID: \`${project.id}\`)`,
   ];
-  if (safeAuthor) bodyParts.push(`**Author:** ${safeAuthor}`);
   if (safeUrl) bodyParts.push(`**URL:** ${safeUrl}`);
-  if (safeReporterEmail) bodyParts.push(`**Reporter:** ${safeReporterEmail}`);
-  else if (safeReporterId) bodyParts.push(`**Reporter ID:** ${safeReporterId}`);
 
   if (safeDetails) {
     bodyParts.push("", "### Details", safeDetails);

--- a/src/app/api/projects/[id]/report/route.ts
+++ b/src/app/api/projects/[id]/report/route.ts
@@ -60,6 +60,7 @@ export async function POST(
   if (url && typeof url === "string") {
     try {
       const u = new URL(url);
+      // pathname only — strips query params and hash to avoid leaking PII (e.g. ref= tracking params)
       if (["http:", "https:"].includes(u.protocol)) safeUrl = escapeMarkdown(u.pathname);
     } catch { /* ignore invalid URLs */ }
   }


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where the report route exposes personally identifiable information (PII) in GitHub issues: reporter email, reporter user ID, and project author name. The fix also corrects URL serialization to exclude query parameters and hash fragments.

**Issue**: Fixes #795

## Changes

### Modified Files
- `src/app/api/projects/[id]/report/route.ts` (+4/-12)
  - Removed author from DB select (no longer needed)
  - Removed reporter email and ID from issue body
  - Fixed URL serialization from `u.toString()` to `u.pathname` (strips query params and hash)

- `src/__tests__/report-route.test.ts` (new, +112)
  - 4 test cases asserting PII redaction:
    - Reporter email is not in issue body
    - Reporter user ID is not in issue body  
    - Project author name is not in issue body
    - Query params and hash are stripped from URLs

### Details

The report route was logging PII fields that should be redacted:
- Reporter email from `x-user-email` header → now excluded
- Reporter user ID from `x-user-id` header → now excluded
- Project author name from database → now excluded from DB select
- Full URL with query params → now using `pathname` only

This mirrors the established PII-redaction pattern already implemented in the feedback route.

## Validation

✅ Type check: No errors
✅ Tests: 1132 passed, 0 failed (95 test files)
✅ Lint: 0 errors
✅ Build: Success

All validation checks pass. Tests confirm:
- Reporter email is not included in GitHub issue body
- Reporter user ID is not included in GitHub issue body
- Project author name is not included in GitHub issue body
- URL query parameters are stripped (e.g., `?ref=email` excluded)

## Scope

**Fixed:**
- PII fields in GitHub issue body from report route
- URL query param/hash exposure in report route

**Not changed:**
- Feedback route (already correctly redacted)
- Server-side logging (PII still logged server-side for admin lookup)