### PR TITLE
Fix: Align Railway monitor with current metrics API schema (#916)

### DIFF
--- a/.github/workflows/railway-resource-monitor.yml
+++ b/.github/workflows/railway-resource-monitor.yml
@@ -46,7 +46,7 @@ jobs:
             -H "Authorization: Bearer $RAILWAY_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{
-              \"query\": \"query { metrics(projectId: \\\"$RAILWAY_PROJECT_ID\\\", serviceId: \\\"$RAILWAY_SERVICE_ID\\\", environmentId: \\\"$RAILWAY_ENVIRONMENT_ID\\\", startDate: \\\"$START\\\", endDate: \\\"$END\\\", measurements: [MEMORY_USAGE_GB, CPU_USAGE]) { measurement { metric values { value } } } }\"
+              \"query\": \"query { metrics(projectId: \\\"$RAILWAY_PROJECT_ID\\\", serviceId: \\\"$RAILWAY_SERVICE_ID\\\", environmentId: \\\"$RAILWAY_ENVIRONMENT_ID\\\", startDate: \\\"$START\\\", endDate: \\\"$END\\\", measurements: [MEMORY_USAGE_GB, CPU_USAGE]) { measurement values { value } } }\"
             }")
 
           API_ERRORS=$(echo "$METRICS_RESPONSE" | jq -r '.errors // empty')
@@ -56,14 +56,15 @@ jobs:
           fi
 
           # Extract max memory usage (GB) and max CPU usage (%)
+          # Railway metrics() returns a flat array: [{measurement: "MEMORY_USAGE_GB", values: [{ts, value}]}, ...]
           MEMORY_GB=$(echo "$METRICS_RESPONSE" | jq -r '
-            [.data.metrics.measurement[]
-              | select(.metric == "MEMORY_USAGE_GB")
+            [.data.metrics[]
+              | select(.measurement == "MEMORY_USAGE_GB")
               | .values[].value] | if length == 0 then 0 else max end')
 
           CPU_PCT=$(echo "$METRICS_RESPONSE" | jq -r '
-            [.data.metrics.measurement[]
-              | select(.metric == "CPU_USAGE")
+            [.data.metrics[]
+              | select(.measurement == "CPU_USAGE")
               | .values[].value] | if length == 0 then 0 else max end')
 
           # Handle empty/null values


### PR DESCRIPTION
## Summary

Railway's `metrics()` API changed its response structure:
- `measurement` is now a **scalar enum** (`MetricMeasurement!`), not an object with `{ metric, values }` subfields
- Previous fixes (#917, #918) corrected the field name but kept the old nested structure, causing: `Field "measurement" must not have a selection since type "MetricMeasurement!" has no subfields`

This PR fixes the query to match Railway's current schema:
- GraphQL: `{ measurement values { value } }` (flat) instead of `{ measurement { metric values { value } } }` (nested)  
- jq: `.data.metrics[]` filtered by `.measurement` enum value

## Test plan

- [ ] Merge PR
- [ ] Trigger: `gh workflow run railway-resource-monitor.yml --repo alexsiri7/word-coach-annie`
- [ ] Verify workflow completes successfully (no GRAPHQL_VALIDATION_FAILED)

Fixes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)