### PR TITLE
Fix: validate timeline entry ownership at route level

### DIFF
--- a/src/__tests__/timeline-reorder-route.test.ts
+++ b/src/__tests__/timeline-reorder-route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-auth", () => ({
+  getCurrentUserId: vi.fn(() => "user-1"),
+  verifyUniverseAccess: vi.fn(async () => ({ authorized: true })),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    worldObject: {
+      findUnique: vi.fn(async () => ({ universeId: "universe-1" })),
+    },
+    worldObjectTimelineEntry: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/controllers/universes", () => ({
+  UniversesController: {
+    reorderTimelineEntries: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { prisma } from "@/lib/db";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/world-objects/wo-1/timeline/reorder",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+const mockParams = { params: Promise.resolve({ id: "wo-1" }) };
+
+describe("POST /api/world-objects/[id]/timeline/reorder — route-level ownership check", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: worldObject belongs to universe-1
+    vi.mocked(prisma.worldObject.findUnique).mockResolvedValue({
+      universeId: "universe-1",
+    } as any);
+  });
+
+  it("returns 400 when orderedIds contain entries from a different world object", async () => {
+    // 2 IDs submitted but only 1 belongs to wo-1
+    vi.mocked(prisma.worldObjectTimelineEntry.findMany).mockResolvedValue([
+      { id: "entry-1" },
+    ] as any);
+
+    const { POST } = await import(
+      "@/app/api/world-objects/[id]/timeline/reorder/route"
+    );
+    const res = await POST(
+      makeRequest({ orderedIds: ["entry-1", "entry-from-other-wo"] }),
+      mockParams
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe(
+      "Some timeline entries do not belong to this world object"
+    );
+  });
+
+  it("returns 400 with distinct message when orderedIds contains duplicates", async () => {
+    const { POST } = await import(
+      "@/app/api/world-objects/[id]/timeline/reorder/route"
+    );
+    const res = await POST(
+      makeRequest({ orderedIds: ["entry-1", "entry-1"] }),
+      mockParams
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("orderedIds contains duplicate entries");
+    // Ownership DB query should not be called for duplicates
+    expect(prisma.worldObjectTimelineEntry.findMany).not.toHaveBeenCalled();
+  });
+
+  it("skips the ownership DB query and succeeds when orderedIds is empty", async () => {
+    const { POST } = await import(
+      "@/app/api/world-objects/[id]/timeline/reorder/route"
+    );
+    const res = await POST(makeRequest({ orderedIds: [] }), mockParams);
+
+    expect(res.status).toBe(200);
+    expect(prisma.worldObjectTimelineEntry.findMany).not.toHaveBeenCalled();
+  });
+
+  it("proceeds to reorder when all IDs are owned", async () => {
+    vi.mocked(prisma.worldObjectTimelineEntry.findMany).mockResolvedValue([
+      { id: "e1" },
+      { id: "e2" },
+    ] as any);
+
+    const { POST } = await import(
+      "@/app/api/world-objects/[id]/timeline/reorder/route"
+    );
+    const res = await POST(makeRequest({ orderedIds: ["e1", "e2"] }), mockParams);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 400 when orderedIds is not an array", async () => {
+    const { POST } = await import(
+      "@/app/api/world-objects/[id]/timeline/reorder/route"
+    );
+    const res = await POST(makeRequest({ orderedIds: "not-an-array" }), mockParams);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("orderedIds must be an array");
+  });
+});

--- a/src/__tests__/timeline-reorder-route.test.ts
+++ b/src/__tests__/timeline-reorder-route.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import { prisma } from "@/lib/db";
+import { POST } from "@/app/api/world-objects/[id]/timeline/reorder/route";
 
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest(
@@ -57,9 +58,6 @@ describe("POST /api/world-objects/[id]/timeline/reorder — route-level ownershi
       { id: "entry-1" },
     ] as any);
 
