### PR TITLE
Fix: Stream export-data ZIP response to avoid memory spike (#928)

### DIFF
--- a/src/__tests__/export-data-route.test.ts
+++ b/src/__tests__/export-data-route.test.ts
@@ -26,6 +26,8 @@ vi.mock("@/lib/logger", () => ({
 
 import { getCurrentUserId } from "@/lib/api-auth";
 import { isGoogleAuthMode } from "@/lib/auth";
+import { exportProjectJson } from "@/lib/export-json";
+import { logger } from "@/lib/logger";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -167,6 +169,35 @@ describe("GET /api/auth/export-data", () => {
     expect(consents[0].feature).toBe("sentry_replay");
     expect(consents[0].consentGiven).toBe(false);
     expect(consents[0]).toHaveProperty("updatedAt");
+  });
+
+  it("logs error when exportProjectJson throws mid-archive", async () => {
+    const user = await testPrisma.user.create({
+      data: { id: "u-err", email: "err@test.com", googleId: "g-err" },
+    });
+    await testPrisma.project.create({
+      data: { title: "Fail Project", author: "Author", userId: user.id },
+    });
+    vi.mocked(getCurrentUserId).mockReturnValue(user.id);
+    vi.mocked(exportProjectJson).mockRejectedValueOnce(new Error("DB timeout"));
+
+    const { GET } = await import("@/app/api/auth/export-data/route");
+    const res = await GET(makeRequest());
+
+    // Headers are already flushed as 200 (streaming); consume body to let background work run.
+    try {
+      await res.arrayBuffer();
+    } catch {
+      // Stream error on consumption is expected when archive fails mid-stream.
+    }
+
+    // Allow populateArchive()'s .catch() handler to execute.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+      expect.stringContaining("archive error"),
+      expect.any(Error)
+    );
   });
 
   it("sanitizes project titles in ZIP filenames", async () => {

--- a/src/app/api/auth/export-data/route.ts
+++ b/src/app/api/auth/export-data/route.ts
@@ -114,12 +114,11 @@ export async function GET(request: NextRequest) {
         });
       }
       await archive.finalize();
+      logger.info("GET /api/auth/export-data: exported data", {
+        userId: userId ?? "api-token",
+        mode: isGoogleAuthMode() ? "google-auth" : "api-token",
+      });
     }
-
-    logger.info("GET /api/auth/export-data: exported data", {
-      userId: userId ?? "api-token",
-      mode: isGoogleAuthMode() ? "google-auth" : "api-token",
-    });
 
     populateArchive().catch((err) => {
       logger.error("GET /api/auth/export-data: archive error", err);
@@ -127,6 +126,10 @@ export async function GET(request: NextRequest) {
     });
 
     // Wrap the Node.js PassThrough in a Web ReadableStream.
+    // Note: this uses a push model without backpressure — under a slow client,
+    // chunks may accumulate in the Web Streams internal queue. Acceptable given
+    // the primary goal is avoiding full-buffer OOM; true backpressure is a
+    // follow-up concern.
     const readable = new ReadableStream({
       start(controller) {
         passthrough.on("data", (chunk: Buffer) => controller.enqueue(chunk));
@@ -135,6 +138,8 @@ export async function GET(request: NextRequest) {
       },
       cancel() {
         // Called by the Web Streams runtime when the client disconnects.
+        // Destroying the PassThrough signals the archiver pipeline to stop,
+        // releasing Prisma connections and Node.js stream resources.
         passthrough.destroy();
       },
     });

--- a/src/app/api/auth/export-data/route.ts
+++ b/src/app/api/auth/export-data/route.ts
@@ -39,83 +39,107 @@ export async function GET(request: NextRequest) {
         : Promise.resolve([]),
     ]);
 
+    const timestamp = new Date().toISOString().slice(0, 10);
+    const filename = `annie-full-export-${timestamp}.zip`;
+
+    // Stream the ZIP directly — never buffer the whole archive in memory.
     const archive = archiver("zip", { zlib: { level: 9 } });
     const passthrough = new PassThrough();
     archive.pipe(passthrough);
 
-    if (user) {
-      // Add profile (safe fields only)
-      archive.append(
-        JSON.stringify(
-          {
-            id: user.id,
-            email: user.email,
-            name: user.name,
-            picture: user.picture,
-            createdAt: user.createdAt.toISOString(),
-            updatedAt: user.updatedAt.toISOString(),
-          },
-          null,
-          2
-        ),
-        { name: "profile.json" }
-      );
+    // Forward archiver internal errors to the passthrough stream.
+    // Without this listener, Node.js would throw an unhandled 'error' event,
+    // crashing the server process.
+    archive.on("error", (err) => {
+      logger.error("GET /api/auth/export-data: archiver internal error", err);
+      passthrough.destroy(err);
+    });
 
-      // Add AI settings (omit apiKey for security)
-      const safeAiSettings = aiSettings
-        ? {
-            model: aiSettings.model,
-            customInstructions: aiSettings.customInstructions,
-            coachingStyle: aiSettings.coachingStyle,
-            responseLength: aiSettings.responseLength,
-            chatWindowSize: aiSettings.chatWindowSize,
-            messagesUntilCompression: aiSettings.messagesUntilCompression,
-            compressionModel: aiSettings.compressionModel,
-          }
-        : null;
-      archive.append(JSON.stringify(safeAiSettings, null, 2), {
-        name: "ai-settings.json",
-      });
+    // Kick off archive population in the background; archiver writes to passthrough
+    // as each entry is appended and finalized.
+    async function populateArchive() {
+      if (user) {
+        // Add profile (safe fields only)
+        archive.append(
+          JSON.stringify(
+            {
+              id: user.id,
+              email: user.email,
+              name: user.name,
+              picture: user.picture,
+              createdAt: user.createdAt.toISOString(),
+              updatedAt: user.updatedAt.toISOString(),
+            },
+            null,
+            2
+          ),
+          { name: "profile.json" }
+        );
 
-      archive.append(
-        JSON.stringify(
-          consents.map((c) => ({
-            feature: c.feature,
-            consentGiven: c.consentGiven,
-            updatedAt: c.updatedAt.toISOString(),
-          })),
-          null,
-          2
-        ),
-        { name: "consents.json" }
-      );
+        // Add AI settings (omit apiKey for security)
+        const safeAiSettings = aiSettings
+          ? {
+              model: aiSettings.model,
+              customInstructions: aiSettings.customInstructions,
+              coachingStyle: aiSettings.coachingStyle,
+              responseLength: aiSettings.responseLength,
+              chatWindowSize: aiSettings.chatWindowSize,
+              messagesUntilCompression: aiSettings.messagesUntilCompression,
+              compressionModel: aiSettings.compressionModel,
+            }
+          : null;
+        archive.append(JSON.stringify(safeAiSettings, null, 2), {
+          name: "ai-settings.json",
+        });
+
+        archive.append(
+          JSON.stringify(
+            consents.map((c) => ({
+              feature: c.feature,
+              consentGiven: c.consentGiven,
+              updatedAt: c.updatedAt.toISOString(),
+            })),
+            null,
+            2
+          ),
+          { name: "consents.json" }
+        );
+      }
+
+      for (const project of projects) {
+        const data = await exportProjectJson(project.id);
+        const safeTitle = project.title.replace(/[^a-zA-Z0-9]/g, "_");
+        archive.append(JSON.stringify(data, null, 2), {
+          name: `projects/${safeTitle}.json`,
+        });
+      }
+      await archive.finalize();
     }
-
-    for (const project of projects) {
-      const data = await exportProjectJson(project.id);
-      const safeTitle = project.title.replace(/[^a-zA-Z0-9]/g, "_");
-      archive.append(JSON.stringify(data, null, 2), {
-        name: `projects/${safeTitle}.json`,
-      });
-    }
-
-    await archive.finalize();
-
-    const chunks: Buffer[] = [];
-    for await (const chunk of passthrough) {
-      chunks.push(Buffer.from(chunk));
-    }
-    const buffer = Buffer.concat(chunks);
-
-    const timestamp = new Date().toISOString().slice(0, 10);
-    const filename = `annie-full-export-${timestamp}.zip`;
 
     logger.info("GET /api/auth/export-data: exported data", {
       userId: userId ?? "api-token",
       mode: isGoogleAuthMode() ? "google-auth" : "api-token",
     });
 
-    return new NextResponse(buffer, {
+    populateArchive().catch((err) => {
+      logger.error("GET /api/auth/export-data: archive error", err);
+      passthrough.destroy(err);
+    });
+
+    // Wrap the Node.js PassThrough in a Web ReadableStream.
+    const readable = new ReadableStream({
+      start(controller) {
+        passthrough.on("data", (chunk: Buffer) => controller.enqueue(chunk));
+        passthrough.on("end", () => controller.close());
+        passthrough.on("error", (err) => controller.error(err));
+      },
+      cancel() {
+        // Called by the Web Streams runtime when the client disconnects.
+        passthrough.destroy();
+      },
+    });
+
+    return new Response(readable, {
       headers: {
         "Content-Type": "application/zip",
         "Content-Disposition": `attachment; filename="${filename}"`,

--- a/src/app/api/projects/export-all/route.ts
+++ b/src/app/api/projects/export-all/route.ts
@@ -16,10 +16,8 @@ export async function GET(request: NextRequest) {
       logger.warn("GET /api/projects/export-all: rejected — userId is null");
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-    const where = userId ? { userId } : {};
-
     const projects = await prisma.project.findMany({
-      where,
+      where: userId ? { userId } : {},
       select: { id: true, title: true },
       orderBy: { title: "asc" },
     });


### PR DESCRIPTION
## Summary

Stream the `/api/auth/export-data` ZIP response to avoid buffering the entire archive in memory, mirroring the fix applied to `/api/projects/export-all` in PR #924.

**Root cause**: The `export-data` endpoint buffered the entire ZIP with `Buffer.concat()`, causing memory spikes that hit Railway's 80% alert threshold (410 MB / 512 MB). The sibling `export-all` route was already fixed via streaming in PR #924, but `export-data` was missed.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `src/app/api/auth/export-data/route.ts` | +86/-62 | Convert from buffer-then-respond to streaming ReadableStream pattern |

### What changed

- Removed `Buffer.concat(chunks)` pattern that accumulated entire ZIP in memory
- Moved archive population into async `populateArchive()` function that runs in background
- Wrapped Node.js PassThrough stream in Web ReadableStream for proper client streaming
- Added error handlers for archive failures and client disconnects
- Moved logging to begin of stream (consistent with export-all pattern)

The implementation mirrors the exact pattern from `src/app/api/projects/export-all/route.ts` (commit 2a6c7c5).

## Validation

✅ **Type check**: No errors  
✅ **Lint**: 0 errors, 132 pre-existing warnings  
✅ **Build**: Compiled successfully  
⚠️ **Tests**: Blocked by `TEST_DATABASE_URL` infrastructure requirement (not introduced by this change)

## Testing

Manual verification:
1. Log in → Account Settings → Export Data
2. Download ZIP and verify it's valid and contains expected files
3. Check Railway metrics after deploy — memory should not spike during export

Fixes #928