### PR TITLE
Fix: cap pagination limit and add distinct to search query (#856)

### DIFF
--- a/src/app/api/projects/[id]/search/route.ts
+++ b/src/app/api/projects/[id]/search/route.ts
@@ -79,6 +79,7 @@ export async function GET(
             ? await prisma.contentVersion.findMany({
                 where: { nodeId: { in: sceneIds } },
                 orderBy: { createdAt: "desc" },
+                distinct: ["nodeId"],
                 select: { nodeId: true, content: true },
             })
             : [];

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -10,8 +10,12 @@ import { ProjectCreateSchema } from "@/schemas/projects";
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const limit = parseInt(searchParams.get("limit") || "20");
-    const offset = parseInt(searchParams.get("offset") || "0");
+    const MAX_LIMIT = 200;
+    const limit = Math.min(
+      Math.max(parseInt(searchParams.get("limit") || "20", 10) || 20, 1),
+      MAX_LIMIT
+    );
+    const offset = Math.max(parseInt(searchParams.get("offset") || "0", 10) || 0, 0);
     const showArchived = searchParams.get("archived") === "true";
     const userId = getCurrentUserId(request);
 


### PR DESCRIPTION
## Summary

Fixes two security vulnerabilities in API pagination and search that enable resource exhaustion attacks:

1. **Unbounded pagination in `/api/projects`**: The `limit` parameter was not capped, allowing an attacker to request arbitrarily many rows and exhaust server memory/bandwidth.
2. **Full version history loaded in search**: The `/api/projects/[id]/search` endpoint loaded all historical content versions into memory before filtering, causing O(scenes × versions) memory usage instead of O(scenes).

## Changes

### `src/app/api/projects/route.ts`
- Added `MAX_LIMIT = 200` constant
- Cap `limit` parameter with `Math.min(Math.max(..., 1), MAX_LIMIT)`
- Sanitize `offset` with `Math.max(..., 0)` for consistency

This mirrors the existing pattern in `story-objects/route.ts` (lines 23-26).

### `src/app/api/projects/[id]/search/route.ts`
- Added `distinct: ["nodeId"]` to the content version query
- Pushes deduplication to the database, reducing memory from O(scenes × all_versions) to O(scenes × 1)
- Uses existing `@@index([nodeId, createdAt(sort: Desc)])` for efficient query

This mirrors the existing pattern in `projects/route.ts` (lines 51-58).

## Validation

- ✅ Type check: `npm run typecheck` — 0 errors
- ✅ Lint: `npm run lint` — 0 errors (148 pre-existing warnings in test files)
- ✅ Build: `npm run build` — successful
- ⚠️ Tests: Blocked by missing `TEST_DATABASE_URL` environment variable (infrastructure constraint, not a code issue)

## Issue

Fixes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)