### PR TITLE
Fix: pin Docker sidecar images to immutable references

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - phoenix
 
   phoenix:
+    # Pinned to arizephoenix/phoenix:latest as of 2026-05-30 (no stable version tags available)
+    # To update: docker pull arizephoenix/phoenix:latest && docker inspect --format='{{index .RepoDigests 0}}'
     image: arizephoenix/phoenix@sha256:91bb10c1217cd1fc0b3ac5908cc8d11f663bc56e00241b7f7551af880d5bcd92
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - phoenix
 
   phoenix:
-    image: arizephoenix/phoenix:latest
+    image: arizephoenix/phoenix@sha256:91bb10c1217cd1fc0b3ac5908cc8d11f663bc56e00241b7f7551af880d5bcd92
     restart: unless-stopped
     ports:
       - "127.0.0.1:6006:6006"
@@ -22,7 +22,7 @@ services:
       - phoenix-data:/data
 
   tunnel:
-    image: cloudflare/cloudflared:latest
+    image: cloudflare/cloudflared:2026.5.2
     restart: always
     environment:
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability where Docker sidecar images (Phoenix and Cloudflared) were using unpinned `:latest` tags, creating a supply chain risk. Any compromise or breaking change in the upstream images would be silently adopted on next deployment.

## Changes

**Files modified**: `docker-compose.yml`

- **Line 17**: Pin `arizephoenix/phoenix` from `:latest` to immutable digest
  - Current: `image: arizephoenix/phoenix:latest`
  - Fixed: `image: arizephoenix/phoenix@sha256:91bb10c1217cd1fc0b3ac5908cc8d11f663bc56e00241b7f7551af880d5bcd92`
  - Reason: `arizephoenix/phoenix` has no stable version tags on Docker Hub; digest is the only immutable reference

- **Line 25**: Pin `cloudflare/cloudflared` from `:latest` to stable version
  - Current: `image: cloudflare/cloudflared:latest`
  - Fixed: `image: cloudflare/cloudflared:2026.5.2`
  - Reason: `cloudflared` publishes dated version tags (YYYY.M.patch format); `2026.5.2` is current latest

Both pinned versions were verified on 2026-05-30 and their digests confirmed to match current `:latest` images.

## Validation

✅ **Type check**: No type errors  
✅ **Lint**: 0 errors (145 pre-existing warnings, all unrelated)  
✅ **Build**: Next.js build successful  
✅ **Docker Compose syntax**: YAML valid (docker-compose config passes)

**Note**: Unit tests require `TEST_DATABASE_URL` env var (pre-existing setup issue). This change only modifies docker-compose.yml image references and has no test coverage in the test suite.

## Issue

Fixes #793