### PR TITLE
Fix: GDPR account deletion & complete data export (#844)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -72,9 +72,39 @@ Export all personal data for the authenticated user as a ZIP archive (GDPR Artic
 - `200 application/zip` — ZIP archive (`annie-full-export-<date>.zip`) containing:
   - `profile.json` — user profile fields (`id`, `email`, `name`, `picture`, `createdAt`, `updatedAt`)
   - `ai-settings.json` — AI preferences (API key is **omitted** for security)
-  - `projects/<title>.json` — full project JSON for each project (same format as `/api/projects/:id/export?format=json`)
+  - `consents.json` — consent preferences (`feature`, `consentGiven`, `updatedAt` per entry)
+  - `projects/<title>.json` — full project JSON for each project, including:
+    - structure nodes, story objects, chat messages, annotations, relationships
+    - `writingSessions` — word count and duration records per scene
+    - `conversations` — AI chat threads (title, type, summary; messages excluded)
+    - `googleDocExports` — Google Docs sync records (credential tokens **omitted**)
+    - `hashnodeExports` — Hashnode publish records (`credentialId` **omitted** for security)
 - `401 Unauthorized` — not authenticated
 - `500 Internal Server Error` — export generation failed
+
+---
+
+### `DELETE /api/auth/delete-account`
+Permanently delete the authenticated user's account and all associated data (GDPR Article 17 — right to erasure).
+
+**Authentication**: Required (session cookie). Returns `401` if not authenticated.
+
+**CSRF**: Requires `X-CSRF-Protection: 1` header. Returns `403` without it.
+
+**Mode restriction**: Only available in Google Auth mode. Returns `403` in API_TOKEN (single-user) mode — owner-operated instances are not subject to GDPR self-service deletion.
+
+**Request body**:
+```json
+{ "email": "user@example.com" }
+```
+The `email` field must exactly match the authenticated user's email as a confirmation step.
+
+**Response**:
+- `200 OK` — `{ "ok": true }`. Session cookie is cleared (`Max-Age=0`).
+- `400 Bad Request` — missing/invalid email, or email does not match (`{ "error": "Email does not match" }`)
+- `401 Unauthorized` — not authenticated or user not found
+- `403 Forbidden` — missing CSRF header, or API_TOKEN mode
+- `500 Internal Server Error` — deletion failed
 
 ---
 

--- a/prisma/migrations/20260612_gdpr_cascade_delete_user/migration.sql
+++ b/prisma/migrations/20260612_gdpr_cascade_delete_user/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable: Add ON DELETE CASCADE to Project.userId -> User.id
+ALTER TABLE "Project" DROP CONSTRAINT IF EXISTS "Project_userId_fkey";
+ALTER TABLE "Project" ADD CONSTRAINT "Project_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable: Add ON DELETE CASCADE to Universe.userId -> User.id
+ALTER TABLE "Universe" DROP CONSTRAINT IF EXISTS "Universe_userId_fkey";
+ALTER TABLE "Universe" ADD CONSTRAINT "Universe_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,7 +72,7 @@ model Project {
   storyObjects     StoryObject[]
   structureNodes   StructureNode[]
   universe         Universe?         @relation(fields: [universeId], references: [id])
-  user             User?             @relation(fields: [userId], references: [id])
+  user             User?             @relation(fields: [userId], references: [id], onDelete: Cascade)
   projectType      String            @default("FICTION") // FICTION, ARTICLE_COLLECTION, GENERAL
   isSample         Boolean           @default(false)
   conversations    Conversation[]
@@ -177,7 +177,7 @@ model Universe {
   projects         Project[]
   worldObjects     WorldObject[]
   googleDocExports GoogleDocExport[]
-  user             User?             @relation(fields: [userId], references: [id])
+  user             User?             @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
 }

--- a/src/__tests__/delete-account-route.test.ts
+++ b/src/__tests__/delete-account-route.test.ts
@@ -22,7 +22,8 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import { getCurrentUserId, validateCsrfHeader } from "@/lib/api-auth";
-import { isGoogleAuthMode } from "@/lib/auth";
+import { isGoogleAuthMode, verifySessionToken } from "@/lib/auth";
+import { revokeToken } from "@/lib/token-blocklist";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -138,5 +139,74 @@ describe("DELETE /api/auth/delete-account", () => {
     expect(setCookie).toBeTruthy();
     expect(setCookie).toContain("session=");
     expect(setCookie).toContain("Max-Age=0");
+  });
+
+  it("revokes session token on successful deletion", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "del-u5", email: "del5@test.com", googleId: "g-del5" },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+    vi.mocked(verifySessionToken).mockResolvedValue({ jti: "jti-abc", userId: user.id, email: "del5@test.com", name: "Test" });
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const req = new NextRequest("http://localhost/api/auth/delete-account", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", "X-CSRF-Protection": "1", Cookie: "session=tok123" },
+      body: JSON.stringify({ email: "del5@test.com" }),
+    });
+    const res = await DELETE(req);
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(revokeToken)).toHaveBeenCalledWith("jti-abc", user.id, expect.any(Date));
+  });
+
+  it("still returns 200 when revokeToken throws (best-effort)", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "del-u6", email: "del6@test.com", googleId: "g-del6" },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+    vi.mocked(verifySessionToken).mockResolvedValue({ jti: "jti-xyz", userId: user.id, email: "del6@test.com", name: "Test" });
+    vi.mocked(revokeToken).mockRejectedValue(new Error("DB down"));
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const req = new NextRequest("http://localhost/api/auth/delete-account", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", "X-CSRF-Protection": "1", Cookie: "session=tok456" },
+      body: JSON.stringify({ email: "del6@test.com" }),
+    });
+    const res = await DELETE(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("deletes user's projects and credentials along with account", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "del-u7", email: "del7@test.com", googleId: "g-del7" },
+    });
+    const project = await testPrisma.project.create({
+      data: { id: "proj-del7", title: "My Novel", userId: user.id },
+    });
+    await testPrisma.googleCredential.create({
+      data: { userId: user.id, accessToken: "tok", refreshToken: "ref", expiresAt: new Date("2030-01-01") },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest({ email: "del7@test.com" }));
+    expect(res.status).toBe(200);
+
+    expect(await testPrisma.user.findUnique({ where: { id: user.id } })).toBeNull();
+    expect(await testPrisma.project.findUnique({ where: { id: project.id } })).toBeNull();
+    expect(await testPrisma.googleCredential.findFirst({ where: { userId: user.id } })).toBeNull();
+  });
+
+  it("returns 400 for malformed email format", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "del-u8", email: "del8@test.com", googleId: "g-del8" },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest({ email: "notanemail" }));
+    expect(res.status).toBe(400);
   });
 });

