### PR TITLE
Fix: add CSRF header check to state-changing endpoints

### DIFF
--- a/src/__tests__/api-auth.test.ts
+++ b/src/__tests__/api-auth.test.ts
@@ -259,28 +259,31 @@ describe("api-auth", () => {
             expect(result).toBeNull();
         });
 
-        it("returns 403 when X-CSRF-Protection header is absent", () => {
+        it("returns 403 when X-CSRF-Protection header is absent", async () => {
             const headers = new Headers();
             const request = { headers, url: "http://localhost/test" } as unknown as import("next/server").NextRequest;
             const result = validateCsrfHeader(request);
             expect(result).not.toBeNull();
             expect(result!.status).toBe(403);
+            expect(await result!.json()).toEqual({ error: "Forbidden" });
         });
 
-        it("returns 403 when X-CSRF-Protection header has wrong value", () => {
+        it("returns 403 when X-CSRF-Protection header has wrong value", async () => {
             const headers = new Headers({ "x-csrf-protection": "true" });
             const request = { headers, url: "http://localhost/test" } as unknown as import("next/server").NextRequest;
             const result = validateCsrfHeader(request);
             expect(result).not.toBeNull();
             expect(result!.status).toBe(403);
+            expect(await result!.json()).toEqual({ error: "Forbidden" });
         });
 
-        it("returns 403 when X-CSRF-Protection header is empty string", () => {
+        it("returns 403 when X-CSRF-Protection header is empty string", async () => {
             const headers = new Headers({ "x-csrf-protection": "" });
             const request = { headers, url: "http://localhost/test" } as unknown as import("next/server").NextRequest;
             const result = validateCsrfHeader(request);
             expect(result).not.toBeNull();
             expect(result!.status).toBe(403);
+            expect(await result!.json()).toEqual({ error: "Forbidden" });
         });
     });
 });

--- a/src/__tests__/api-auth.test.ts
+++ b/src/__tests__/api-auth.test.ts
@@ -11,6 +11,7 @@ import {
     verifyProjectReadAccess,
     verifyUniverseAccess,
     verifyProjectAccessByNode,
+    validateCsrfHeader,
 } from "@/lib/api-auth";
 import { ProjectsController } from "@/lib/controllers/projects";
 import { StructureController } from "@/lib/controllers/structure";
@@ -247,6 +248,39 @@ describe("api-auth", () => {
             if (!result.authorized) {
                 expect(result.response.status).toBe(403);
             }
+        });
+    });
+
+    describe("validateCsrfHeader", () => {
+        it("returns null when X-CSRF-Protection header is '1'", () => {
+            const headers = new Headers({ "x-csrf-protection": "1" });
+            const request = { headers, url: "http://localhost/test" } as unknown as import("next/server").NextRequest;
+            const result = validateCsrfHeader(request);
+            expect(result).toBeNull();
+        });
+
+        it("returns 403 when X-CSRF-Protection header is absent", () => {
+            const headers = new Headers();
+            const request = { headers, url: "http://localhost/test" } as unknown as import("next/server").NextRequest;
+            const result = validateCsrfHeader(request);
+            expect(result).not.toBeNull();
+            expect(result!.status).toBe(403);
+        });
+
+        it("returns 403 when X-CSRF-Protection header has wrong value", () => {
+            const headers = new Headers({ "x-csrf-protection": "true" });
+            const request = { headers, url: "http://localhost/test" } as unknown as import("next/server").NextRequest;
+            const result = validateCsrfHeader(request);
+            expect(result).not.toBeNull();
+            expect(result!.status).toBe(403);
+        });
+
+        it("returns 403 when X-CSRF-Protection header is empty string", () => {
+            const headers = new Headers({ "x-csrf-protection": "" });
+            const request = { headers, url: "http://localhost/test" } as unknown as import("next/server").NextRequest;
+            const result = validateCsrfHeader(request);
+            expect(result).not.toBeNull();
+            expect(result!.status).toBe(403);
         });
     });
 });

--- a/src/__tests__/consent-route.test.ts
+++ b/src/__tests__/consent-route.test.ts
@@ -4,9 +4,19 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-vi.mock("@/lib/api-auth", () => ({
-  getCurrentUserId: vi.fn(() => null),
-}));
+vi.mock("@/lib/api-auth", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    getCurrentUserId: vi.fn(() => null),
+    validateCsrfHeader: (request: { headers: Headers }) => {
+      const header = request.headers.get("x-csrf-protection");
+      if (header !== "1") {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+      return null;
+    },
+  };
+});
 vi.mock("@/lib/logger", () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }));
