### PR TITLE
Fix: use PrismaClientKnownRequestError in token-blocklist test mock

### DIFF
--- a/src/__tests__/token-blocklist.test.ts
+++ b/src/__tests__/token-blocklist.test.ts
@@ -35,14 +35,14 @@ describe("token-blocklist", () => {
                 "Unique constraint failed on the constraint: `RevokedToken_jti_key`",
                 { code: "P2002", clientVersion: "5.0.0", meta: {} }
             );
-            (prisma.revokedToken.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(p2002);
+            vi.mocked(prisma.revokedToken.create).mockRejectedValueOnce(p2002);
             await expect(revokeToken("jti-1", "user-1", new Date())).resolves.toBeUndefined();
             expect(logger.error).not.toHaveBeenCalled();
         });
 
         it("logs error for non-P2002 DB failures", async () => {
             const dbErr = new Error("Connection refused");
-            (prisma.revokedToken.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(dbErr);
+            vi.mocked(prisma.revokedToken.create).mockRejectedValueOnce(dbErr);
             await revokeToken("jti-1", "user-1", new Date());
             expect(logger.error).toHaveBeenCalledWith(
                 "[token-blocklist] Failed to revoke token:",

--- a/src/__tests__/token-blocklist.test.ts
+++ b/src/__tests__/token-blocklist.test.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/db", () => ({
@@ -30,7 +31,10 @@ describe("token-blocklist", () => {
         });
 
         it("silently ignores P2002 unique constraint (token already revoked)", async () => {
-            const p2002 = Object.assign(new Error("Unique constraint failed"), { code: "P2002" });
+            const p2002 = new Prisma.PrismaClientKnownRequestError(
+                "Unique constraint failed on the constraint: `RevokedToken_jti_key`",
+                { code: "P2002", clientVersion: "5.0.0", meta: {} }
+            );
             (prisma.revokedToken.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(p2002);
             await expect(revokeToken("jti-1", "user-1", new Date())).resolves.toBeUndefined();
             expect(logger.error).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Fixes #875 by updating the token-blocklist test mock to use `PrismaClientKnownRequestError` instead of a plain `Error` object. This prevents test breakage when the stricter `instanceof` error check lands.

## Root Cause

Commit `31647b2` (on another branch) changed the P2002 error check in `token-blocklist.ts` from duck-typing to a strict `instanceof Prisma.PrismaClientKnownRequestError` check. The test was using a plain Error mock that doesn't pass the `instanceof` check, causing `logger.error` to fire when the test asserts it must not.

## Changes

- **File**: `src/__tests__/token-blocklist.test.ts`
- **Action**: Replace plain Error mock with `new Prisma.PrismaClientKnownRequestError()`
- **Pattern**: Mirrors existing pattern from `src/__tests__/sharing.test.ts`

## Validation

- ✅ Type check: No errors
- ✅ Lint: 0 errors
- ✅ Target tests (token-blocklist.test.ts): 8 passed
- ✅ Full build: Success
- ✅ No regressions: Pre-existing test failures unaffected

Fixes #875