--- a/src/__tests__/delete-account-route.test.ts
+++ b/src/__tests__/delete-account-route.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { testPrisma } from "./setup";
+import { NextRequest } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/api-auth", () => ({
+  getCurrentUserId: vi.fn(() => null),
+  validateCsrfHeader: vi.fn(() => null),
+}));
+vi.mock("@/lib/auth", () => ({
+  isGoogleAuthMode: vi.fn(() => true),
+  SESSION_COOKIE_NAME: "session",
+  SESSION_MAX_AGE: 3600,
+  verifySessionToken: vi.fn(() => null),
+}));
+vi.mock("@/lib/token-blocklist", () => ({
+  revokeToken: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { getCurrentUserId, validateCsrfHeader } from "@/lib/api-auth";
+import { isGoogleAuthMode } from "@/lib/auth";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRequest(body: Record<string, unknown> = {}, withCsrf = true): NextRequest {
+  return new NextRequest("http://localhost/api/auth/delete-account", {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      ...(withCsrf ? { "X-CSRF-Protection": "1" } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("DELETE /api/auth/delete-account", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+    vi.mocked(isGoogleAuthMode).mockReturnValue(true);
+    vi.mocked(validateCsrfHeader).mockReturnValue(null);
+  });
+
+  it("returns 403 without CSRF header", async () => {
+    const { NextResponse } = await import("next/server");
+    vi.mocked(validateCsrfHeader).mockReturnValue(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    );
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest({}, false));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 in API_TOKEN mode", async () => {
+    vi.mocked(isGoogleAuthMode).mockReturnValue(false);
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when userId is null", async () => {
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when userId not found in DB", async () => {
+    vi.mocked(getCurrentUserId).mockReturnValue("nonexistent-user");
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "del-u1", email: "del1@test.com", googleId: "g-del1" },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when email does not match", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "del-u2", email: "del2@test.com", googleId: "g-del2" },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest({ email: "wrong@test.com" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Email does not match");
+  });
+
+  it("deletes user and returns 200", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "del-u3", email: "del3@test.com", googleId: "g-del3" },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest({ email: "del3@test.com" }));
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+
+    // Verify user no longer exists
+    const deleted = await testPrisma.user.findUnique({ where: { id: user.id } });
+    expect(deleted).toBeNull();
+  });
+
+  it("clears session cookie in response", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "del-u4", email: "del4@test.com", googleId: "g-del4" },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+
+    const { DELETE } = await import("@/app/api/auth/delete-account/route");
+    const res = await DELETE(makeRequest({ email: "del4@test.com" }));
+    expect(res.status).toBe(200);
+
+    const setCookie = res.headers.get("set-cookie");
+    expect(setCookie).toBeTruthy();
+    expect(setCookie).toContain("session=");
+    expect(setCookie).toContain("Max-Age=0");
+  });
+});

