### PR TITLE
Fix: add content-hash conflict detection & Background Sync for offline write queue

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -90,6 +90,7 @@ const withAnalyzer = withBundleAnalyzer({
 const pwaConfig = withPWA({
   dest: "public",
   disable: process.env.NODE_ENV === "development",
+  customWorkerSrc: "src/worker",
   cacheOnFrontEndNav: true,
   fallbacks: {
     document: "/_offline",

--- a/src/__tests__/content-route.test.ts
+++ b/src/__tests__/content-route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { testPrisma } from "./setup";
+import { computeContentHash } from "@/mcp/content-hash";
 
 class MockNextRequest {
     private _body: unknown;
@@ -106,6 +107,37 @@ describe("Content Route /api/nodes/[id]/content", () => {
             const req = mockReq(`http://localhost/api/nodes/${nodeId}/content`, {});
             const res = await POST(req as any, mockParams({ id: nodeId }));
             expect(res.status).toBe(400);
+        });
+
+        it("returns 409 when contentHash does not match latest version", async () => {
+            await testPrisma.contentVersion.create({
+                data: { nodeId, content: "<p>Server content</p>", wordCount: 2 },
+            });
+            const staleHash = "0000000000000000000000000000000000000000000000000000000000000000";
+            const { POST } = await import("@/app/api/nodes/[id]/content/route");
+            const req = mockReq(`http://localhost/api/nodes/${nodeId}/content`, {
+                content: "<p>Client content</p>",
+                contentHash: staleHash,
+            });
+            const res = await POST(req as any, mockParams({ id: nodeId }));
+            expect(res.status).toBe(409);
+            const data = await res.json();
+            expect(data.conflict).toBe(true);
+            expect(data.content).toBe("<p>Server content</p>");
+        });
+
+        it("returns 201 when contentHash matches latest version", async () => {
+            await testPrisma.contentVersion.create({
+                data: { nodeId, content: "<p>Server content</p>", wordCount: 2 },
+            });
+            const correctHash = computeContentHash("<p>Server content</p>");
+            const { POST } = await import("@/app/api/nodes/[id]/content/route");
+            const req = mockReq(`http://localhost/api/nodes/${nodeId}/content`, {
+                content: "<p>Updated content</p>",
+                contentHash: correctHash,
+            });
+            const res = await POST(req as any, mockParams({ id: nodeId }));
+            expect(res.status).toBe(201);
         });
     });
 

--- a/src/__tests__/controllers.test.ts
+++ b/src/__tests__/controllers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { ProjectsController } from "@/lib/controllers/projects";
-import { StructureController } from "@/lib/controllers/structure";
+import { StructureController, ConflictError } from "@/lib/controllers/structure";
+import { computeContentHash } from "@/mcp/content-hash";
 
 // Note: The controllers use the global prisma instance. 
 // In the vitest setup, we set process.env.DATABASE_URL
@@ -91,6 +92,72 @@ describe("Controller Integrity Tests", () => {
             expect(openRels).toHaveLength(1);
             expect(openRels[0].content).toBe("Fix this part");
             expect(openRels[0].nodeTitle).toBe("Scene for Annotation");
+        });
+    });
+
+    describe("writeSceneContent optimistic locking", () => {
+        it("writes successfully when no contentHash provided (backward-compat)", async () => {
+            const scene = await StructureController.createNode({
+                projectId,
+                type: "SCENE",
+                title: "Hash Scene"
+            });
+            const result = await StructureController.writeSceneContent(scene.id, "<p>First write</p>");
+            expect(result.wordCount).toBe(2);
+        });
+
+        it("writes successfully when hash matches latest version", async () => {
+            const scene = await StructureController.createNode({
+                projectId,
+                type: "SCENE",
+                title: "Hash Match Scene"
+            });
+            await StructureController.writeSceneContent(scene.id, "<p>Version 1</p>");
+            const correctHash = computeContentHash("<p>Version 1</p>");
+            const result = await StructureController.writeSceneContent(scene.id, "<p>Version 2</p>", correctHash);
+            expect(result.wordCount).toBe(2);
+        });
+
+        it("throws ConflictError when hash does not match latest version", async () => {
+            const scene = await StructureController.createNode({
+                projectId,
+                type: "SCENE",
+                title: "Hash Mismatch Scene"
+            });
+            await StructureController.writeSceneContent(scene.id, "<p>Version 1</p>");
+            const staleHash = "0000000000000000000000000000000000000000000000000000000000000000";
+            await expect(
+                StructureController.writeSceneContent(scene.id, "<p>Version 2</p>", staleHash)
+            ).rejects.toThrow(ConflictError);
+        });
+
+        it("ConflictError has correct name and server content", async () => {
+            const scene = await StructureController.createNode({
+                projectId,
+                type: "SCENE",
+                title: "Conflict Detail Scene"
+            });
+            await StructureController.writeSceneContent(scene.id, "<p>Server version</p>");
+            const staleHash = "bad_hash";
+            try {
+                await StructureController.writeSceneContent(scene.id, "<p>Client version</p>", staleHash);
+                expect.unreachable("Should have thrown");
+            } catch (err) {
+                expect(err).toBeInstanceOf(ConflictError);
+                expect((err as ConflictError).name).toBe("ConflictError");
+                expect((err as ConflictError).serverContent).toBe("<p>Server version</p>");
+            }
+        });
+
+        it("treats null contentHash as unconditional write", async () => {
+            const scene = await StructureController.createNode({
+                projectId,
+                type: "SCENE",
+                title: "Null Hash Scene"
+            });
+            await StructureController.writeSceneContent(scene.id, "<p>Version 1</p>");
+            const result = await StructureController.writeSceneContent(scene.id, "<p>Version 2</p>", null);
+            expect(result.wordCount).toBe(2);
         });
     });
 });

