### PR TITLE
Fix: sanitize health endpoint error response

### DIFF
--- a/src/__tests__/health-route.test.ts
+++ b/src/__tests__/health-route.test.ts
@@ -41,7 +41,7 @@ describe("GET /api/health", () => {
         expect(body.db).toBeUndefined();
     });
 
-    it("returns 503 on DB error without leaking error details beyond message", async () => {
+    it("returns 503 on DB error with generic message, not raw error details", async () => {
         (prisma.project.count as ReturnType<typeof vi.fn>).mockRejectedValue(
             new Error("Connection refused")
         );
@@ -50,18 +50,19 @@ describe("GET /api/health", () => {
         expect(res.status).toBe(503);
         const body = await res.json();
         expect(body.status).toBe("error");
-        expect(body.error).toBe("Connection refused");
+        expect(body.error).toBe("database unavailable");          // generic — not raw e.message
+        expect(body.error).not.toBe("Connection refused");        // explicitly no leak
         expect(body.db).toBeUndefined();
         expect(body.stack).toBeUndefined();
     });
 
-    it("returns 503 with 'DB unreachable' when a non-Error value is thrown", async () => {
+    it("returns 503 with generic message when a non-Error value is thrown", async () => {
         (prisma.project.count as ReturnType<typeof vi.fn>).mockRejectedValue("timeout");
 
         const res = await GET();
         expect(res.status).toBe(503);
         const body = await res.json();
         expect(body.status).toBe("error");
-        expect(body.error).toBe("DB unreachable");
+        expect(body.error).toBe("database unavailable");
     });
 });

--- a/src/__tests__/health-route.test.ts
+++ b/src/__tests__/health-route.test.ts
@@ -50,8 +50,8 @@ describe("GET /api/health", () => {
         expect(res.status).toBe(503);
         const body = await res.json();
         expect(body.status).toBe("error");
-        expect(body.error).toBe("database unavailable");          // generic — not raw e.message
-        expect(body.error).not.toBe("Connection refused");        // explicitly no leak
+        expect(body.error).toBe("database unavailable");
+        expect(JSON.stringify(body)).not.toContain("Connection refused"); // security: no leak anywhere in response
         expect(body.db).toBeUndefined();
         expect(body.stack).toBeUndefined();
     });

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -23,7 +23,7 @@ export async function GET() {
     } catch (e) {
         logger.error("Health check DB error", e);
         return NextResponse.json(
-            { status: "error", error: e instanceof Error ? e.message : "DB unreachable" },
+            { status: "error", error: "database unavailable" },
             { status: 503 }
         );
     }


### PR DESCRIPTION
## Summary

Fixes a security issue where the `/api/health` endpoint was leaking database connection details (hostnames, ports, connection strings) to unauthenticated clients through raw error messages.

## Problem

The health endpoint's catch block was returning `e.message` directly in the JSON response body when a database error occurred. Since this is an unauthenticated public endpoint, this exposed sensitive infrastructure details to any external caller.

## Solution

Replaced the raw error message with a generic `"database unavailable"` response. Detailed errors are still logged server-side (line 24), so operational visibility is preserved while leaking no information to clients.

## Changes

- **File**: `src/app/api/health/route.ts` (line 26)
- **Change**: `e instanceof Error ? e.message : "DB unreachable"` → `"database unavailable"`

## Validation

- ✅ Type check: No errors
- ✅ Lint: 0 errors, 148 pre-existing warnings
- ✅ Build: Next.js build compiled successfully
- ⚠️ Tests: Requires TEST_DATABASE_URL (infrastructure constraint, not a code issue)

## Scope

**In**: Sanitize error response on line 26
**Out**: Server-side logging (already secure), other health logic, endpoint authentication

Fixes #854