### PR TITLE
Fix: race condition in active project limit enforcement

### DIFF
--- a/src/__tests__/projects-limit-route.test.ts
+++ b/src/__tests__/projects-limit-route.test.ts
@@ -100,6 +100,40 @@ describe("POST /api/projects - active project limit (HTTP level)", () => {
     expect(res.status).toBe(201);
   });
 
+  it("enforces the limit even under concurrent requests (simulated TOCTOU)", async () => {
+    const user = await testPrisma.user.create({
+      data: { email: "concurrent-limit@test.com", googleId: "g-concurrent" },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+
+    // Fill up to limit - 1
+    await testPrisma.project.createMany({
+      data: [
+        { title: "P1", userId: user.id },
+        { title: "P2", userId: user.id },
+      ],
+    });
+
+    const { POST } = await import("@/app/api/projects/route");
+
+    // Fire two simultaneous requests that would both see count=2 without serialization
+    const [res1, res2] = await Promise.all([
+      POST(makePostRequest({ title: "Concurrent A" })),
+      POST(makePostRequest({ title: "Concurrent B" })),
+    ]);
+
+    const statuses = [res1.status, res2.status].sort();
+    // One should succeed (201), the other should fail (403 limit OR 409 serialization conflict)
+    expect(statuses[0]).toBe(201);
+    expect([403, 409]).toContain(statuses[1]);
+
+    // Confirm DB has exactly 3 active projects
+    const finalCount = await testPrisma.project.count({
+      where: { userId: user.id, archivedAt: null },
+    });
+    expect(finalCount).toBe(3);
+  });
+
   it("respects custom maxActiveProjects limit from UserAiSettings", async () => {
     const user = await testPrisma.user.create({
       data: { email: "route-custom-limit@test.com", googleId: "g-route-custom" },

--- a/src/__tests__/projects-limit-route.test.ts
+++ b/src/__tests__/projects-limit-route.test.ts
@@ -116,7 +116,10 @@ describe("POST /api/projects - active project limit (HTTP level)", () => {
 
     const { POST } = await import("@/app/api/projects/route");
 
-    // Fire two simultaneous requests that would both see count=2 without serialization
+    // Simulate interleaved requests — both async chains start before either write commits,
+    // which exercises the serializable-transaction guard.
+    // Note: Node.js is single-threaded so true simultaneity isn't guaranteed; the P2034
+    // serialization-failure (409) path may not be exercised in every run — see test name.
     const [res1, res2] = await Promise.all([
       POST(makePostRequest({ title: "Concurrent A" })),
       POST(makePostRequest({ title: "Concurrent B" })),
@@ -132,6 +135,22 @@ describe("POST /api/projects - active project limit (HTTP level)", () => {
       where: { userId: user.id, archivedAt: null },
     });
     expect(finalCount).toBe(3);
+  });
+
+  it("skips the limit check and creates a project for unauthenticated (API_TOKEN/dev) requests", async () => {
+    // Arrange — no userId (API_TOKEN / dev mode); null is the default from the top-level mock
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+
+    const { POST } = await import("@/app/api/projects/route");
+
+    // Act
+    const res = await POST(makePostRequest({ title: "Dev Project" }));
+
+    // Assert
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.title).toBe("Dev Project");
+    expect(body.userId).toBeNull();
   });
 
   it("respects custom maxActiveProjects limit from UserAiSettings", async () => {

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db";
 import { getCurrentUserId } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
@@ -115,33 +116,60 @@ export async function POST(request: NextRequest) {
     const { title, author, synopsis, genre, projectType } = parsed.data;
 
     // Only enforce active project limit for authenticated users; skip in API_TOKEN/dev mode
-    if (userId) {
-      const [activeCount, settings] = await Promise.all([
-        prisma.project.count({ where: { userId, archivedAt: null } }),
-        prisma.userAiSettings.findUnique({ where: { userId }, select: { maxActiveProjects: true } }),
-      ]);
-      const limit = settings?.maxActiveProjects ?? 3; // matches schema @default(3)
-      if (activeCount >= limit) {
-        return NextResponse.json(
-          { error: `You've reached your ${limit} active project limit. Archive a project to create a new one.` },
-          { status: 403 }
-        );
-      }
-    }
+    let limitError: { error: string; status: number } | null = null;
+    const project = await prisma.$transaction(
+      async (tx) => {
+        if (userId) {
+          const [activeCount, settings] = await Promise.all([
+            tx.project.count({ where: { userId, archivedAt: null } }),
+            tx.userAiSettings.findUnique({ where: { userId }, select: { maxActiveProjects: true } }),
+          ]);
+          const limit = settings?.maxActiveProjects ?? 3; // matches schema @default(3)
+          if (activeCount >= limit) {
+            limitError = {
+              error: `You've reached your ${limit} active project limit. Archive a project to create a new one.`,
+              status: 403,
+            };
+            // Throw to abort the transaction without creating the project
+            throw new Error("LIMIT_EXCEEDED");
+          }
+        }
 
-    const project = await prisma.project.create({
-      data: {
-        title: sanitizeInput(title.trim()),
-        author: author ? sanitizeInput(author.trim()) : "",
-        synopsis: synopsis ? sanitizeInput(synopsis.trim()) : "",
-        genre: genre ? sanitizeInput(genre.trim()) : "",
-        projectType: projectType || "FICTION",
-        ...(userId && { userId }),
+        return tx.project.create({
+          data: {
+            title: sanitizeInput(title.trim()),
+            author: author ? sanitizeInput(author.trim()) : "",
+            synopsis: synopsis ? sanitizeInput(synopsis.trim()) : "",
+            genre: genre ? sanitizeInput(genre.trim()) : "",
+            projectType: projectType || "FICTION",
+            ...(userId && { userId }),
+          },
+        });
       },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    ).catch((err: unknown) => {
+      if (err instanceof Error && err.message === "LIMIT_EXCEEDED") {
+        return null; // handled via limitError
+      }
+      throw err; // re-throw unexpected errors (including P2034 serialization failure)
     });
+
+    if (limitError) {
+      return NextResponse.json(
+        { error: (limitError as { error: string }).error },
+        { status: (limitError as { status: number }).status }
+      );
+    }
 
     return NextResponse.json(project, { status: 201 });
   } catch (error) {
+    // P2034 = transaction serialization failure (two concurrent requests raced)
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034") {
+      return NextResponse.json(
+        { error: "Request conflict, please try again." },
+        { status: 409 }
+      );
+    }
     logger.error("POST /api/projects error", error);
     return NextResponse.json(
       { error: "Internal server error" },

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -7,6 +7,14 @@ import { isGoogleAuthMode } from "@/lib/auth";
 import { sanitizeInput } from "@/lib/sanitize-server";
 import { ProjectCreateSchema } from "@/schemas/projects";
 
+// Sentinel error used to abort a Prisma transaction when the project limit is exceeded.
+// Prisma transactions must be aborted by throwing — there is no early-return path.
+class LimitExceededError extends Error {
+  constructor(readonly limitPayload: { error: string; status: number }) {
+    super("LIMIT_EXCEEDED");
+  }
+}
+
 // GET /api/projects - List projects (scoped by userId when authenticated via Google)
 export async function GET(request: NextRequest) {
   try {
@@ -97,8 +105,9 @@ export async function GET(request: NextRequest) {
 
 // POST /api/projects - Create a new project (owned by current user)
 export async function POST(request: NextRequest) {
+  // Declared outside the try block so it's accessible in the catch handler for logging
+  const userId = getCurrentUserId(request);
   try {
-    const userId = getCurrentUserId(request);
 
     if (isGoogleAuthMode() && !userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -115,7 +124,10 @@ export async function POST(request: NextRequest) {
 
     const { title, author, synopsis, genre, projectType } = parsed.data;
 
-    // Only enforce active project limit for authenticated users; skip in API_TOKEN/dev mode
+    // Only enforce active project limit for authenticated users; skip in API_TOKEN/dev mode.
+    // Side-channel to convey limit-exceeded details across the transaction boundary:
+    // Prisma transactions must be aborted by throwing; we can't early-return a response
+    // from inside the callback, so we capture the payload here and check it after .catch().
     let limitError: { error: string; status: number } | null = null;
     const project = await prisma.$transaction(
       async (tx) => {
@@ -131,7 +143,7 @@ export async function POST(request: NextRequest) {
               status: 403,
             };
             // Throw to abort the transaction without creating the project
-            throw new Error("LIMIT_EXCEEDED");
+            throw new LimitExceededError(limitError);
           }
         }
 
@@ -148,23 +160,34 @@ export async function POST(request: NextRequest) {
       },
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
     ).catch((err: unknown) => {
-      if (err instanceof Error && err.message === "LIMIT_EXCEEDED") {
+      if (err instanceof LimitExceededError) {
         return null; // handled via limitError
       }
       throw err; // re-throw unexpected errors (including P2034 serialization failure)
     });
 
-    if (limitError) {
+    // TypeScript 6 cannot track mutations to `let` bindings made inside async closures,
+    // so it still believes `limitError` is `null` here. The cast restores the declared type
+    // and allows TS to narrow correctly within the if-check.
+    const capturedLimitError = limitError as { error: string; status: number } | null;
+    if (capturedLimitError) {
       return NextResponse.json(
-        { error: (limitError as { error: string }).error },
-        { status: (limitError as { status: number }).status }
+        { error: capturedLimitError.error },
+        { status: capturedLimitError.status }
       );
+    }
+
+    if (!project) {
+      // Should be unreachable: project is only null when limitError is set
+      logger.error("POST /api/projects: project unexpectedly null after transaction");
+      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 
     return NextResponse.json(project, { status: 201 });
   } catch (error) {
     // P2034 = transaction serialization failure (two concurrent requests raced)
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034") {
+      logger.warn("POST /api/projects serialization conflict (P2034)", { userId });
       return NextResponse.json(
         { error: "Request conflict, please try again." },
         { status: 409 }


### PR DESCRIPTION
## Summary

Fixes a TOCTOU (Time-of-Check-Time-of-Use) race condition that allowed authenticated users to bypass the active project limit by sending concurrent requests. The system now uses a serializable database transaction to atomically check the count and create projects, preventing both requests from passing the limit check simultaneously.

## Problem

The POST `/api/projects` endpoint enforced the limit by:
1. Counting active projects for the user
2. Checking if count >= limit
3. Creating the project

Without atomicity, two concurrent requests could both pass the count check before either insert completed, resulting in more projects than the limit allowed.

## Solution

- Wrapped the count + create operations in a `SERIALIZABLE` transaction, ensuring PostgreSQL atomically enforces the limit
- Added specific handling for `P2034` serialization failures (when two transactions race), returning 409 Conflict so clients can retry
- Added a concurrent request test to verify the fix

## Changes

| File | Changes |
|------|---------|
| `src/app/api/projects/route.ts` | Added Prisma import, wrapped count+create in SERIALIZABLE transaction, handle P2034 errors |
| `src/__tests__/projects-limit-route.test.ts` | Added test for concurrent create requests |

## Validation

✅ Type check: No errors
✅ Lint: 0 errors (148 pre-existing warnings unrelated to changes)
✅ Build: Successful

Fixes #846