-    const { POST } = await import(
-      "@/app/api/world-objects/[id]/timeline/reorder/route"
-    );
     const res = await POST(
       makeRequest({ orderedIds: ["entry-1", "entry-from-other-wo"] }),
       mockParams
@@ -73,9 +71,6 @@ describe("POST /api/world-objects/[id]/timeline/reorder — route-level ownershi
   });
 
   it("returns 400 with distinct message when orderedIds contains duplicates", async () => {
-    const { POST } = await import(
-      "@/app/api/world-objects/[id]/timeline/reorder/route"
-    );
     const res = await POST(
       makeRequest({ orderedIds: ["entry-1", "entry-1"] }),
       mockParams
@@ -89,9 +84,6 @@ describe("POST /api/world-objects/[id]/timeline/reorder — route-level ownershi
   });
 
   it("skips the ownership DB query and succeeds when orderedIds is empty", async () => {
-    const { POST } = await import(
-      "@/app/api/world-objects/[id]/timeline/reorder/route"
-    );
     const res = await POST(makeRequest({ orderedIds: [] }), mockParams);
 
     expect(res.status).toBe(200);
@@ -104,9 +96,6 @@ describe("POST /api/world-objects/[id]/timeline/reorder — route-level ownershi
       { id: "e2" },
     ] as any);
 
-    const { POST } = await import(
-      "@/app/api/world-objects/[id]/timeline/reorder/route"
-    );
     const res = await POST(makeRequest({ orderedIds: ["e1", "e2"] }), mockParams);
     const body = await res.json();
 
@@ -115,9 +104,6 @@ describe("POST /api/world-objects/[id]/timeline/reorder — route-level ownershi
   });
 
   it("returns 400 when orderedIds is not an array", async () => {
-    const { POST } = await import(
-      "@/app/api/world-objects/[id]/timeline/reorder/route"
-    );
     const res = await POST(makeRequest({ orderedIds: "not-an-array" }), mockParams);
     const body = await res.json();
 

--- a/src/__tests__/universes.test.ts
+++ b/src/__tests__/universes.test.ts
@@ -83,6 +83,9 @@ describe("UniversesController", () => {
         expect(woWithTimeline.timeline[1].label).toBe("E1");
     });
 
+    // Note: these tests cover the controller-layer defense (UniversesController.reorderTimelineEntries).
+    // The route-layer guard in reorder/route.ts returns 400 before this controller throw can produce a 500;
+    // that HTTP-level behavior is covered in src/__tests__/timeline-reorder-route.test.ts.
     it("should reject orderedIds that belong to a different world object", async () => {
         const u = await UniversesController.createUniverse({ title: "U1" });
         const wo1 = await UniversesController.createWorldObject({ universeId: u.id, type: "CHARACTER", name: "Hero" });

--- a/src/__tests__/universes.test.ts
+++ b/src/__tests__/universes.test.ts
@@ -83,6 +83,27 @@ describe("UniversesController", () => {
         expect(woWithTimeline.timeline[1].label).toBe("E1");
     });
 
+    it("should reject orderedIds that belong to a different world object", async () => {
+        const u = await UniversesController.createUniverse({ title: "U1" });
+        const wo1 = await UniversesController.createWorldObject({ universeId: u.id, type: "CHARACTER", name: "Hero" });
+        const wo2 = await UniversesController.createWorldObject({ universeId: u.id, type: "CHARACTER", name: "Villain" });
+
+        const e = await UniversesController.addTimelineEntry({ worldObjectId: wo2.id, label: "E1" });
+
+        await expect(
+            UniversesController.reorderTimelineEntries(wo1.id, [e.id])
+        ).rejects.toThrow("Some timeline entries do not belong to this world object");
+    });
+
+    it("should accept an empty orderedIds array", async () => {
+        const u = await UniversesController.createUniverse({ title: "U2" });
+        const wo = await UniversesController.createWorldObject({ universeId: u.id, type: "CHARACTER", name: "Hero" });
+
+        await expect(
+            UniversesController.reorderTimelineEntries(wo.id, [])
+        ).resolves.not.toThrow();
+    });
+
     it("should link and unlink projects", async () => {
         const u = await UniversesController.createUniverse({ title: "U1" });
         const p = await ProjectsController.createProject({ title: "P1" });

--- a/src/app/api/world-objects/[id]/timeline/reorder/route.ts
+++ b/src/app/api/world-objects/[id]/timeline/reorder/route.ts
@@ -32,6 +32,21 @@ export async function POST(
                 { status: 400 }
             );
         }
+
+        // Verify all IDs belong to this world object before reordering
+        if (orderedIds.length > 0) {
+            const owned = await prisma.worldObjectTimelineEntry.findMany({
+                where: { id: { in: orderedIds }, worldObjectId: id },
+                select: { id: true },
+            });
+            if (owned.length !== orderedIds.length) {
+                return NextResponse.json(
+                    { error: "Some timeline entries do not belong to this world object" },
+                    { status: 400 }
+                );
+            }
+        }
+
         await UniversesController.reorderTimelineEntries(id, orderedIds);
         return NextResponse.json({ success: true });
     } catch (error: unknown) {

--- a/src/app/api/world-objects/[id]/timeline/reorder/route.ts
+++ b/src/app/api/world-objects/[id]/timeline/reorder/route.ts
@@ -19,8 +19,8 @@ export async function POST(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
+    const { id } = await params;
     try {
-        const { id } = await params;
         const userId = getCurrentUserId(request);
         const access = await verifyWorldObjectAccess(id, userId);
         if (!access.authorized) return access.response;
@@ -35,6 +35,13 @@ export async function POST(
 
         // Verify all IDs belong to this world object before reordering
         if (orderedIds.length > 0) {
+            const uniqueIds = new Set(orderedIds);
+            if (uniqueIds.size !== orderedIds.length) {
+                return NextResponse.json(
+                    { error: "orderedIds contains duplicate entries" },
+                    { status: 400 }
+                );
+            }
             const owned = await prisma.worldObjectTimelineEntry.findMany({
                 where: { id: { in: orderedIds }, worldObjectId: id },
                 select: { id: true },
@@ -50,7 +57,7 @@ export async function POST(
         await UniversesController.reorderTimelineEntries(id, orderedIds);
         return NextResponse.json({ success: true });
     } catch (error: unknown) {
-        logger.error("POST /api/world-objects/[id]/timeline/reorder error", error);
+        logger.error("POST /api/world-objects/[id]/timeline/reorder error", { error, worldObjectId: id });
         return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where the timeline reorder endpoint (`POST /api/world-objects/[id]/timeline/reorder`) accepted cross-object IDs without validation at the route level. The endpoint would return HTTP 500 instead of the proper HTTP 400 for invalid input.

## Changes

- **Route-level validation**: Added ownership check in `src/app/api/world-objects/[id]/timeline/reorder/route.ts` to verify all `orderedIds` belong to the specified world object before calling the controller (defense-in-depth pattern)
- **Security tests**: Added tests in `src/__tests__/universes.test.ts` to verify cross-object ID rejection and edge cases

## Implementation Details

The fix mirrors the `verifyEntryOwnership` pattern from the single-entry route (`[entryId]/route.ts`):
- Uses `prisma.worldObjectTimelineEntry.findMany()` to check ownership in bulk
- Returns HTTP 400 with a clear error message for invalid requests
- Guards against empty arrays with `if (orderedIds.length > 0)`
- Keeps controller-level validation as a second layer of defense

## Test Coverage

- ✅ Type check passes
- ✅ Linting passes (0 new errors)
- ⚠️ Note: Full test suite requires TEST_DATABASE_URL in worktree environment

## Severity Assessment

| Aspect | Details |
|--------|---------|
| Severity | MEDIUM |
| Complexity | LOW (isolated change to one route) |
| Confidence | HIGH (root cause precisely identified) |

Fixes #789