### PR TITLE
Fix: add StaleWhileRevalidate caching for app shell routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -135,6 +135,25 @@ const pwaConfig = withPWA({
           },
         },
       },
+      // App shell routes — serve from cache first, revalidate in background.
+      // Placed before the default spread so it overrides the default document/pages
+      // handler (which uses NetworkFirst and requires a network attempt offline).
+      {
+        urlPattern: ({ request, url }: { request: Request; url: URL }) =>
+          request.mode === "navigate" &&
+          (url.pathname === "/" || url.pathname.startsWith("/projects/")),
+        handler: "StaleWhileRevalidate" as const,
+        options: {
+          cacheName: "app-shell",
+          expiration: {
+            maxEntries: 32,
+            maxAgeSeconds: 24 * 60 * 60, // 24 hours
+          },
+          cacheableResponse: {
+            statuses: [0, 200],
+          },
+        },
+      },
       // Include the default caches (static assets, images, etc.)
       // Filter out the built-in `apis` entry — authenticated API responses
       // must not be cached on shared devices (MED-17).

--- a/next.config.ts
+++ b/next.config.ts
@@ -108,7 +108,7 @@ const pwaConfig = withPWA({
       // Cache Google Fonts stylesheets
       {
         urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
-        handler: "StaleWhileRevalidate",
+        handler: "StaleWhileRevalidate" as const,
         options: {
           cacheName: "google-fonts-stylesheets",
           expiration: {
@@ -123,7 +123,7 @@ const pwaConfig = withPWA({
       // Cache Google Fonts webfont files
       {
         urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
-        handler: "CacheFirst",
+        handler: "CacheFirst" as const,
         options: {
           cacheName: "google-fonts-webfonts",
           expiration: {


### PR DESCRIPTION
## Summary

Added explicit `StaleWhileRevalidate` Workbox runtime caching rule for app shell routes (`/` and `/projects/**`) in `next.config.ts`. This ensures the app shell is served from cache on repeat visits and when offline, rather than attempting a network request first.

The PWA infrastructure was already largely implemented (`@ducanh2912/next-pwa` installed, manifest present, offline fallback in place); this completes the gap identified in the issue: explicit caching strategy for core app shell routes.

## Changes

| File | Action | Details |
|------|--------|---------|
| `next.config.ts` | UPDATE | Added `StaleWhileRevalidate` rule scoped to navigation requests for `/` and `/projects/**` paths, with 24h expiration and a dedicated `app-shell` cache name. Rule is placed before the default `runtimeCaching` spread to take precedence. |

## Validation

- **Type check**: ✅ Pass (`npm run typecheck`)
- **Lint**: ✅ Pass (0 errors, 148 pre-existing warnings unrelated to this change)
- **Tests**: ⚠️ Skipped — requires `TEST_DATABASE_URL` unavailable in worktree; change is config-only and has no unit test coverage (Workbox config is generated at build time)
- **Build**: TypeScript clean; ready for CI full build verification

## Implementation Details

The new caching rule:
- Matches navigation requests (`request.mode === "navigate"`) to `/` or `/projects/**`
- Uses `StaleWhileRevalidate` strategy (serves from cache instantly, revalidates in background)
- 24-hour expiration; max 32 cache entries
- Placed before `...runtimeCaching.filter(...)` so it overrides the default document handler (which uses `NetworkFirst` and requires network on offline access)

**No regressions**: Auth routes still use `NetworkOnly` (their rule is first in array), and API-style XHR requests are not matched by the `navigate`-mode filter.

Fixes #885