--- a/src/__tests__/export-data-route.test.ts
+++ b/src/__tests__/export-data-route.test.ts
@@ -142,6 +142,33 @@ describe("GET /api/auth/export-data", () => {
     expect(profile).not.toHaveProperty("googleId");
   });
 
+  it("includes consents.json in export for authenticated user", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "u-consent", email: "consent@test.com", googleId: "g-consent" },
+    });
+    await testPrisma.userConsent.create({
+      data: {
+        userId: user.id,
+        feature: "sentry_replay",
+        consentGiven: false,
+      },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+
+    const { GET } = await import("@/app/api/auth/export-data/route");
+    const res = await GET(makeRequest());
+    const buf = Buffer.from(await res.arrayBuffer());
+
+    const zip = await JSZip.loadAsync(buf);
+    const consentsFile = zip.file("consents.json");
+    expect(consentsFile).not.toBeNull();
+    const consents = JSON.parse(await consentsFile!.async("string"));
+    expect(consents).toHaveLength(1);
+    expect(consents[0].feature).toBe("sentry_replay");
+    expect(consents[0].consentGiven).toBe(false);
+    expect(consents[0]).toHaveProperty("updatedAt");
+  });
+
   it("sanitizes project titles in ZIP filenames", async () => {
     const user = await testPrisma.user.create({
       data: { id: "u4", email: "w@test.com", googleId: "g4" },

--- a/src/__tests__/export-json.test.ts
+++ b/src/__tests__/export-json.test.ts
@@ -155,6 +155,7 @@ describe("exportProjectJson", () => {
     expect(result.writingSessions[0].wordsWritten).toBe(500);
     expect(result.writingSessions[0].durationSeconds).toBe(1800);
     expect(result.writingSessions[0].date).toBe("2026-06-01");
+    expect(result.writingSessions[0].endedAt).toBeNull();
   });
 
   it("exports conversations with summary", async () => {

--- a/src/__tests__/export-json.test.ts
+++ b/src/__tests__/export-json.test.ts
@@ -135,6 +135,89 @@ describe("exportProjectJson", () => {
     expect(result.chatHistory[1].role).toBe("assistant");
   });
 
+  it("exports writing sessions", async () => {
+    const scene = await testPrisma.structureNode.create({
+      data: { projectId, type: "SCENE", title: "Scene WS", orderIndex: 0 },
+    });
+    await testPrisma.writingSession.create({
+      data: {
+        projectId,
+        nodeId: scene.id,
+        wordsWritten: 500,
+        durationSeconds: 1800,
+        date: "2026-06-01",
+      },
+    });
+
+    const result = await exportProjectJson(projectId);
+
+    expect(result.writingSessions).toHaveLength(1);
+    expect(result.writingSessions[0].wordsWritten).toBe(500);
+    expect(result.writingSessions[0].durationSeconds).toBe(1800);
+    expect(result.writingSessions[0].date).toBe("2026-06-01");
+  });
+
+  it("exports conversations with summary", async () => {
+    await testPrisma.conversation.create({
+      data: {
+        projectId,
+        title: "Brainstorm",
+        type: "chat",
+        summary: "Discussed character arcs",
+      },
+    });
+
+    const result = await exportProjectJson(projectId);
+
+    expect(result.conversations).toHaveLength(1);
+    expect(result.conversations[0].title).toBe("Brainstorm");
+    expect(result.conversations[0].summary).toBe("Discussed character arcs");
+  });
+
+  it("exports google doc exports", async () => {
+    await testPrisma.googleDocExport.create({
+      data: {
+        projectId,
+        exportMode: "STORY_READER",
+        googleDocId: "doc-123",
+        googleDocUrl: "https://docs.google.com/doc-123",
+        lastSyncedAt: new Date("2026-06-01"),
+      },
+    });
+
+    const result = await exportProjectJson(projectId);
+
+    expect(result.googleDocExports).toHaveLength(1);
+    expect(result.googleDocExports[0].exportMode).toBe("STORY_READER");
+    expect(result.googleDocExports[0].googleDocId).toBe("doc-123");
+  });
+
+  it("exports hashnode exports without credentialId", async () => {
+    const credential = await testPrisma.hashnodeCredential.create({
+      data: {
+        userId: "local",
+        accessToken: "test-token",
+      },
+    });
+    await testPrisma.hashnodeExport.create({
+      data: {
+        projectId,
+        hashnodePostId: "post-123",
+        hashnodePostUrl: "https://hashnode.com/post-123",
+        publishStatus: "published",
+        lastSyncedAt: new Date("2026-06-01"),
+        credentialId: credential.id,
+      },
+    });
+
+    const result = await exportProjectJson(projectId);
+
+    expect(result.hashnodeExports).toHaveLength(1);
+    expect(result.hashnodeExports[0].hashnodePostId).toBe("post-123");
+    expect(result.hashnodeExports[0].publishStatus).toBe("published");
+    expect(result.hashnodeExports[0]).not.toHaveProperty("credentialId");
+  });
+
   it("only exports relationships belonging to the project", async () => {
     const scene = await testPrisma.structureNode.create({
       data: { projectId, type: "SCENE", title: "Scene A", orderIndex: 0 },

--- a/src/app/api/auth/delete-account/route.ts
+++ b/src/app/api/auth/delete-account/route.ts
@@ -1,0 +1,81 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getCurrentUserId, validateCsrfHeader } from "@/lib/api-auth";
+import { isGoogleAuthMode, SESSION_COOKIE_NAME, SESSION_MAX_AGE, verifySessionToken } from "@/lib/auth";
+import { revokeToken } from "@/lib/token-blocklist";
+import { AccountDeleteSchema } from "@/schemas/account";
+import { logger } from "@/lib/logger";
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const csrfError = validateCsrfHeader(request);
+    if (csrfError) return csrfError;
+
+    if (!isGoogleAuthMode()) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const userId = getCurrentUserId(request);
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const parsed = AccountDeleteSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid input" },
+        { status: 400 }
+      );
+    }
+
+    if (parsed.data.email !== user.email) {
+      return NextResponse.json({ error: "Email does not match" }, { status: 400 });
+    }
+
+    await prisma.$transaction([
+      prisma.googleCredential.deleteMany({ where: { userId } }),
+      prisma.hashnodeCredential.deleteMany({ where: { userId } }),
+      prisma.project.deleteMany({ where: { userId } }),
+      prisma.universe.deleteMany({ where: { userId } }),
+      prisma.user.delete({ where: { id: userId } }),
+    ]);
+
+    // Revoke session token (best-effort, after transaction)
+    const sessionCookie = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+    if (sessionCookie) {
+      const session = await verifySessionToken(sessionCookie);
+      if (session?.jti) {
+        const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000);
+        try {
+          await revokeToken(session.jti, session.userId, expiresAt);
+        } catch (err) {
+          logger.error("[delete-account] Failed to revoke token in blocklist:", err);
+        }
+      }
+    }
+
+    logger.info("DELETE /api/auth/delete-account: account deleted", { userId });
+
+    const response = NextResponse.json({ ok: true });
+    response.cookies.set(SESSION_COOKIE_NAME, "", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      maxAge: 0,
+      path: "/",
+    });
+    return response;
+  } catch (error) {
+    logger.error("DELETE /api/auth/delete-account error", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/delete-account/route.ts
+++ b/src/app/api/auth/delete-account/route.ts
@@ -38,7 +38,11 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "Email does not match" }, { status: 400 });
     }
 
+    // Credentials and GoogleDocExports lack cascade; delete them explicitly before removing the user.
+    // Project and Universe rows are also deleted explicitly (cascade covers them too, belt-and-suspenders).
     await prisma.$transaction([
+      prisma.googleDocExport.deleteMany({ where: { project: { userId } } }),
+      prisma.googleDocExport.deleteMany({ where: { universe: { userId } } }),
       prisma.googleCredential.deleteMany({ where: { userId } }),
       prisma.hashnodeCredential.deleteMany({ where: { userId } }),
       prisma.project.deleteMany({ where: { userId } }),
@@ -49,14 +53,14 @@ export async function DELETE(request: NextRequest) {
     // Revoke session token (best-effort, after transaction)
     const sessionCookie = request.cookies.get(SESSION_COOKIE_NAME)?.value;
     if (sessionCookie) {
-      const session = await verifySessionToken(sessionCookie);
-      if (session?.jti) {
-        const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000);
-        try {
+      try {
+        const session = await verifySessionToken(sessionCookie);
+        if (session?.jti) {
+          const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000);
           await revokeToken(session.jti, session.userId, expiresAt);
-        } catch (err) {
-          logger.error("[delete-account] Failed to revoke token in blocklist:", err);
         }
+      } catch (err) {
+        logger.error("[delete-account] Failed to revoke token in blocklist:", err);
       }
     }
 

--- a/src/app/api/auth/export-data/route.ts
+++ b/src/app/api/auth/export-data/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const [projects, aiSettings] = await Promise.all([
+    const [projects, aiSettings, consents] = await Promise.all([
       prisma.project.findMany({
         where: userId ? { userId } : {},
         select: { id: true, title: true },
@@ -34,6 +34,9 @@ export async function GET(request: NextRequest) {
       userId
         ? prisma.userAiSettings.findUnique({ where: { userId } })
         : Promise.resolve(null),
+      userId
+        ? prisma.userConsent.findMany({ where: { userId } })
+        : Promise.resolve([]),
     ]);
 
     const archive = archiver("zip", { zlib: { level: 9 } });
@@ -73,6 +76,19 @@ export async function GET(request: NextRequest) {
       archive.append(JSON.stringify(safeAiSettings, null, 2), {
         name: "ai-settings.json",
       });
+
+      archive.append(
+        JSON.stringify(
+          consents.map((c) => ({
+            feature: c.feature,
+            consentGiven: c.consentGiven,
+            updatedAt: c.updatedAt.toISOString(),
+          })),
+          null,
+          2
+        ),
+        { name: "consents.json" }
+      );
     }
 
     for (const project of projects) {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -104,9 +104,9 @@ export default function PrivacyPage() {
               within the app. Deleted items are removed from the database.
             </p>
             <p>
-              To delete your entire account and all associated data, contact the
-              instance administrator. We will remove all your data promptly upon
-              request.
+              To delete your entire account and all associated data, go to{" "}
+              <Link href="/settings" className="text-accent hover:underline">Settings → Privacy & Data → Delete account</Link>.
+              All data is removed immediately and permanently.
             </p>
           </section>
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -237,7 +237,8 @@ export default function SettingsPage() {
         return;
       }
       window.location.href = "/";
-    } catch {
+    } catch (err) {
+      console.error("Failed to delete account:", err);
       setDeleteError("Deletion failed. Please check your connection and try again.");
     } finally {
       setDeletingAccount(false);
@@ -850,7 +851,10 @@ export default function SettingsPage() {
           <AlertDialogFooter>
             <AlertDialogCancel disabled={deletingAccount}>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={handleDeleteAccount}
+              onClick={(e) => {
+                e.preventDefault();
+                handleDeleteAccount();
+              }}
               disabled={deletingAccount || !deleteConfirmEmail.trim()}
               className="bg-red-600 hover:bg-red-700 text-white"
             >

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Save, Check, Eye, EyeOff, Settings, Sparkles, MessageSquare, Link2, Link2Off, Loader2, Shield, Download } from "lucide-react";
+import { ArrowLeft, Save, Check, Eye, EyeOff, Settings, Sparkles, MessageSquare, Link2, Link2Off, Loader2, Shield, Download, Trash2 } from "lucide-react";
 import { offlineFetch } from "@/lib/offline/sync-queue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -83,6 +83,10 @@ export default function SettingsPage() {
   const [consentLoading, setConsentLoading] = useState(true);
   const [exportingData, setExportingData] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [deleteAccountOpen, setDeleteAccountOpen] = useState(false);
+  const [deleteConfirmEmail, setDeleteConfirmEmail] = useState("");
+  const [deletingAccount, setDeletingAccount] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/ai-settings")
@@ -215,6 +219,28 @@ export default function SettingsPage() {
       setExportError("Export failed. Please check your connection and try again.");
     } finally {
       setExportingData(false);
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    setDeletingAccount(true);
+    setDeleteError(null);
+    try {
+      const res = await fetch("/api/auth/delete-account", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json", "X-CSRF-Protection": "1" },
+        body: JSON.stringify({ email: deleteConfirmEmail }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setDeleteError(data.error || "Deletion failed. Please try again.");
+        return;
+      }
+      window.location.href = "/";
+    } catch {
+      setDeleteError("Deletion failed. Please check your connection and try again.");
+    } finally {
+      setDeletingAccount(false);
     }
   };
 
@@ -780,10 +806,60 @@ export default function SettingsPage() {
                   <p className="text-xs text-red-500 mt-2">{exportError}</p>
                 )}
               </div>
+              <div className="border-t border-border pt-4">
+                <p className="text-sm font-medium text-red-600 mb-1">Delete account</p>
+                <p className="text-xs text-text-muted mb-3">
+                  Permanently delete your account and all associated data (GDPR Article 17).
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setDeleteAccountOpen(true)}
+                  className="gap-1.5 border-red-300 text-red-600 hover:bg-red-50 hover:text-red-700"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Delete my account
+                </Button>
+              </div>
             </div>
           )}
         </div>
       </div>
+
+      <AlertDialog open={deleteAccountOpen} onOpenChange={(open) => { setDeleteAccountOpen(open); setDeleteConfirmEmail(""); setDeleteError(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete your account and all associated data including projects, universes, writing sessions, and settings. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="px-1 pb-2">
+            <label className="block text-sm font-medium text-text-secondary mb-1.5">
+              Type your email address to confirm
+            </label>
+            <Input
+              type="email"
+              value={deleteConfirmEmail}
+              onChange={(e) => setDeleteConfirmEmail(e.target.value)}
+              placeholder="your@email.com"
+              autoComplete="off"
+            />
+            {deleteError && <p className="text-xs text-red-500 mt-2">{deleteError}</p>}
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deletingAccount}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteAccount}
+              disabled={deletingAccount || !deleteConfirmEmail.trim()}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              {deletingAccount ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : null}
+              Delete my account
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </main>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -222,6 +222,12 @@ export default function SettingsPage() {
     }
   };
 
+  const handleDeleteDialogChange = (open: boolean) => {
+    setDeleteAccountOpen(open);
+    setDeleteConfirmEmail("");
+    setDeleteError(null);
+  };
+
   const handleDeleteAccount = async () => {
     setDeletingAccount(true);
     setDeleteError(null);
@@ -827,7 +833,7 @@ export default function SettingsPage() {
         </div>
       </div>
 
-      <AlertDialog open={deleteAccountOpen} onOpenChange={(open) => { setDeleteAccountOpen(open); setDeleteConfirmEmail(""); setDeleteError(null); }}>
+      <AlertDialog open={deleteAccountOpen} onOpenChange={handleDeleteDialogChange}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete your account?</AlertDialogTitle>

--- a/src/lib/export-json.ts
+++ b/src/lib/export-json.ts
@@ -5,7 +5,7 @@ export async function exportProjectJson(projectId: string) {
   if (!project) throw new Error(`Project not found: ${projectId}`);
 
   // Fetch all related data in parallel
-  const [structureNodes, storyObjects, chatMessages, annotations, relationships] =
+  const [structureNodes, storyObjects, chatMessages, annotations, relationships, writingSessions, conversations, googleDocExports, hashnodeExports] =
     await Promise.all([
       prisma.structureNode.findMany({
         where: { projectId },
@@ -30,6 +30,23 @@ export async function exportProjectJson(projectId: string) {
           toNode: { select: { id: true, projectId: true } },
           toObject: { select: { id: true, projectId: true } },
         },
+      }),
+      prisma.writingSession.findMany({
+        where: { projectId },
+        orderBy: { startedAt: "asc" },
+      }),
+      prisma.conversation.findMany({
+        where: { projectId },
+        orderBy: { createdAt: "asc" },
+        select: { id: true, title: true, type: true, summary: true, createdAt: true, updatedAt: true },
+      }),
+      prisma.googleDocExport.findMany({
+        where: { projectId },
+        orderBy: { createdAt: "asc" },
+      }),
+      prisma.hashnodeExport.findMany({
+        where: { projectId },
+        orderBy: { createdAt: "asc" },
       }),
     ]);
 
@@ -121,6 +138,42 @@ export async function exportProjectJson(projectId: string) {
       role: m.role,
       content: m.content,
       createdAt: m.createdAt.toISOString(),
+    })),
+    writingSessions: writingSessions.map((s) => ({
+      id: s.id,
+      projectId: s.projectId,
+      nodeId: s.nodeId,
+      startedAt: s.startedAt.toISOString(),
+      endedAt: s.endedAt?.toISOString() ?? null,
+      wordsWritten: s.wordsWritten,
+      durationSeconds: s.durationSeconds,
+      date: s.date,
+    })),
+    conversations: conversations.map((c) => ({
+      id: c.id,
+      title: c.title,
+      type: c.type,
+      summary: c.summary,
+      createdAt: c.createdAt.toISOString(),
+      updatedAt: c.updatedAt.toISOString(),
+    })),
+    googleDocExports: googleDocExports.map((e) => ({
+      id: e.id,
+      exportMode: e.exportMode,
+      googleDocId: e.googleDocId,
+      googleDocUrl: e.googleDocUrl,
+      lastSyncedAt: e.lastSyncedAt.toISOString(),
+      createdAt: e.createdAt.toISOString(),
+    })),
+    hashnodeExports: hashnodeExports.map((e) => ({
+      id: e.id,
+      nodeId: e.nodeId,
+      hashnodePostId: e.hashnodePostId,
+      hashnodePostUrl: e.hashnodePostUrl,
+      publishStatus: e.publishStatus,
+      lastSyncedAt: e.lastSyncedAt.toISOString(),
+      createdAt: e.createdAt.toISOString(),
+      updatedAt: e.updatedAt.toISOString(),
     })),
   };
 }

--- a/src/lib/export-json.ts
+++ b/src/lib/export-json.ts
@@ -5,8 +5,10 @@ export async function exportProjectJson(projectId: string) {
   if (!project) throw new Error(`Project not found: ${projectId}`);
 
   // Fetch all related data in parallel
-  const [structureNodes, storyObjects, chatMessages, annotations, relationships, writingSessions, conversations, googleDocExports, hashnodeExports] =
-    await Promise.all([
+  const [
+    structureNodes, storyObjects, chatMessages, annotations, relationships,
+    writingSessions, conversations, googleDocExports, hashnodeExports,
+  ] = await Promise.all([
       prisma.structureNode.findMany({
         where: { projectId },
         orderBy: { orderIndex: "asc" },

--- a/src/lib/export-json.ts
+++ b/src/lib/export-json.ts
@@ -47,6 +47,10 @@ export async function exportProjectJson(projectId: string) {
       prisma.hashnodeExport.findMany({
         where: { projectId },
         orderBy: { createdAt: "asc" },
+        select: {
+          id: true, nodeId: true, hashnodePostId: true, hashnodePostUrl: true,
+          publishStatus: true, lastSyncedAt: true, createdAt: true, updatedAt: true,
+        },
       }),
     ]);
 
@@ -174,6 +178,7 @@ export async function exportProjectJson(projectId: string) {
       lastSyncedAt: e.lastSyncedAt.toISOString(),
       createdAt: e.createdAt.toISOString(),
       updatedAt: e.updatedAt.toISOString(),
+      // credentialId intentionally excluded — points to raw OAuth token, metadata-only export
     })),
   };
 }

--- a/src/schemas/account.ts
+++ b/src/schemas/account.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const AccountDeleteSchema = z.object({
+  email: z.string().email("Must be a valid email address"),
+});
+
+export type AccountDeleteInput = z.infer<typeof AccountDeleteSchema>;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -5,3 +5,4 @@ export * from "./universes";
 export * from "./world-objects";
 export * from "./relationships";
 export * from "./timeline";
+export * from "./account";


### PR DESCRIPTION
## Summary

Implement self-service account deletion (GDPR Article 17) and extend the data export to include all missing data categories (GDPR Article 20). A new `DELETE /api/auth/delete-account` endpoint handles cascade deletion with email confirmation. The export ZIP gains `consents.json` and per-project `writingSessions`, `conversations`, `googleDocExports`, `hashnodeExports`. The settings page gains a "Delete Account" section with an email-confirmation AlertDialog, and the privacy page copy is updated to reference the in-app path.

## Changes

### Database Schema
- Add `onDelete: Cascade` to `Project.user` and `Universe.user` relations to prevent data orphaning on user deletion

### API Changes
- **New**: `DELETE /api/auth/delete-account` endpoint with email confirmation
  - Validates CSRF header
  - Returns 403 in API_TOKEN mode (single-user)
  - Deletes all user data in transaction: credentials, projects, universes, user
  - Revokes session token and clears auth cookie

### Export Enhancements
- Add `consents.json` to export ZIP with user consent records
- Extend per-project exports to include:
  - `writingSessions` (all writing session records)
  - `conversations` (with summaries)
  - `googleDocExports` (metadata only, no tokens)
  - `hashnodeExports` (metadata only, no credentials)

### UI Changes
- Add "Delete Account" section to Settings → Privacy & Data
  - New danger-colored button opening email confirmation dialog
  - Requires email address typing to confirm deletion
- Update Privacy page copy to point to Settings → Delete Account instead of "contact admin"

### Schema
- Add `src/schemas/account.ts` with `AccountDeleteSchema` for email validation
- Update `src/schemas/index.ts` barrel export

## Test Coverage

- Full test suite for `DELETE /api/auth/delete-account` endpoint (CSRF validation, auth mode checks, email confirmation, transaction correctness)
- Extended export tests for new data types in ZIP and per-project exports
- All existing tests continue to pass

## Validation

```bash
# Static analysis
npx tsc --noEmit && npx eslint src/

# Unit tests
npm test -- src/__tests__/delete-account-route.test.ts src/__tests__/export-data-route.test.ts src/__tests__/export-json.test.ts

# Full suite
npm run validate
```

## Scope Limitations

- Hard deletion only (no anonymization)
- Single-user (API_TOKEN) mode returns 403 — not applicable to owner-operated instances
- Credential metadata only in exports (no tokens or sensitive data)
- Screenshot tests deferred (require auth mocking in Playwright)

Fixes #844