### PR TITLE
Fix: allow export-all and export-data in API_TOKEN mode

### DIFF
--- a/src/__tests__/export-all-route.test.ts
+++ b/src/__tests__/export-all-route.test.ts
@@ -95,6 +95,24 @@ describe("GET /api/projects/export-all", () => {
     expect(res.headers.get("content-disposition")).toContain(".zip");
   });
 
+  it("returns 200 with ZIP when userId is null in API_TOKEN mode", async () => {
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(isGoogleAuthMode).mockReturnValue(false);
+
+    const user = await testPrisma.user.create({
+      data: { id: "any-user", email: "any@test.com", googleId: "g-any" },
+    });
+    await testPrisma.project.create({
+      data: { title: "Token Project", author: "Author", userId: user.id },
+    });
+
+    const { GET } = await import("@/app/api/projects/export-all/route");
+    const res = await GET(makeGetRequest());
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/zip");
+  });
+
   it("scopes to user when userId is present", async () => {
     vi.mocked(getCurrentUserId).mockReturnValue("user-abc");
 

--- a/src/__tests__/export-all-route.test.ts
+++ b/src/__tests__/export-all-route.test.ts
@@ -111,6 +111,7 @@ describe("GET /api/projects/export-all", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("application/zip");
+    expect(res.headers.get("content-disposition")).toMatch(/attachment.*\.zip/);
   });
 
   it("scopes to user when userId is present", async () => {

--- a/src/__tests__/export-all-route.test.ts
+++ b/src/__tests__/export-all-route.test.ts
@@ -8,6 +8,10 @@ vi.mock("@/lib/api-auth", () => ({
   getCurrentUserId: vi.fn(() => null),
 }));
 
+vi.mock("@/lib/auth", () => ({
+  isGoogleAuthMode: vi.fn(() => true),
+}));
+
 vi.mock("@/lib/export-json", () => ({
   exportProjectJson: vi.fn(async (id: string) => ({
     exportVersion: 1,
@@ -23,6 +27,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import { getCurrentUserId } from "@/lib/api-auth";
+import { isGoogleAuthMode } from "@/lib/auth";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -38,9 +43,10 @@ describe("GET /api/projects/export-all", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(isGoogleAuthMode).mockReturnValue(true);
   });
 
-  it("returns 401 when no userId (API_TOKEN mode)", async () => {
+  it("returns 401 when no userId in Google auth mode", async () => {
     const { GET } = await import("@/app/api/projects/export-all/route");
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(401);

--- a/src/__tests__/export-data-route.test.ts
+++ b/src/__tests__/export-data-route.test.ts
@@ -55,6 +55,30 @@ describe("GET /api/auth/export-data", () => {
     expect(res.status).toBe(401);
   });
 
+  it("returns ZIP without profile/ai-settings in API_TOKEN mode", async () => {
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(isGoogleAuthMode).mockReturnValue(false);
+
+    const user = await testPrisma.user.create({
+      data: { id: "token-user", email: "t@test.com", googleId: "g-t" },
+    });
+    await testPrisma.project.create({
+      data: { title: "Token Project", author: "Author", userId: user.id },
+    });
+
+    const { GET } = await import("@/app/api/auth/export-data/route");
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(200);
+    const buf = Buffer.from(await res.arrayBuffer());
+    const zip = await JSZip.loadAsync(buf);
+
+    expect(zip.file("profile.json")).toBeNull();
+    expect(zip.file("ai-settings.json")).toBeNull();
+    const projectFiles = Object.keys(zip.files).filter((n) => n.startsWith("projects/"));
+    expect(projectFiles.length).toBeGreaterThan(0);
+  });
+
   it("returns ZIP with correct headers for authenticated user", async () => {
     const user = await testPrisma.user.create({
       data: { id: "u1", email: "x@test.com", googleId: "g1" },

--- a/src/__tests__/export-data-route.test.ts
+++ b/src/__tests__/export-data-route.test.ts
@@ -8,6 +8,9 @@ import JSZip from "jszip";
 vi.mock("@/lib/api-auth", () => ({
   getCurrentUserId: vi.fn(() => null),
 }));
+vi.mock("@/lib/auth", () => ({
+  isGoogleAuthMode: vi.fn(() => true),
+}));
 vi.mock("@/lib/export-json", () => ({
   exportProjectJson: vi.fn(async (id: string) => ({
     exportVersion: 1,
@@ -22,6 +25,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import { getCurrentUserId } from "@/lib/api-auth";
+import { isGoogleAuthMode } from "@/lib/auth";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -35,9 +39,10 @@ describe("GET /api/auth/export-data", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(isGoogleAuthMode).mockReturnValue(true);
   });
 
-  it("returns 401 for unauthenticated request", async () => {
+  it("returns 401 for unauthenticated request in Google auth mode", async () => {
     const { GET } = await import("@/app/api/auth/export-data/route");
     const res = await GET(makeRequest());
     expect(res.status).toBe(401);

--- a/src/app/api/auth/export-data/route.ts
+++ b/src/app/api/auth/export-data/route.ts
@@ -12,7 +12,8 @@ export async function GET(request: NextRequest) {
     const userId = getCurrentUserId(request);
     // In Google auth mode (multi-user), a null userId means unauthenticated — reject.
     // In API_TOKEN mode (single-user), userId is always null; allow and export all data.
-    if (!userId && isGoogleAuthMode()) {
+    if (isGoogleAuthMode() && !userId) {
+      logger.warn("GET /api/auth/export-data: rejected — userId is null");
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/src/app/api/auth/export-data/route.ts
+++ b/src/app/api/auth/export-data/route.ts
@@ -21,6 +21,7 @@ export async function GET(request: NextRequest) {
       ? await prisma.user.findUnique({ where: { id: userId } })
       : null;
     if (userId && !user) {
+      logger.warn("GET /api/auth/export-data: rejected — userId not found in DB", { userId });
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -93,7 +94,10 @@ export async function GET(request: NextRequest) {
     const timestamp = new Date().toISOString().slice(0, 10);
     const filename = `annie-full-export-${timestamp}.zip`;
 
-    logger.info("GET /api/auth/export-data: user exported data", { userId });
+    logger.info("GET /api/auth/export-data: exported data", {
+      userId: userId ?? "api-token",
+      mode: isGoogleAuthMode() ? "google-auth" : "api-token",
+    });
 
     return new NextResponse(buffer, {
       headers: {

--- a/src/app/api/auth/export-data/route.ts
+++ b/src/app/api/auth/export-data/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { getCurrentUserId } from "@/lib/api-auth";
+import { isGoogleAuthMode } from "@/lib/auth";
 import archiver from "archiver";
 import { PassThrough } from "stream";
 import { exportProjectJson } from "@/lib/export-json";
@@ -9,60 +10,68 @@ import { logger } from "@/lib/logger";
 export async function GET(request: NextRequest) {
   try {
     const userId = getCurrentUserId(request);
-    if (!userId) {
+    // In Google auth mode (multi-user), a null userId means unauthenticated — reject.
+    // In API_TOKEN mode (single-user), userId is always null; allow and export all data.
+    if (!userId && isGoogleAuthMode()) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const user = await prisma.user.findUnique({ where: { id: userId } });
-    if (!user) {
+    const user = userId
+      ? await prisma.user.findUnique({ where: { id: userId } })
+      : null;
+    if (userId && !user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const [projects, aiSettings] = await Promise.all([
       prisma.project.findMany({
-        where: { userId },
+        where: userId ? { userId } : {},
         select: { id: true, title: true },
         orderBy: { title: "asc" },
       }),
-      prisma.userAiSettings.findUnique({ where: { userId } }),
+      userId
+        ? prisma.userAiSettings.findUnique({ where: { userId } })
+        : Promise.resolve(null),
     ]);
 
     const archive = archiver("zip", { zlib: { level: 9 } });
     const passthrough = new PassThrough();
     archive.pipe(passthrough);
 
-    // Add profile (safe fields only)
-    archive.append(
-      JSON.stringify(
-        {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          picture: user.picture,
-          createdAt: user.createdAt.toISOString(),
-          updatedAt: user.updatedAt.toISOString(),
-        },
-        null,
-        2
-      ),
-      { name: "profile.json" }
-    );
+    if (user) {
+      // Add profile (safe fields only)
+      archive.append(
+        JSON.stringify(
+          {
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            picture: user.picture,
+            createdAt: user.createdAt.toISOString(),
+            updatedAt: user.updatedAt.toISOString(),
+          },
+          null,
+          2
+        ),
+        { name: "profile.json" }
+      );
 
-    // Add AI settings (omit apiKey for security)
-    const safeAiSettings = aiSettings
-      ? {
-          model: aiSettings.model,
-          customInstructions: aiSettings.customInstructions,
-          coachingStyle: aiSettings.coachingStyle,
-          responseLength: aiSettings.responseLength,
-          chatWindowSize: aiSettings.chatWindowSize,
-          messagesUntilCompression: aiSettings.messagesUntilCompression,
-          compressionModel: aiSettings.compressionModel,
-        }
-      : null;
-    archive.append(JSON.stringify(safeAiSettings, null, 2), {
-      name: "ai-settings.json",
-    });
+      // Add AI settings (omit apiKey for security)
+      const safeAiSettings = aiSettings
+        ? {
+            model: aiSettings.model,
+            customInstructions: aiSettings.customInstructions,
+            coachingStyle: aiSettings.coachingStyle,
+            responseLength: aiSettings.responseLength,
+            chatWindowSize: aiSettings.chatWindowSize,
+            messagesUntilCompression: aiSettings.messagesUntilCompression,
+            compressionModel: aiSettings.compressionModel,
+          }
+        : null;
+      archive.append(JSON.stringify(safeAiSettings, null, 2), {
+        name: "ai-settings.json",
+      });
+    }
 
     for (const project of projects) {
       const data = await exportProjectJson(project.id);

--- a/src/app/api/projects/export-all/route.ts
+++ b/src/app/api/projects/export-all/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { getCurrentUserId } from "@/lib/api-auth";
+import { isGoogleAuthMode } from "@/lib/auth";
 import archiver from "archiver";
 import { PassThrough } from "stream";
 import { exportProjectJson } from "@/lib/export-json";
@@ -9,11 +10,13 @@ import { logger } from "@/lib/logger";
 export async function GET(request: NextRequest) {
   try {
     const userId = getCurrentUserId(request);
-    if (!userId) {
+    // In Google auth mode (multi-user), a null userId means unauthenticated — reject.
+    // In API_TOKEN mode (single-user), userId is always null; allow and export all projects.
+    if (!userId && isGoogleAuthMode()) {
       logger.warn("GET /api/projects/export-all: rejected — userId is null");
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-    const where = { userId };
+    const where = userId ? { userId } : {};
 
     const projects = await prisma.project.findMany({
       where,

--- a/src/app/api/projects/export-all/route.ts
+++ b/src/app/api/projects/export-all/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
     const userId = getCurrentUserId(request);
     // In Google auth mode (multi-user), a null userId means unauthenticated — reject.
     // In API_TOKEN mode (single-user), userId is always null; allow and export all projects.
-    if (!userId && isGoogleAuthMode()) {
+    if (isGoogleAuthMode() && !userId) {
       logger.warn("GET /api/projects/export-all: rejected — userId is null");
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }


### PR DESCRIPTION
## Summary

- The null-userId guard added in #806 correctly prevents data leaks in Google auth (multi-user) mode, but also blocked API_TOKEN (single-user) mode where `userId` is always null by design
- This caused 2 E2E tests to fail on every `main` push, causing the Staging → Production Pipeline to skip and prod to fall 13+ hours behind main (issue #811)
- Fix: gate the null-userId rejection on `isGoogleAuthMode()` in both `export-all` and `export-data`
- Unit tests updated to mock `isGoogleAuthMode` (default `true`) so the 401 assertions remain valid for the Google auth mode scenario

## Root cause chain

```
#806 added if (!userId) return 401 in export-all
  → E2E CI uses API_TOKEN Bearer auth
  → middleware doesn't set x-user-id for API_TOKEN Bearer
  → getCurrentUserId() always returns null in E2E
  → export-all and export-data both return 401
  → 2 E2E tests fail
  → CI fails on every main push
  → Staging pipeline skips (gated on CI success)
  → prod falls behind main
```

## Test plan

- [ ] CI passes (export-all and export-data E2E tests now get 200 in API_TOKEN mode)
- [ ] Unit tests pass (isGoogleAuthMode mocked to true, 401 path still covered)
- [ ] Staging pipeline fires after CI succeeds and deploys to prod

Fixes #811