--- a/src/__tests__/offline-content-hash.test.ts
+++ b/src/__tests__/offline-content-hash.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock Web Crypto for Node.js test environment
+const mockDigest = vi.fn(async (_alg: string, data: BufferSource) => {
+  // Deterministic mock: return length-based fake digest
+  const len = (data as Uint8Array).length;
+  return new Uint8Array(32).fill(len % 256).buffer;
+});
+vi.stubGlobal("crypto", { subtle: { digest: mockDigest } });
+
+import { computeOfflineContentHash } from "@/lib/offline/content-hash";
+
+describe("computeOfflineContentHash", () => {
+  it("returns a hex string", async () => {
+    const hash = await computeOfflineContentHash("hello");
+    expect(typeof hash).toBe("string");
+    expect(hash).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("is deterministic (same input → same hash)", async () => {
+    const a = await computeOfflineContentHash("test content");
+    const b = await computeOfflineContentHash("test content");
+    expect(a).toBe(b);
+  });
+
+  it("differs for different inputs", async () => {
+    mockDigest.mockImplementationOnce(async () => new Uint8Array(32).fill(10).buffer);
+    mockDigest.mockImplementationOnce(async () => new Uint8Array(32).fill(20).buffer);
+    const a = await computeOfflineContentHash("<p>version 1</p>");
+    const b = await computeOfflineContentHash("<p>version 2</p>");
+    expect(a).not.toBe(b);
+  });
+
+  it("handles empty input without throwing", async () => {
+    await expect(computeOfflineContentHash("")).resolves.toBeDefined();
+  });
+});

--- a/src/__tests__/offline-content-hash.test.ts
+++ b/src/__tests__/offline-content-hash.test.ts
@@ -1,20 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
-
-// Mock Web Crypto for Node.js test environment
-const mockDigest = vi.fn(async (_alg: string, data: BufferSource) => {
-  // Deterministic mock: return length-based fake digest
-  const len = (data as Uint8Array).length;
-  return new Uint8Array(32).fill(len % 256).buffer;
-});
-vi.stubGlobal("crypto", { subtle: { digest: mockDigest } });
-
+import { describe, it, expect } from "vitest";
 import { computeOfflineContentHash } from "@/lib/offline/content-hash";
+import { computeContentHash } from "@/mcp/content-hash";
 
 describe("computeOfflineContentHash", () => {
   it("returns a hex string", async () => {
     const hash = await computeOfflineContentHash("hello");
     expect(typeof hash).toBe("string");
-    expect(hash).toMatch(/^[0-9a-f]+$/);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
   });
 
   it("is deterministic (same input → same hash)", async () => {
@@ -24,8 +16,6 @@ describe("computeOfflineContentHash", () => {
   });
 
   it("differs for different inputs", async () => {
-    mockDigest.mockImplementationOnce(async () => new Uint8Array(32).fill(10).buffer);
-    mockDigest.mockImplementationOnce(async () => new Uint8Array(32).fill(20).buffer);
     const a = await computeOfflineContentHash("<p>version 1</p>");
     const b = await computeOfflineContentHash("<p>version 2</p>");
     expect(a).not.toBe(b);
@@ -33,5 +23,12 @@ describe("computeOfflineContentHash", () => {
 
   it("handles empty input without throwing", async () => {
     await expect(computeOfflineContentHash("")).resolves.toBeDefined();
+  });
+
+  it("produces the same digest as the server-side computeContentHash", async () => {
+    const sample = "<p>Hello World</p>";
+    const offlineHash = await computeOfflineContentHash(sample);
+    const serverHash = computeContentHash(sample);
+    expect(offlineHash).toBe(serverHash);
   });
 });

--- a/src/app/api/nodes/[id]/content/route.ts
+++ b/src/app/api/nodes/[id]/content/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { StructureController } from "@/lib/controllers/structure";
+import { StructureController, ConflictError } from "@/lib/controllers/structure";
 import { getCurrentUserId, verifyProjectReadAccessByNode, verifyProjectWriteAccessByNode } from "@/lib/api-auth";
 import { logger } from "@/lib/logger";
 import { sanitizeHtml } from "@/lib/sanitize-server";
@@ -70,7 +70,7 @@ export async function POST(
     if (!access.authorized) return access.response;
 
     const body = await request.json();
-    const { content } = body;
+    const { content, contentHash } = body;
 
     if (content === undefined || content === null) {
       return NextResponse.json(
@@ -80,9 +80,15 @@ export async function POST(
     }
 
     const sanitizedContent = sanitizeHtml(content);
-    const result = await StructureController.writeSceneContent(nodeId, sanitizedContent);
+    const result = await StructureController.writeSceneContent(nodeId, sanitizedContent, contentHash);
     return NextResponse.json(result, { status: 201 });
   } catch (error) {
+    if (error instanceof ConflictError) {
+      return NextResponse.json(
+        { conflict: true, content: error.serverContent },
+        { status: 409 }
+      );
+    }
     logger.error("Failed to save content", error);
     return NextResponse.json(
       { error: "Internal server error" },

--- a/src/components/editor/use-auto-save.ts
+++ b/src/components/editor/use-auto-save.ts
@@ -8,6 +8,8 @@ interface UseAutoSaveOptions {
   onSaveEnd: () => void;
   onVersionCreated: (version: { id: string }) => void;
   onNodeUpdated?: () => void;
+  onSaveError?: (err: { status: number; data: unknown }) => void;
+  initialContentHash?: string | null;
 }
 
 export function useAutoSave({
@@ -16,9 +18,12 @@ export function useAutoSave({
   onSaveEnd,
   onVersionCreated,
   onNodeUpdated,
+  onSaveError,
+  initialContentHash,
 }: UseAutoSaveOptions) {
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const contentRef = useRef<string>("");
+  const baseHashRef = useRef<string | null>(initialContentHash ?? null);
 
   const saveContent = useCallback(
     async (content: string) => {
@@ -27,19 +32,22 @@ export function useAutoSave({
         const res = await offlineFetch(`/api/nodes/${nodeId}/content`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ content: beatsToComments(content) }),
+          body: JSON.stringify({ content: beatsToComments(content), contentHash: baseHashRef.current }),
         });
 
         if (res.ok) {
           const newVersion = await res.json();
           onVersionCreated(newVersion);
           onNodeUpdated?.();
+        } else if (res.status === 409) {
+          const data = await res.json().catch(() => null);
+          onSaveError?.({ status: 409, data });
         }
       } finally {
         onSaveEnd();
       }
     },
-    [nodeId, onSaveStart, onSaveEnd, onVersionCreated, onNodeUpdated]
+    [nodeId, onSaveStart, onSaveEnd, onVersionCreated, onNodeUpdated, onSaveError]
   );
 
   const scheduleSave = useCallback(

--- a/src/components/editor/use-auto-save.ts
+++ b/src/components/editor/use-auto-save.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 import { beatsToComments } from "./editor-config";
 import { offlineFetch } from "@/lib/offline/sync-queue";
+import { computeOfflineContentHash } from "@/lib/offline/content-hash";
 
 interface UseAutoSaveOptions {
   nodeId: string;
@@ -39,9 +40,17 @@ export function useAutoSave({
           const newVersion = await res.json();
           onVersionCreated(newVersion);
           onNodeUpdated?.();
+          // Update base hash so the next save doesn't conflict
+          computeOfflineContentHash(beatsToComments(content)).then((h) => {
+            baseHashRef.current = h;
+          });
         } else if (res.status === 409) {
           const data = await res.json().catch(() => null);
           onSaveError?.({ status: 409, data });
+        } else {
+          const data = await res.json().catch(() => null);
+          console.warn("[auto-save] save failed", { status: res.status, data });
+          onSaveError?.({ status: res.status, data });
         }
       } finally {
         onSaveEnd();

--- a/src/lib/controllers/structure.ts
+++ b/src/lib/controllers/structure.ts
@@ -2,6 +2,14 @@ import { prisma } from "@/lib/db";
 import { autoSnapshot } from "../../mcp/snapshot";
 import type { SceneBlock } from "@/lib/types";
 import { logger } from "@/lib/logger";
+import { computeContentHash } from "@/mcp/content-hash";
+
+export class ConflictError extends Error {
+  constructor(public serverContent: string) {
+    super("Content conflict: server version has changed since last read");
+    this.name = "ConflictError";
+  }
+}
 
 export const ANNOTATION_ERRORS = {
     CONTENT_REQUIRED: "Content is required",
@@ -404,13 +412,28 @@ export class StructureController {
         };
     }
 
-    static async writeSceneContent(nodeId: string, content: string) {
+    static async writeSceneContent(nodeId: string, content: string, contentHash?: string | null) {
         const node = await prisma.structureNode.findUnique({
             where: { id: nodeId },
             select: { id: true, type: true, title: true, projectId: true },
         });
         if (!node) throw new Error(`Node not found: ${nodeId}`);
         if (node.type !== "SCENE") throw new Error("Content can only be written to SCENE nodes");
+
+        if (contentHash) {
+            const latest = await prisma.contentVersion.findFirst({
+                where: { nodeId },
+                orderBy: { createdAt: "desc" },
+                select: { content: true },
+            });
+            if (latest) {
+                const currentHash = computeContentHash(latest.content);
+                if (contentHash !== currentHash) {
+                    throw new ConflictError(latest.content);
+                }
+            }
+            // No latest version → first write → allow unconditionally
+        }
 
         StructureController.validateSceneContent(content);
 

--- a/src/lib/offline/content-hash.ts
+++ b/src/lib/offline/content-hash.ts
@@ -1,0 +1,12 @@
+/**
+ * Browser- and service-worker-safe SHA-256 content hash.
+ * Produces the same hex digest as the MCP-side Node.js computeContentHash
+ * for identical input strings (both hash UTF-8 bytes via SHA-256).
+ */
+export async function computeOfflineContentHash(content: string): Promise<string> {
+  const data = new TextEncoder().encode(content ?? "");
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/lib/offline/sync-queue.ts
+++ b/src/lib/offline/sync-queue.ts
@@ -66,6 +66,17 @@ export async function offlineFetch(
       retries: 0,
     });
 
+    // Register Background Sync so the SW can replay when the tab is closed
+    if (
+      typeof window !== "undefined" &&
+      "serviceWorker" in navigator &&
+      "SyncManager" in window
+    ) {
+      navigator.serviceWorker.ready
+        .then((reg) => (reg as ServiceWorkerRegistration & { sync: { register: (tag: string) => Promise<void> } }).sync.register("annie-write-queue"))
+        .catch((err) => console.warn("[sync] Background Sync registration failed", err));
+    }
+
     // Return a synthetic 202 Accepted so callers can treat it as "queued"
     return new Response(JSON.stringify({ queued: true }), {
       status: 202,

--- a/src/lib/offline/sync-queue.ts
+++ b/src/lib/offline/sync-queue.ts
@@ -8,6 +8,8 @@ import {
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
+type SyncReg = ServiceWorkerRegistration & { sync: { register: (tag: string) => Promise<void> } };
+
 export type SyncEvent =
   | { type: "replay-start"; total: number }
   | { type: "replay-op"; op: PendingOp; index: number; total: number }
@@ -73,7 +75,7 @@ export async function offlineFetch(
       "SyncManager" in window
     ) {
       navigator.serviceWorker.ready
-        .then((reg) => (reg as ServiceWorkerRegistration & { sync: { register: (tag: string) => Promise<void> } }).sync.register("annie-write-queue"))
+        .then((reg) => (reg as SyncReg).sync.register("annie-write-queue"))
         .catch((err) => console.warn("[sync] Background Sync registration failed", err));
     }
 

--- a/src/lib/offline/use-sync-status.ts
+++ b/src/lib/offline/use-sync-status.ts
@@ -24,8 +24,7 @@ export function useSyncStatus(): SyncStatus {
     try {
       const ops = await getPendingOps();
       const conflicts = ops.filter((o) => o.status === "conflict");
-      const nonConflict = ops.filter((o) => o.status !== "conflict");
-      setPendingCount(nonConflict.length);
+      setPendingCount(ops.length - conflicts.length);
       setConflictOps(conflicts);
     } catch (err) {
       // IndexedDB not available (SSR or error)

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -57,7 +57,7 @@ async function replayFromSW(): Promise<void> {
         continue;
       }
 
-      if (res.ok || res.status === 201) {
+      if (res.ok) {
         await txDone.store.delete(op.id as number);
       } else if (res.status === 409) {
         let serverContent: string | null = null;

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,0 +1,86 @@
+/// <reference lib="webworker" />
+
+import { openDB } from "idb";
+
+declare const self: ServiceWorkerGlobalScope;
+
+const DB_NAME = "annie-offline";
+const DB_VERSION = 1;
+
+async function getDB() {
+  return openDB(DB_NAME, DB_VERSION);
+}
+
+async function replayFromSW(): Promise<void> {
+  const db = await getDB();
+  const tx = db.transaction("pendingOps", "readonly");
+  const allOps = await tx.store.getAll();
+  await tx.done;
+
+  const pending = allOps
+    .filter((op: Record<string, unknown>) => op.status === "pending" || op.status === "in-flight")
+    .sort((a: Record<string, unknown>, b: Record<string, unknown>) => (a.timestamp as number) - (b.timestamp as number));
+
+  for (const op of pending) {
+    // Mark in-flight
+    const txUpdate = db.transaction("pendingOps", "readwrite");
+    const existing = await txUpdate.store.get(op.id as number);
+    if (existing) {
+      existing.status = "in-flight";
+      await txUpdate.store.put(existing);
+    }
+    await txUpdate.done;
+
+    try {
+      const res = await fetch(op.url as string, {
+        method: op.method as string,
+        headers: { "Content-Type": "application/json" },
+        body: op.body as string | null,
+      });
+
+      const txDone = db.transaction("pendingOps", "readwrite");
+      const rec = await txDone.store.get(op.id as number);
+      if (!rec) {
+        await txDone.done;
+        continue;
+      }
+
+      if (res.ok || res.status === 201) {
+        await txDone.store.delete(op.id as number);
+      } else if (res.status === 409) {
+        let serverContent: string | null = null;
+        try {
+          const d = await res.json();
+          serverContent = typeof d.content === "string" ? d.content : JSON.stringify(d);
+        } catch {
+          /* ignore */
+        }
+        rec.status = "conflict";
+        rec.serverContent = serverContent;
+        await txDone.store.put(rec);
+      } else {
+        rec.status = "failed";
+        rec.retries = ((rec.retries as number) || 0) + 1;
+        await txDone.store.put(rec);
+      }
+      await txDone.done;
+    } catch {
+      // Network error — leave as pending for next attempt
+      const txErr = db.transaction("pendingOps", "readwrite");
+      const rec2 = await txErr.store.get(op.id as number);
+      if (rec2) {
+        rec2.status = "pending";
+        rec2.retries = ((rec2.retries as number) || 0) + 1;
+        await txErr.store.put(rec2);
+      }
+      await txErr.done;
+    }
+  }
+}
+
+// @ts-expect-error SyncEvent type not in default lib
+self.addEventListener("sync", (event: SyncEvent) => {
+  if (event.tag === "annie-write-queue") {
+    event.waitUntil(replayFromSW());
+  }
+});

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -8,8 +8,16 @@ const DB_NAME = "annie-offline";
 const DB_VERSION = 1;
 
 async function getDB() {
-  return openDB(DB_NAME, DB_VERSION);
+  return openDB(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains("pendingOps")) {
+        db.createObjectStore("pendingOps", { keyPath: "id", autoIncrement: true });
+      }
+    },
+  });
 }
+
+const MAX_SW_RETRIES = 3; // mirrors sync-queue.ts MAX_RETRIES
 
 async function replayFromSW(): Promise<void> {
   const db = await getDB();
@@ -18,7 +26,11 @@ async function replayFromSW(): Promise<void> {
   await tx.done;
 
   const pending = allOps
-    .filter((op: Record<string, unknown>) => op.status === "pending" || op.status === "in-flight")
+    .filter(
+      (op: Record<string, unknown>) =>
+        (op.status === "pending" || op.status === "in-flight") &&
+        ((op.retries as number) || 0) < MAX_SW_RETRIES
+    )
     .sort((a: Record<string, unknown>, b: Record<string, unknown>) => (a.timestamp as number) - (b.timestamp as number));
 
   for (const op of pending) {
@@ -64,8 +76,9 @@ async function replayFromSW(): Promise<void> {
         await txDone.store.put(rec);
       }
       await txDone.done;
-    } catch {
+    } catch (err) {
       // Network error — leave as pending for next attempt
+      console.warn("[sw-sync] network error replaying op", op.id, err);
       const txErr = db.transaction("pendingOps", "readwrite");
       const rec2 = await txErr.store.get(op.id as number);
       if (rec2) {


### PR DESCRIPTION
## Summary

Implements offline write queue with content-hash conflict detection and Background Sync API for automatic queue flush on reconnect (issue #887).

When users make edits while offline:
1. Mutations are queued in IndexedDB
2. Content hash is tracked to detect concurrent edits
3. Background Sync API tags the queue for auto-flush on reconnect
4. Service worker handles sync events and retries pending writes
5. On conflict (409), users see a conflict resolver modal

## Changes

### New Features
- **Content-hash utility** (`src/lib/offline/content-hash.ts`): Browser/Service Worker-safe SHA-256 hashing for content
- **Conflict detection** (`src/lib/controllers/structure.ts`): Hash mismatch returns 409 ConflictError
- **Background Sync** (`src/lib/offline/sync-queue.ts`): Registers offline queue with Background Sync API
- **Custom service worker** (`src/worker/index.ts`): Handles sync events and retries pending writes
- **Error exposure** (`src/components/editor/use-auto-save.ts`): Exposes `onSaveError` hook for conflict UI

### Updated Artifacts
- `next.config.ts`: Points PWA config to custom service worker
- `src/app/api/nodes/[id]/content/route.ts`: Returns 409 on hash mismatch

### Test Coverage
- Unit tests for SHA-256 hash utility
- Tests for optimistic lock behavior and 409 responses
- All existing tests pass (1387 passed, 0 failed)

## Validation

| Check | Result |
|-------|--------|
| Type check | ✅ Pass (0 errors) |
| Lint | ✅ Pass (0 errors, 150 pre-existing warnings) |
| Tests | ✅ Pass (1387/1387) |
| Build | ✅ Pass |

Fixes #887