### PR TITLE
Fix: prevent migration crash and return 503 for degraded health (#813)

### DIFF
--- a/prisma/migrations/20260531_drop_revoked_token_jti_idx/migration.sql
+++ b/prisma/migrations/20260531_drop_revoked_token_jti_idx/migration.sql
@@ -1,4 +1,4 @@
 -- DropIndex
 -- The unique constraint on jti already creates a B-tree index (RevokedToken_jti_key).
 -- The non-unique @@index([jti]) was redundant and added unnecessary write overhead.
-DROP INDEX "RevokedToken_jti_idx";
+DROP INDEX IF EXISTS "RevokedToken_jti_idx";

--- a/src/__tests__/health-route.test.ts
+++ b/src/__tests__/health-route.test.ts
@@ -21,6 +21,7 @@ describe("GET /api/health", () => {
         const res = await GET();
         const body = await res.json();
 
+        expect(res.status).toBe(200);
         expect(body.status).toBe("ok");
         expect(body.db).toBeUndefined();
         expect(body.projects).toBeUndefined();
@@ -34,6 +35,7 @@ describe("GET /api/health", () => {
         const res = await GET();
         const body = await res.json();
 
+        expect(res.status).toBe(503);
         expect(body.status).toBe("degraded");
         expect(body.warning).toBeDefined();
         expect(body.db).toBeUndefined();

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -12,10 +12,13 @@ export async function GET() {
 
         const dataOk = projects > 0 || users > 0;
 
-        return NextResponse.json({
-            status: dataOk ? "ok" : "degraded",
-            ...(!dataOk && { warning: "Database appears empty — possible data loss" }),
-        });
+        return NextResponse.json(
+            {
+                status: dataOk ? "ok" : "degraded",
+                ...(!dataOk && { warning: "Database appears empty — possible data loss" }),
+            },
+            { status: dataOk ? 200 : 503 }
+        );
     } catch (e) {
         return NextResponse.json(
             { status: "error", error: e instanceof Error ? e.message : "DB unreachable" },

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
+import { logger } from "@/lib/logger";
 
 export async function GET() {
     // Quick data integrity check — ensure core tables have data.
@@ -20,6 +21,7 @@ export async function GET() {
             { status: dataOk ? 200 : 503 }
         );
     } catch (e) {
+        logger.error("Health check DB error", e);
         return NextResponse.json(
             { status: "error", error: e instanceof Error ? e.message : "DB unreachable" },
             { status: 503 }


### PR DESCRIPTION
## Summary

Fixes two issues that contributed to the HTTP 520 health check failure on 2026-06-01 03:00:11 UTC:

1. **Migration idempotency**: Added `IF EXISTS` to `DROP INDEX` in the revoked token migration to prevent container crashes if the index doesn't exist (schema divergence or re-runs)
2. **Health check status**: Return HTTP 503 for degraded health state (empty database) instead of HTTP 200, allowing monitoring systems to detect the degraded condition

## Changes

### 1. prisma/migrations/20260531_drop_revoked_token_jti_idx/migration.sql
- Updated `DROP INDEX "RevokedToken_jti_idx"` → `DROP INDEX IF EXISTS "RevokedToken_jti_idx"`
- Ensures idempotency; prevents migration failure if index doesn't exist

### 2. src/app/api/health/route.ts
- Modified health endpoint to return HTTP 503 when `status: "degraded"` (empty database)
- Maintains HTTP 200 for healthy state (data present)
- Allows Cloudflare and monitoring systems to distinguish healthy from degraded via status code

## Root Cause Analysis

HTTP 520 ("Unknown Error") from Cloudflare indicates the origin server returned an invalid/empty response — typically a container crash. The most likely trigger:

- The migration `20260531_drop_revoked_token_jti_idx` runs `DROP INDEX` without `IF EXISTS`
- If the index doesn't exist (schema drift, manual drops, or re-run after partial failure), PostgreSQL throws an error
- `migrate.mjs` catches the error and calls `process.exit(1)` 
- Container exits before startup completes → Railway returns 520 to Cloudflare
- App later restarts and recovers → HTTP 200 restored

Secondary possibility: transient infrastructure restart (Railway maintenance/OOM kill) unrelated to code.

## Validation

✅ Type check: Pass (no errors)
✅ Lint: Pass (0 new errors, 148 pre-existing warnings)
✅ Build: Pass (Next.js build successful)
⚠️ Tests: Skipped (requires TEST_DATABASE_URL — pre-existing setup requirement)

## Testing Instructions

1. Fresh local DB: `node scripts/migrate.mjs` completes without error
2. Simulate divergence: Drop `RevokedToken_jti_idx` manually, run migrate again — completes (IF EXISTS handles missing index)
3. Health check returns HTTP 200 with `{"status":"ok"}` when database has data
4. Health check returns HTTP 503 with `{"status":"degraded"}` when database is empty

Fixes #813