### PR TITLE
fix: skip backup-alert step when Supabase credentials not configured

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -179,6 +179,7 @@ jobs:
           if [ -z "$SUPABASE_PROJECT_REF" ] || [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
             echo "::warning::SUPABASE_PROJECT_REF or SUPABASE_ACCESS_TOKEN not set — skipping backup freshness check"
             echo "stale=false" >> "$GITHUB_OUTPUT"
+            echo "configured=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -202,6 +203,7 @@ jobs:
             echo "::error::No backups found via Supabase API — possible backup system failure"
             echo "stale=true" >> "$GITHUB_OUTPUT"
             echo "reason=No backups found" >> "$GITHUB_OUTPUT"
+            echo "configured=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -209,6 +211,7 @@ jobs:
           BACKUP_TIME=$(date -d "$NEWEST_TS" +%s)
           AGE_SECONDS=$(( NOW - BACKUP_TIME ))
           AGE_HOURS=$(( AGE_SECONDS / 3600 ))
+          echo "configured=true" >> "$GITHUB_OUTPUT"
 
           echo "Newest backup: $NEWEST_TS (${AGE_HOURS}h ago)"
 
@@ -224,7 +227,7 @@ jobs:
           fi
 
       - name: Alert or resolve backup staleness
-        if: always()
+        if: steps.backup-check.outputs.configured == 'true'
         uses: actions/github-script@v7
         env:
           STALE: ${{ steps.backup-check.outputs.stale }}

--- a/src/app/project/[id]/tasks/page.tsx
+++ b/src/app/project/[id]/tasks/page.tsx
@@ -38,6 +38,11 @@ const SIZE_COLORS: Record<string, string> = {
   Large: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
 };
 
+const STATUS_OPTIONS = [
+  { label: "Open", value: false, activeClass: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300" },
+  { label: "Completed", value: true, activeClass: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300" },
+] as const;
+
 interface Filters {
   energy?: string;
   importance?: string;
@@ -226,10 +231,7 @@ export default function TasksPage({ params }: { params: Promise<{ id: string }> 
                 <FilterRow label="Size" options={SIZE_OPTIONS} activeValue={filters.size} colors={SIZE_COLORS} onToggle={(v) => toggleFilter("size", v)} />
                 <div className="flex flex-wrap gap-2 items-center">
                   <span className="text-xs font-semibold text-text-muted uppercase tracking-wider mr-1">Status</span>
-                  {([
-                    { label: "Open", value: false, activeClass: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300" },
-                    { label: "Completed", value: true, activeClass: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300" },
-                  ] as const).map(({ label, value, activeClass }) => (
+                  {STATUS_OPTIONS.map(({ label, value, activeClass }) => (
                     <button
                       key={label}
                       onClick={() => toggleFilter("completed", value)}

--- a/src/components/editor/peer-review-panel.tsx
+++ b/src/components/editor/peer-review-panel.tsx
@@ -446,7 +446,7 @@ export function PeerReviewPanel({ projectId, onStartChat }: PeerReviewPanelProps
                 {activeTab === "consensus" ? (
                   renderConsensusTab(review.consensus)
                 ) : review[activeTab] ? (
-                  renderReviewTab(review[activeTab]!)
+                  renderReviewTab(review[activeTab] as ReviewFeedback)
                 ) : (
                   <div className="p-4 text-center">
                     <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

- Adds a `configured` output to the `Check Supabase backup age` step (`false` when secrets are absent, `true` when a real API check runs)
- Changes the "Alert or resolve backup staleness" step condition from `if: always()` to `if: steps.backup-check.outputs.configured == 'true'`, so GitHub API calls are only made when Supabase is actually configured
- Prevents the intermittent `HttpError: Unexpected end of JSON input` failure that occurred because the alert step was calling `getLabel`/`listForRepo` unnecessarily when credentials were absent

Fixes #839

## Test plan

- [ ] Merge and verify that the next scheduled `uptime.yml` run shows the "Alert or resolve backup staleness" step as **skipped** (Supabase secrets not configured in this repo)
- [ ] Confirm the `Backup Freshness Check` job passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)