@@ -21,7 +31,7 @@ function makeGetRequest(): NextRequest {
 function makePutRequest(body: object): NextRequest {
   return new NextRequest("http://localhost/api/account/consent", {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "X-CSRF-Protection": "1" },
     body: JSON.stringify(body),
   });
 }
@@ -169,5 +179,17 @@ describe("PUT /api/account/consent", () => {
       where: { userId_feature: { userId: user.id, feature: "sentry_replay" } },
     });
     expect(row?.consentGiven).toBe(false);
+  });
+
+  it("returns 403 when CSRF header is missing", async () => {
+    const req = new NextRequest("http://localhost/api/account/consent", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ feature: "sentry_replay", consentGiven: true }),
+    });
+    const { PUT } = await import("@/app/api/account/consent/route");
+    const res = await PUT(req);
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("Forbidden");
   });
 });

--- a/src/app/api/account/consent/route.ts
+++ b/src/app/api/account/consent/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/db";
-import { getCurrentUserId } from "@/lib/api-auth";
+import { getCurrentUserId, validateCsrfHeader } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 
 const ConsentUpdateSchema = z.object({
@@ -24,6 +24,8 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
+  const csrfError = validateCsrfHeader(request);
+  if (csrfError) return csrfError;
   try {
     const userId = getCurrentUserId(request);
     if (!userId) {

--- a/src/app/api/integrations/google-docs/route.ts
+++ b/src/app/api/integrations/google-docs/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GoogleDocsCommentSync } from '@/lib/export/google-docs-comment-sync';
 import { GoogleAuthController } from '@/lib/controllers/google-auth';
-import { getCurrentUserId, verifyProjectWriteAccess } from '@/lib/api-auth';
+import { getCurrentUserId, verifyProjectWriteAccess, validateCsrfHeader } from '@/lib/api-auth';
 import { logger } from '@/lib/logger';
 
 /**
@@ -40,6 +40,8 @@ export async function GET(request: NextRequest) {
  * Disconnects Google Docs by removing the stored credential for the current user.
  */
 export async function DELETE(request: NextRequest) {
+    const csrfError = validateCsrfHeader(request);
+    if (csrfError) return csrfError;
     try {
         const userId = getCurrentUserId(request);
         await GoogleAuthController.disconnect(userId);

--- a/src/app/api/integrations/hashnode/route.ts
+++ b/src/app/api/integrations/hashnode/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { HashnodeAuthController } from '@/lib/controllers/hashnode-auth';
-import { getCurrentUserId } from '@/lib/api-auth';
+import { getCurrentUserId, validateCsrfHeader } from '@/lib/api-auth';
 import { logger } from '@/lib/logger';
 
 /**
@@ -49,6 +49,8 @@ export async function GET(request: NextRequest) {
  * Removes the stored Hashnode credential.
  */
 export async function DELETE(request: NextRequest) {
+    const csrfError = validateCsrfHeader(request);
+    if (csrfError) return csrfError;
     try {
         const userId = getCurrentUserId(request);
         await HashnodeAuthController.disconnect(userId);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -163,7 +163,7 @@ export default function SettingsPage() {
   const handleHashnodeDisconnect = async () => {
     setHashnodeDisconnecting(true);
     try {
-      await fetch("/api/integrations/hashnode", { method: "DELETE" });
+      await fetch("/api/integrations/hashnode", { method: "DELETE", headers: { "X-CSRF-Protection": "1" } });
       setHashnodeConnected(false);
       setHashnodeUsername(null);
       setHashnodeDisconnectOpen(false);
@@ -179,7 +179,7 @@ export default function SettingsPage() {
     try {
       const res = await fetch("/api/account/consent", {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-CSRF-Protection": "1" },
         body: JSON.stringify({ feature: "sentry_replay", consentGiven: allowed }),
       });
       if (!res.ok) throw new Error(`consent PUT failed: ${res.status}`);
@@ -218,7 +218,7 @@ export default function SettingsPage() {
   const handleGoogleDocsDisconnect = async () => {
     setGoogleDocsDisconnecting(true);
     try {
-      await fetch("/api/integrations/google-docs", { method: "DELETE" });
+      await fetch("/api/integrations/google-docs", { method: "DELETE", headers: { "X-CSRF-Protection": "1" } });
       setGoogleDocsConnected(false);
     } finally {
       setGoogleDocsDisconnecting(false);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -163,10 +163,13 @@ export default function SettingsPage() {
   const handleHashnodeDisconnect = async () => {
     setHashnodeDisconnecting(true);
     try {
-      await fetch("/api/integrations/hashnode", { method: "DELETE", headers: { "X-CSRF-Protection": "1" } });
+      const res = await fetch("/api/integrations/hashnode", { method: "DELETE", headers: { "X-CSRF-Protection": "1" } });
+      if (!res.ok) throw new Error(`Hashnode disconnect failed: ${res.status}`);
       setHashnodeConnected(false);
       setHashnodeUsername(null);
       setHashnodeDisconnectOpen(false);
+    } catch (err) {
+      console.error("Failed to disconnect Hashnode", err);
     } finally {
       setHashnodeDisconnecting(false);
     }
@@ -218,8 +221,11 @@ export default function SettingsPage() {
   const handleGoogleDocsDisconnect = async () => {
     setGoogleDocsDisconnecting(true);
     try {
-      await fetch("/api/integrations/google-docs", { method: "DELETE", headers: { "X-CSRF-Protection": "1" } });
+      const res = await fetch("/api/integrations/google-docs", { method: "DELETE", headers: { "X-CSRF-Protection": "1" } });
+      if (!res.ok) throw new Error(`Google Docs disconnect failed: ${res.status}`);
       setGoogleDocsConnected(false);
+    } catch (err) {
+      console.error("Failed to disconnect Google Docs", err);
     } finally {
       setGoogleDocsDisconnecting(false);
     }

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -284,7 +284,12 @@ export async function verifyProjectWriteAccessByNode(
 
 /**
  * Validate the CSRF custom header to protect state-changing endpoints.
- * Returns a 403 NextResponse if the header is missing or incorrect; null otherwise.
+ *
+ * Expects the `x-csrf-protection` header to be present with the exact value `"1"`.
+ * Returns a 403 NextResponse if the header is absent or has any other value; null otherwise.
+ *
+ * @param request - The incoming Next.js request.
+ * @returns null on success, or a 403 NextResponse on CSRF validation failure.
  */
 export function validateCsrfHeader(request: NextRequest): NextResponse | null {
     const header = request.headers.get("x-csrf-protection");

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/db";
+import { logger } from "@/lib/logger";
 
 /**
  * Get the authenticated user's ID from the request.
@@ -279,4 +280,17 @@ export async function verifyProjectWriteAccessByNode(
     const access = await verifyProjectWriteAccess(node.projectId, userId, userEmail);
     if (!access.authorized) return access;
     return { authorized: true, projectId: node.projectId, role: access.role };
+}
+
+/**
+ * Validate the CSRF custom header to protect state-changing endpoints.
+ * Returns a 403 NextResponse if the header is missing or incorrect; null otherwise.
+ */
+export function validateCsrfHeader(request: NextRequest): NextResponse | null {
+    const header = request.headers.get("x-csrf-protection");
+    if (header !== "1") {
+        logger.warn("CSRF header missing or invalid", { url: request.url });
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return null;
 }


### PR DESCRIPTION
## Summary

Add CSRF protection to three state-changing endpoints that were vulnerable to same-site subdomain attacks. These endpoints rely on `SameSite=Lax` session cookies, which permit cross-origin top-level navigations and treat subdomain pages as same-site. A new `validateCsrfHeader()` utility validates an explicit `X-CSRF-Protection: 1` custom header — browsers never include custom headers in cross-origin requests unless CORS explicitly permits them, making subdomain-origin forging impossible.

## Changes

### Backend
- **`src/lib/api-auth.ts`**: Added `validateCsrfHeader()` utility that validates the `X-CSRF-Protection: 1` header and returns a 403 response if missing or invalid
- **`src/app/api/integrations/hashnode/route.ts`**: Added CSRF guard to DELETE handler
- **`src/app/api/integrations/google-docs/route.ts`**: Added CSRF guard to DELETE handler
- **`src/app/api/account/consent/route.ts`**: Added CSRF guard to PUT handler

### Frontend
- **`src/app/settings/page.tsx`**: Added `X-CSRF-Protection: 1` header to three mutation fetch calls (Hashnode disconnect, consent toggle, Google Docs disconnect)

### Tests
- **`src/__tests__/consent-route.test.ts`**: Updated `makePutRequest` helper to include CSRF header; added new test for 403 response when CSRF header is missing
- **`src/__tests__/api-auth.test.ts`**: Added four unit tests for `validateCsrfHeader` covering header present/absent/invalid/empty cases

## Validation

| Check | Result |
|-------|--------|
| Type check | ✅ Pass |
| Lint | ✅ Pass (0 errors, 148 pre-existing warnings) |
| Build | ✅ Pass |
| Tests | ⚠️ Infrastructure limitation (TEST_DATABASE_URL unavailable in worktree) |

All modified test files validated manually by implementing agent. Changes follow established patterns from the codebase for guard functions that return `NextResponse | null`.

Fixes #848